### PR TITLE
feat(ui): geist-style dark theme overhaul

### DIFF
--- a/frontend/apps/web/index.html
+++ b/frontend/apps/web/index.html
@@ -1,10 +1,17 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TraceRTM</title>
+    <!-- Geist font family (Vercel) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/apps/web/src/components/layout/sidebar-view.tsx
+++ b/frontend/apps/web/src/components/layout/sidebar-view.tsx
@@ -108,7 +108,7 @@ export const SidebarView = ({
   );
 
   const navClassName = cn(
-    'relative flex h-full max-h-screen flex-col border-r border-white/0 bg-[linear-gradient(155deg,rgba(2,6,23,0.65),rgba(2,6,23,0.35)_55%,rgba(15,23,42,0.25))] backdrop-blur-2xl shadow-[1px_0_0_rgba(15,23,42,0.6)] shrink-0 overflow-x-auto overflow-y-auto box-border',
+    'geist-sidebar relative flex h-full max-h-screen flex-col shrink-0 overflow-x-auto overflow-y-auto box-border',
     isResizing ? 'transition-none' : 'transition-all duration-300 ease-in-out',
     isCollapsed ? 'w-20 min-w-[5rem] max-w-[5rem]' : undefined,
   );

--- a/frontend/apps/web/src/index.css
+++ b/frontend/apps/web/src/index.css
@@ -1,6 +1,28 @@
 @import 'tailwindcss';
 
 /* ---------------------------------------------------------------------------
+   Geist font stack — primary sans and mono accents
+   --------------------------------------------------------------------------- */
+@layer base {
+  :root {
+    --font-sans: 'Geist', 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --font-mono: 'Geist Mono', 'JetBrains Mono', ui-monospace, 'Cascadia Code', monospace;
+  }
+
+  html {
+    font-family: var(--font-sans);
+  }
+
+  code,
+  kbd,
+  samp,
+  pre,
+  .font-mono {
+    font-family: var(--font-mono);
+  }
+}
+
+/* ---------------------------------------------------------------------------
    Animation & transition design tokens (respect prefers-reduced-motion in base)
    --------------------------------------------------------------------------- */
 @layer base {
@@ -212,50 +234,67 @@ a[href]:hover {
 }
 
 @layer base {
+  /* Light theme — clean neutral */
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 0 0% 98%;
+    --foreground: 0 0% 9%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 0 0% 9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --popover-foreground: 0 0% 9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 45%;
+    --accent: 0 0% 96%;
+    --accent-foreground: 0 0% 9%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.5rem;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 0 0% 9%;
+    --radius: 0.375rem;
+
+    /* Coverage badge tokens */
+    --coverage-covered: 142 72% 29%;
+    --coverage-covered-fg: 142 76% 95%;
+    --coverage-partial: 38 92% 40%;
+    --coverage-partial-fg: 38 96% 95%;
+    --coverage-uncovered: 0 72% 51%;
+    --coverage-uncovered-fg: 0 86% 97%;
   }
 
+  /* Geist-style dark theme — true black base, pure neutral grays */
   .dark {
-    /* Match gradient base (slate-900 #0f172a) so gradient shows, no purple cast */
-    --background: 222 47% 9%;
-    --foreground: 210 40% 98%;
-    --card: 222 47% 9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 5.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+
+    /* Coverage badge tokens — slightly more vibrant in dark */
+    --coverage-covered: 142 76% 36%;
+    --coverage-covered-fg: 142 80% 96%;
+    --coverage-partial: 38 92% 50%;
+    --coverage-partial-fg: 38 96% 10%;
+    --coverage-uncovered: 0 72% 51%;
+    --coverage-uncovered-fg: 0 86% 97%;
   }
 }
 
@@ -266,6 +305,9 @@ a[href]:hover {
   body {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   /* Visible focus indicators for WCAG 2.1 AA compliance (2px minimum) */
@@ -337,5 +379,78 @@ a[href]:hover {
     transition:
       outline-offset var(--duration-fast, 150ms) ease,
       box-shadow var(--duration-fast, 150ms) ease;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Coverage status badges — COVERED / PARTIAL / UNCOVERED
+   --------------------------------------------------------------------------- */
+@layer components {
+  .badge-covered {
+    background-color: hsl(var(--coverage-covered) / 0.15);
+    color: hsl(var(--coverage-covered));
+    border: 1px solid hsl(var(--coverage-covered) / 0.3);
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .badge-partial {
+    background-color: hsl(var(--coverage-partial) / 0.15);
+    color: hsl(var(--coverage-partial));
+    border: 1px solid hsl(var(--coverage-partial) / 0.3);
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .badge-uncovered {
+    background-color: hsl(var(--coverage-uncovered) / 0.12);
+    color: hsl(var(--coverage-uncovered));
+    border: 1px solid hsl(var(--coverage-uncovered) / 0.25);
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  /* Geist sidebar styles */
+  .geist-sidebar {
+    background-color: hsl(0 0% 3.9%);
+    border-right: 1px solid hsl(var(--border));
+  }
+
+  .dark .geist-sidebar {
+    background-color: hsl(0 0% 2%);
+  }
+
+  /* Monospace accent text */
+  .mono-label {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
   }
 }

--- a/frontend/apps/web/src/providers/theme-provider.jsx
+++ b/frontend/apps/web/src/providers/theme-provider.jsx
@@ -8,16 +8,8 @@ const resolveInitialTheme = () => {
     return stored;
   }
 
-  if (
-    typeof globalThis !== 'undefined' &&
-    'matchMedia' in globalThis &&
-    typeof globalThis.matchMedia === 'function' &&
-    globalThis.matchMedia('(prefers-color-scheme: dark)').matches
-  ) {
-    return 'dark';
-  }
-
-  return 'light';
+  // Default to dark theme for geist-style aesthetic
+  return 'dark';
 };
 
 const applyThemeToDom = (theme) => {

--- a/frontend/apps/web/src/views/TraceabilityMatrixView.tsx
+++ b/frontend/apps/web/src/views/TraceabilityMatrixView.tsx
@@ -1,4 +1,14 @@
-import { Activity, Box, CheckCircle2, Download, FileText, Layers, Search } from 'lucide-react';
+import {
+  Activity,
+  Box,
+  CheckCircle2,
+  Circle,
+  Download,
+  FileText,
+  Layers,
+  MinusCircle,
+  Search,
+} from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -13,6 +23,49 @@ import { useLinks } from '../hooks/useLinks';
 
 interface TraceabilityMatrixViewProps {
   projectId: string;
+}
+
+type CoverageStatus = 'covered' | 'partial' | 'uncovered';
+
+function getCoverageStatus(coveredCount: number, totalFeatures: number): CoverageStatus {
+  if (totalFeatures === 0 || coveredCount === 0) {
+    return 'uncovered';
+  }
+  if (coveredCount >= totalFeatures) {
+    return 'covered';
+  }
+  return 'partial';
+}
+
+interface CoverageBadgeProps {
+  status: CoverageStatus;
+  coveredCount: number;
+  totalFeatures: number;
+}
+
+function CoverageBadge({ status, coveredCount, totalFeatures }: CoverageBadgeProps) {
+  if (status === 'covered') {
+    return (
+      <span className='badge-covered'>
+        <CheckCircle2 className='h-2.5 w-2.5' />
+        COVERED {coveredCount}/{totalFeatures}
+      </span>
+    );
+  }
+  if (status === 'partial') {
+    return (
+      <span className='badge-partial'>
+        <MinusCircle className='h-2.5 w-2.5' />
+        PARTIAL {coveredCount}/{totalFeatures}
+      </span>
+    );
+  }
+  return (
+    <span className='badge-uncovered'>
+      <Circle className='h-2.5 w-2.5' />
+      UNCOVERED
+    </span>
+  );
 }
 
 export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProps) {
@@ -58,78 +111,109 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
     return Math.round((covered / matrix.requirements.length) * 100);
   }, [matrix]);
 
+  const coverageSummary = useMemo(() => {
+    const totalReqs = matrix.requirements.length;
+    const covered = matrix.requirements.filter(
+      (r) => (matrix.coverage[r.id]?.size ?? 0) >= matrix.features.length && matrix.features.length > 0,
+    ).length;
+    const partial = matrix.requirements.filter((r) => {
+      const c = matrix.coverage[r.id]?.size ?? 0;
+      return c > 0 && c < matrix.features.length;
+    }).length;
+    const uncovered = totalReqs - covered - partial;
+    return { covered, partial, uncovered };
+  }, [matrix]);
+
   if (isLoading) {
     return (
       <div className='animate-pulse space-y-8 p-6'>
         <Skeleton className='h-10 w-48' />
         <div className='flex gap-4'>
           {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className='h-24 flex-1 rounded-2xl' />
+            <Skeleton key={i} className='h-24 flex-1 rounded-xl' />
           ))}
         </div>
-        <Skeleton className='h-[500px] w-full rounded-2xl' />
+        <Skeleton className='h-[500px] w-full rounded-xl' />
       </div>
     );
   }
 
   return (
-    <div className='animate-in fade-in mx-auto max-w-[1800px] space-y-8 p-6 duration-500'>
+    <div className='animate-in fade-in mx-auto max-w-[1800px] space-y-6 p-6 duration-500'>
       {/* Header */}
-      <div className='flex flex-col justify-between gap-4 md:flex-row md:items-center'>
+      <div className='flex flex-col justify-between gap-4 md:flex-row md:items-start'>
         <div>
-          <h1 className='text-2xl font-black tracking-tight uppercase'>Traceability Matrix</h1>
-          <p className='text-muted-foreground text-sm font-medium'>
-            Validation grid mapping high-level requirements to functional features.
+          <h1 className='font-mono text-xl font-bold tracking-tight'>
+            Traceability Matrix
+          </h1>
+          <p className='text-muted-foreground mt-1 text-sm'>
+            Requirements coverage mapped to functional features.
           </p>
         </div>
         <Button
           variant='outline'
           size='sm'
-          className='gap-2 rounded-xl'
+          className='gap-2 rounded-lg font-mono text-xs uppercase tracking-wider'
           onClick={() => toast.success('Matrix exported to CSV')}
         >
-          <Download className='h-4 w-4' /> Export
+          <Download className='h-3.5 w-3.5' /> Export CSV
         </Button>
       </div>
 
       {/* Stats Bar */}
-      <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
         {[
           {
-            color: 'text-blue-500',
             icon: FileText,
-            label: 'High-Level REQS',
+            label: 'Requirements',
             value: matrix.requirements.length,
+            accent: 'text-foreground',
           },
           {
-            color: 'text-purple-500',
             icon: Box,
-            label: 'Mapped Features',
+            label: 'Features',
             value: matrix.features.length,
+            accent: 'text-foreground',
           },
           {
-            color: 'text-green-500',
             icon: Activity,
-            label: 'Integrity Ratio',
+            label: 'Coverage',
             progress: true,
             value: `${coveragePercent}%`,
+            accent: coveragePercent >= 80 ? 'text-green-500' : coveragePercent >= 40 ? 'text-yellow-500' : 'text-red-500',
+          },
+          {
+            icon: CheckCircle2,
+            label: 'Fully Covered',
+            value: coverageSummary.covered,
+            accent: 'text-green-500',
           },
         ].map((s, i) => (
           <Card
             key={i}
-            className='bg-card/50 flex h-28 flex-col justify-between border-none p-5 shadow-sm'
+            className='bg-card flex h-24 flex-col justify-between rounded-xl border p-4 shadow-none'
           >
-            <div className='flex items-start justify-between'>
-              <p className='text-muted-foreground text-[10px] font-black tracking-widest uppercase'>
-                {s.label}
-              </p>
-              <s.icon className={cn('h-4 w-4 opacity-30', s.color)} />
+            <div className='flex items-center justify-between'>
+              <p className='mono-label'>{s.label}</p>
+              <s.icon className={cn('h-3.5 w-3.5 opacity-40', s.accent)} />
             </div>
             <div className='flex items-end justify-between'>
-              <h3 className='text-2xl leading-none font-black'>{s.value}</h3>
+              <h3 className={cn('font-mono text-2xl font-bold leading-none', s.accent)}>
+                {s.value}
+              </h3>
               {s.progress && (
-                <div className='bg-muted mb-1 h-1.5 w-24 shrink-0 overflow-hidden rounded-full'>
-                  <div className='h-full bg-green-500' style={{ width: `${coveragePercent}%` }} />
+                <div className='bg-muted mb-0.5 h-1 w-20 shrink-0 overflow-hidden rounded-full'>
+                  <div
+                    className={cn(
+                      'h-full rounded-full transition-all duration-700',
+                      coveragePercent >= 80
+                        ? 'bg-green-500'
+                        : coveragePercent >= 40
+                          ? 'bg-yellow-500'
+                          : 'bg-red-500',
+                    )}
+                    style={{ width: `${coveragePercent}%` }}
+                  />
                 </div>
               )}
             </div>
@@ -137,49 +221,67 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
         ))}
       </div>
 
+      {/* Coverage summary badges row */}
+      <div className='flex flex-wrap items-center gap-3'>
+        <span className='mono-label'>Status breakdown:</span>
+        <span className='badge-covered'>
+          <CheckCircle2 className='h-2.5 w-2.5' />
+          COVERED — {coverageSummary.covered}
+        </span>
+        <span className='badge-partial'>
+          <MinusCircle className='h-2.5 w-2.5' />
+          PARTIAL — {coverageSummary.partial}
+        </span>
+        <span className='badge-uncovered'>
+          <Circle className='h-2.5 w-2.5' />
+          UNCOVERED — {coverageSummary.uncovered}
+        </span>
+      </div>
+
       {/* Filters Control */}
-      <Card className='bg-muted/30 flex items-center gap-2 rounded-2xl border-none p-2'>
+      <div className='bg-muted/40 flex items-center gap-2 rounded-xl border p-2'>
         <div className='relative flex-1'>
-          <Search className='text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2' />
+          <Search className='text-muted-foreground absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2' />
           <Input
-            placeholder='Search requirements...'
-            className='h-10 border-none bg-transparent pl-10 focus-visible:ring-0'
+            placeholder='Filter requirements...'
+            className='h-9 border-none bg-transparent pl-9 font-mono text-sm focus-visible:ring-0'
             value={searchQuery}
             onChange={(e) => {
               setSearchQuery(e.target.value);
             }}
           />
         </div>
-        <div className='bg-border/50 mx-2 h-6 w-px' />
+        <div className='bg-border mx-1 h-5 w-px' />
         <Badge
           variant='outline'
-          className='h-8 rounded-lg px-3 font-bold tracking-tighter uppercase'
+          className='h-7 rounded-md px-2.5 font-mono text-[10px] font-bold uppercase tracking-wider'
         >
-          {matrix.requirements.length} REQS x {matrix.features.length} FEATS
+          {matrix.requirements.length}r × {matrix.features.length}f
         </Badge>
-      </Card>
+      </div>
 
       {/* Matrix Grid */}
-      <Card className='bg-card/50 overflow-hidden rounded-[2rem] border-none shadow-xl'>
+      <Card className='bg-card overflow-hidden rounded-xl border shadow-none'>
         <div className='custom-scrollbar overflow-x-auto'>
-          <table className='w-full border-collapse'>
+          <table className='w-full border-collapse text-sm'>
             <thead>
               <tr>
-                <th className='bg-card sticky left-0 z-20 min-w-[300px] border-r border-b p-6 text-left'>
+                <th className='bg-card sticky left-0 z-20 min-w-[340px] border-r border-b p-4 text-left'>
                   <div className='flex items-center gap-2'>
-                    <FileText className='text-primary h-4 w-4' />
-                    <span className='text-[10px] font-black tracking-widest uppercase'>
-                      Requirement Detail
-                    </span>
+                    <FileText className='text-muted-foreground h-3.5 w-3.5' />
+                    <span className='mono-label'>Requirement</span>
                   </div>
+                </th>
+                <th className='bg-card sticky left-[340px] z-20 min-w-[120px] border-r border-b p-4 text-left'>
+                  <span className='mono-label'>Coverage</span>
                 </th>
                 {matrix.features.map((feature) => (
                   <th
                     key={feature.id}
-                    className='bg-muted/30 min-w-[120px] border-r border-b p-4 align-bottom'
+                    className='bg-muted/20 min-w-[100px] border-r border-b p-3 align-bottom'
                   >
-                    <div className='mx-auto rotate-180 text-left [writing-mode:vertical-lr]'>
-                      <span className='text-muted-foreground max-h-[150px] truncate text-[10px] font-bold tracking-tighter uppercase'>
+                    <div className='mx-auto rotate-180 [writing-mode:vertical-lr]'>
+                      <span className='text-muted-foreground max-h-[130px] truncate font-mono text-[9px] font-bold uppercase tracking-tight'>
                         {feature.title}
                       </span>
                     </div>
@@ -188,71 +290,118 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
               </tr>
             </thead>
             <tbody>
-              {matrix.requirements.map((req) => (
-                <tr key={req.id} className='group hover:bg-muted/20 transition-colors'>
-                  <td className='bg-card group-hover:bg-muted/10 sticky left-0 z-10 border-r border-b p-4 transition-colors'>
-                    <div className='flex flex-col gap-1'>
-                      <span className='group-hover:text-primary text-sm font-bold transition-colors'>
-                        {req.title}
-                      </span>
-                      <span className='text-muted-foreground font-mono text-[9px] uppercase'>
-                        {req.id.slice(0, 8)}
-                      </span>
-                    </div>
-                  </td>
-                  {matrix.features.map((feature) => {
-                    const isLinked = matrix.coverage[req.id]?.has(feature.id);
-                    return (
-                      <td
-                        key={feature.id}
-                        className={cn(
-                          'p-4 text-center border-b border-r transition-all',
-                          isLinked ? 'bg-green-500/[0.03]' : 'opacity-20',
-                        )}
-                      >
-                        <div className='flex justify-center'>
-                          {isLinked ? (
-                            <div className='flex h-6 w-6 items-center justify-center rounded-full bg-green-500/10 text-green-600 shadow-sm'>
-                              <CheckCircle2 className='h-4 w-4' />
-                            </div>
-                          ) : (
-                            <div className='bg-muted-foreground h-1 w-1 rounded-full' />
+              {matrix.requirements.map((req) => {
+                const coveredCount = matrix.coverage[req.id]?.size ?? 0;
+                const status = getCoverageStatus(coveredCount, matrix.features.length);
+                return (
+                  <tr
+                    key={req.id}
+                    className={cn(
+                      'group transition-colors',
+                      'hover:bg-muted/30',
+                      status === 'covered' && 'hover:bg-green-500/[0.04]',
+                      status === 'partial' && 'hover:bg-yellow-500/[0.04]',
+                      status === 'uncovered' && 'hover:bg-red-500/[0.03]',
+                    )}
+                  >
+                    <td
+                      className={cn(
+                        'bg-card sticky left-0 z-10 border-r border-b p-4 transition-colors',
+                        'group-hover:bg-muted/20',
+                      )}
+                    >
+                      <div className='flex flex-col gap-1'>
+                        <span className='group-hover:text-foreground text-sm font-semibold leading-tight transition-colors'>
+                          {req.title}
+                        </span>
+                        <span className='text-muted-foreground font-mono text-[9px] uppercase tracking-widest'>
+                          {req.id.slice(0, 8)}
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      className={cn(
+                        'bg-card sticky left-[340px] z-10 border-r border-b p-4 transition-colors',
+                        'group-hover:bg-muted/20',
+                      )}
+                    >
+                      <CoverageBadge
+                        status={status}
+                        coveredCount={coveredCount}
+                        totalFeatures={matrix.features.length}
+                      />
+                    </td>
+                    {matrix.features.map((feature) => {
+                      const isLinked = matrix.coverage[req.id]?.has(feature.id);
+                      return (
+                        <td
+                          key={feature.id}
+                          className={cn(
+                            'border-b border-r p-3 text-center transition-all',
+                            isLinked
+                              ? 'bg-green-500/[0.05] group-hover:bg-green-500/[0.09]'
+                              : 'group-hover:bg-muted/10',
                           )}
-                        </div>
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))}
+                        >
+                          <div className='flex justify-center'>
+                            {isLinked ? (
+                              <div className='flex h-5 w-5 items-center justify-center rounded-full bg-green-500/15 text-green-500 ring-1 ring-green-500/20'>
+                                <CheckCircle2 className='h-3 w-3' />
+                              </div>
+                            ) : (
+                              <div className='bg-muted-foreground/20 h-1.5 w-1.5 rounded-full' />
+                            )}
+                          </div>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
 
           {matrix.requirements.length === 0 && (
-            <div className='text-muted-foreground/30 flex flex-col items-center justify-center py-32'>
-              <Layers className='mb-4 h-16 w-16 opacity-10' />
-              <p className='text-xs font-black tracking-[0.2em] uppercase'>
-                No mapping data available
-              </p>
+            <div className='text-muted-foreground/30 flex flex-col items-center justify-center py-24'>
+              <Layers className='mb-4 h-12 w-12 opacity-10' />
+              <p className='mono-label'>No requirements found</p>
             </div>
           )}
         </div>
       </Card>
 
       {/* Legend */}
-      <div className='flex justify-center gap-8 py-4'>
+      <div className='flex flex-wrap justify-center gap-6 py-2'>
         <div className='flex items-center gap-2'>
-          <div className='flex h-3 w-3 items-center justify-center rounded-full border border-green-500/30 bg-green-500/20'>
-            <CheckCircle2 className='h-2 w-2 text-green-600' />
+          <div className='flex h-4 w-4 items-center justify-center rounded-full bg-green-500/15 text-green-500 ring-1 ring-green-500/20'>
+            <CheckCircle2 className='h-2.5 w-2.5' />
           </div>
-          <span className='text-muted-foreground text-[10px] font-bold tracking-widest uppercase'>
-            Validated Link
-          </span>
+          <span className='mono-label'>Linked</span>
         </div>
         <div className='flex items-center gap-2'>
-          <div className='bg-muted-foreground h-1 w-1 rounded-full opacity-30' />
-          <span className='text-muted-foreground text-[10px] font-bold tracking-widest uppercase'>
-            No Connection
+          <div className='bg-muted-foreground/20 h-1.5 w-1.5 rounded-full' />
+          <span className='mono-label'>Not linked</span>
+        </div>
+        <div className='flex items-center gap-2'>
+          <span className='badge-covered'>
+            <CheckCircle2 className='h-2.5 w-2.5' />
+            COVERED
           </span>
+          <span className='mono-label'>All features linked</span>
+        </div>
+        <div className='flex items-center gap-2'>
+          <span className='badge-partial'>
+            <MinusCircle className='h-2.5 w-2.5' />
+            PARTIAL
+          </span>
+          <span className='mono-label'>Some features linked</span>
+        </div>
+        <div className='flex items-center gap-2'>
+          <span className='badge-uncovered'>
+            <Circle className='h-2.5 w-2.5' />
+            UNCOVERED
+          </span>
+          <span className='mono-label'>No features linked</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Apply Geist font (sans + mono) globally via Google Fonts CDN; font-family CSS vars set on \`:root\`
- Set dark mode as **default** — \`index.html\` has \`class=\"dark\"\`, theme-provider defaults to \`'dark'\`
- Replace CSS variables with Geist-style true-black dark palette (\`0 0% 3.9%\` base, pure neutral grays)
- Add coverage status CSS design tokens and badge utility classes: \`badge-covered\` (green), \`badge-partial\` (yellow), \`badge-uncovered\` (red)
- Add \`mono-label\` and \`geist-sidebar\` utility classes
- Refactor \`TraceabilityMatrixView\` with full geist aesthetic and COVERED/PARTIAL/UNCOVERED badges
- Update sidebar nav to \`geist-sidebar\` (true black, border-r, no gradient blur)

## Test plan

- [ ] App loads dark by default (no flash of light theme)
- [ ] Geist font renders in browser
- [ ] TraceabilityMatrixView shows COVERED/PARTIAL/UNCOVERED badges per requirement row
- [ ] Sidebar renders with clean dark background
- [ ] Coverage stat card progress bar turns green/yellow/red based on coverage % threshold
- [ ] Light mode toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added requirement coverage status tracking with visual indicators (Covered/Partial/Uncovered).
  * New Coverage column in traceability matrix with status breakdown summary.

* **Style**
  * Dark mode is now enabled by default.
  * Integrated Google Fonts for enhanced typography.
  * Updated design tokens, color palette, and visual styling across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->