### PR TITLE
fix(ci): repair broken CI workflow configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1415,9 +1415,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker-build]
     # Only run when a Pulumi access token is configured; otherwise skip gracefully.
-    env:
-      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-    if: env.PULUMI_ACCESS_TOKEN != ''
+    if: ${{ secrets.PULUMI_ACCESS_TOKEN != '' }}
 
     permissions:
       contents: read
@@ -1432,6 +1430,8 @@ jobs:
 
     - name: Pulumi up (dev)
       uses: pulumi/actions@v5
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       with:
         command: up
         stack-name: dev

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: backend/go.sum
+          cache-dependency-path: backend/tests/go.sum
 
       - name: Cache Go modules
         uses: actions/cache@v3
@@ -47,13 +47,17 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Verify dependencies
-        working-directory: backend
+        working-directory: backend/tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
 
       - name: Run unit tests
         working-directory: backend/tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           go test -v -short -race -coverprofile=unit-coverage.out -covermode=atomic \
             -tags=unit \
@@ -139,7 +143,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: backend/go.sum
+          cache-dependency-path: backend/tests/go.sum
 
       - name: Cache Go modules
         uses: actions/cache@v3
@@ -150,7 +154,9 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Verify dependencies
-        working-directory: backend
+        working-directory: backend/tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
@@ -184,6 +190,7 @@ jobs:
           REDIS_URL: ${{ env.REDIS_URL }}
           NATS_URL: ${{ env.NATS_URL }}
           TEST_DATABASE_URL: postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}?sslmode=disable
+          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=integration-coverage.out -covermode=atomic \
             -tags=integration \
@@ -243,7 +250,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: backend/go.sum
+          cache-dependency-path: backend/tests/go.sum
 
       - name: Cache Go modules
         uses: actions/cache@v3
@@ -254,7 +261,9 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Verify dependencies
-        working-directory: backend
+        working-directory: backend/tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
@@ -284,6 +293,7 @@ jobs:
           DB_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           DB_NAME: ${{ env.POSTGRES_DB }}
           TEST_DATABASE_URL: postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}?sslmode=disable
+          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=api-coverage.out -covermode=atomic \
             -tags=api \
@@ -329,7 +339,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: backend/go.sum
+          cache-dependency-path: backend/tests/go.sum
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -373,6 +383,7 @@ jobs:
           REDIS_URL: redis://localhost:6379
           NATS_URL: nats://localhost:4222
           TEST_DATABASE_URL: postgresql://tracertm:tracertm_password@localhost:5432/tracertm?sslmode=disable
+          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=e2e-coverage.out -covermode=atomic \
             -tags=e2e \
@@ -429,7 +440,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: backend/go.sum
+          cache-dependency-path: backend/tests/go.sum
 
       - name: Cache Go modules
         uses: actions/cache@v3
@@ -440,13 +451,17 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Verify dependencies
-        working-directory: backend
+        working-directory: backend/tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
 
       - name: Run security tests
         working-directory: backend/tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=security-coverage.out -covermode=atomic \
             -tags=security \

--- a/.github/workflows/qa-governance.yml
+++ b/.github/workflows/qa-governance.yml
@@ -10,6 +10,8 @@ jobs:
   governance:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -68,13 +68,18 @@ jobs:
   daily-vuln-check:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check for new vulnerabilities
         run: |
           echo "Checking for new CVEs..."
-          
+
           # This creates a GitHub issue for new vulnerabilities
           gh issue create \
+            --repo "${{ github.repository }}" \
             --title "Weekly Security Scan - $(date +%Y-%m-%d)" \
             --body "Automated security scan completed. Check Dependabot alerts and security reports." \
             --label "security,automated" || echo "Issue creation skipped"


### PR DESCRIPTION
## Summary

- **go-tests.yml**: Fixed `cache-dependency-path` pointing to wrong `go.sum` — the `unit-tests`, `integration-tests`, `api-tests`, `e2e-tests`, and `security-tests` jobs all run from `backend/tests` which has its own `go.mod`/`go.sum` module. Changed from `backend/go.sum` to `backend/tests/go.sum`. Also fixed `working-directory` for verify-dependencies steps (was `backend`, now `backend/tests`) and added `GOTOOLCHAIN=local` to all test steps to prevent Go from trying to auto-download the nonexistent toolchain version `go 1.25.7` declared in `go.mod`.
- **security-scans.yml**: Added `permissions: issues: write` and `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `daily-vuln-check` job. The `gh` CLI requires authentication to create issues; without `GH_TOKEN` the step fails with an auth error. Also added `--repo` flag for explicit repo targeting.
- **ci.yml**: Fixed `iac-dev` job conditional expression. The `env` context is not available at job-level `if` expressions in GitHub Actions. Changed `if: env.PULUMI_ACCESS_TOKEN != ''` to `if: ${{ secrets.PULUMI_ACCESS_TOKEN != '' }}` and moved the token into the Pulumi action step env.
- **qa-governance.yml**: Added `permissions: contents: read` to the `governance` job following least-privilege principle and to satisfy repos with default restrictive permission settings.

## Test plan

- [ ] Verify go-tests workflow runs without "module not found" or toolchain download errors
- [ ] Verify security-scans daily-vuln-check can create issues (auth succeeds)
- [ ] Verify ci.yml iac-dev job skips when `PULUMI_ACCESS_TOKEN` secret is not set
- [ ] Verify qa-governance passes with the existing `.claude/quality.json` (established tier, non-critical)

Note: GitHub Actions billing limit is active on this account — CI jobs will show billing errors. These are code-level fixes to the workflow YAML; billing errors are expected and not a code regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)