### PR TITLE
chore: add process-compose.yml for local dev stack

### DIFF
--- a/process-compose.yml
+++ b/process-compose.yml
@@ -1,0 +1,95 @@
+version: "0.5"
+
+processes:
+  # ── Infrastructure ──────────────────────────────────────────────────────────
+
+  postgres:
+    command: "docker run --rm --name trace-postgres -e POSTGRES_USER=tracertm -e POSTGRES_PASSWORD=tracertm_password -e POSTGRES_DB=tracertm -p 5432:5432 pgvector/pgvector:pg16"
+    availability:
+      restart: on_failure
+      max_restarts: 3
+    readiness_probe:
+      exec:
+        command: "docker exec trace-postgres pg_isready -U tracertm -d tracertm"
+      initial_delay_seconds: 5
+      period_seconds: 5
+      failure_threshold: 10
+
+  redis:
+    command: "docker run --rm --name trace-redis -p 6379:6379 redis:7-alpine"
+    availability:
+      restart: on_failure
+      max_restarts: 3
+    readiness_probe:
+      exec:
+        command: "docker exec trace-redis redis-cli ping"
+      initial_delay_seconds: 3
+      period_seconds: 5
+      failure_threshold: 10
+
+  nats:
+    command: "docker run --rm --name trace-nats -p 4222:4222 -p 8222:8222 nats:latest -js -m 8222"
+    availability:
+      restart: on_failure
+      max_restarts: 3
+    readiness_probe:
+      http_get:
+        host: localhost
+        port: 8222
+        path: /healthz
+      initial_delay_seconds: 3
+      period_seconds: 5
+      failure_threshold: 10
+
+  # ── Backend Services ─────────────────────────────────────────────────────────
+
+  trace-api:
+    command: "air"
+    working_dir: "backend"
+    environment:
+      - PORT=8080
+      - ENV=development
+      - GIN_MODE=debug
+      - DATABASE_URL=postgres://tracertm:tracertm_password@localhost:5432/tracertm?sslmode=disable
+      - REDIS_URL=redis://localhost:6379
+      - NATS_URL=nats://localhost:4222
+    depends_on:
+      postgres:
+        condition: process_healthy
+      redis:
+        condition: process_healthy
+      nats:
+        condition: process_healthy
+    availability:
+      restart: on_failure
+      max_restarts: 5
+    readiness_probe:
+      http_get:
+        host: localhost
+        port: 8080
+        path: /health
+      initial_delay_seconds: 5
+      period_seconds: 5
+      failure_threshold: 12
+
+  # ── Frontend ─────────────────────────────────────────────────────────────────
+
+  tracertm-web:
+    command: "bun run dev"
+    working_dir: "frontend/apps/web"
+    environment:
+      - VITE_API_URL=http://localhost:8080
+    depends_on:
+      trace-api:
+        condition: process_healthy
+    availability:
+      restart: on_failure
+      max_restarts: 3
+    readiness_probe:
+      http_get:
+        host: localhost
+        port: 3000
+        path: /
+      initial_delay_seconds: 8
+      period_seconds: 5
+      failure_threshold: 12


### PR DESCRIPTION
## Summary
- Adds `process-compose.yml` covering the full TraceRTM dev stack
- Infrastructure: postgres (pgvector:pg16 on 5432), redis (7-alpine on 6379), nats (JetStream on 4222/8222)
- Backend: `trace-api` via `air` hot-reload on port 8080, waits for all infra to be healthy
- Frontend: `tracertm-web` via `bun run dev` on port 3000, waits for trace-api

## Test plan
- [ ] `process-compose up` starts all services in dependency order
- [ ] Health probes confirm each service becomes healthy before dependents start
- [ ] `process-compose down` stops cleanly