### PR TITLE
chore(precommit): add no-new-todos and markdownlint hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,6 +126,23 @@ repos:
         language: system
         pass_filenames: false
 
+  # Block new TODO/FIXME comments — open a GitHub Issue instead
+  - repo: local
+    hooks:
+      - id: no-new-todos
+        name: No new TODO/FIXME
+        entry: bash -c 'git diff --cached --unified=0 | grep "^\+" | grep -E "TODO|FIXME" && echo "ERROR: New TODO/FIXME detected — open a GitHub Issue instead" && exit 1 || exit 0'
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+  # Markdownlint — enforce consistent Markdown formatting in docs
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        args: ["--ignore", "node_modules", "--ignore", ".archive"]
+
   # Block new linter suppressions (fast)
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- Add `no-new-todos` local hook: blocks commits that introduce new `TODO` or `FIXME` comments; contributors must open GitHub Issues instead
- Add `markdownlint-cli` hook (v0.43.0): enforces consistent Markdown formatting across docs, ignoring `node_modules` and `.archive`

## Test plan
- [ ] `pre-commit run no-new-todos --all-files` exits 0 on clean files
- [ ] Staging a file with a new `TODO:` comment causes `pre-commit` to block the commit
- [ ] `pre-commit run markdownlint --all-files` passes on existing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)