### PR TITLE
feat: add perf benchmarks and topo-sort unit tests

### DIFF
--- a/backend/benchmarks/bench_test.go
+++ b/backend/benchmarks/bench_test.go
@@ -1,0 +1,147 @@
+// Package benchmarks contains performance regression benchmarks for the TraceRTM backend.
+// Run with: go test ./benchmarks/... -bench=. -benchmem
+package benchmarks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kooshapari/tracertm-backend/internal/equivalence"
+)
+
+// BenchmarkNamingStrategyDetect measures naming-similarity detection across candidate pool sizes.
+func BenchmarkNamingStrategyDetect(b *testing.B) {
+	strategy := equivalence.NewNamingStrategy()
+	projectID := uuid.New()
+
+	source := &equivalence.StrategyItemInfo{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		Title:       "UserAuthenticationService",
+		Description: "Handles user login, logout, and session management.",
+		Type:        "service",
+		Perspective: "backend",
+	}
+
+	sizes := []int{10, 50, 100, 500}
+	for _, n := range sizes {
+		candidates := make([]*equivalence.StrategyItemInfo, n)
+		for i := range candidates {
+			candidates[i] = &equivalence.StrategyItemInfo{
+				ID:          uuid.New(),
+				ProjectID:   projectID,
+				Title:       fmt.Sprintf("Candidate%dService", i),
+				Description: "A candidate service item.",
+				Type:        "service",
+				Perspective: "frontend",
+			}
+		}
+		// Insert a strong match roughly in the middle.
+		candidates[n/2] = &equivalence.StrategyItemInfo{
+			ID:          uuid.New(),
+			ProjectID:   projectID,
+			Title:       "UserAuthService",
+			Description: "Manages user authentication flow.",
+			Type:        "service",
+			Perspective: "frontend",
+		}
+
+		req := &equivalence.StrategyDetectionRequest{
+			ProjectID:     projectID,
+			SourceItem:    source,
+			CandidatePool: candidates,
+			MinConfidence: 0.3,
+			MaxResults:    50,
+		}
+
+		b.Run(fmt.Sprintf("candidates=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := strategy.Detect(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkConfidenceScorerCompute measures confidence aggregation under varying evidence counts.
+func BenchmarkConfidenceScorerCompute(b *testing.B) {
+	scorer := equivalence.NewConfidenceScorer()
+
+	strategyTypes := []equivalence.StrategyType{
+		equivalence.StrategyNamingPattern,
+		equivalence.StrategyStructural,
+		equivalence.StrategySemanticSimilarity,
+		equivalence.StrategyAPIContract,
+		equivalence.StrategyExplicitAnnotation,
+	}
+
+	evidenceCounts := []int{1, 3, 5, 10}
+	for _, count := range evidenceCounts {
+		evidence := make([]equivalence.Evidence, count)
+		for i := range evidence {
+			st := strategyTypes[i%len(strategyTypes)]
+			evidence[i] = equivalence.Evidence{
+				Strategy:    st,
+				Confidence:  0.6 + float64(i)*0.03,
+				Description: fmt.Sprintf("Matched via %s strategy (signal %d)", st, i),
+				DetectedAt:  time.Now(),
+			}
+		}
+
+		b.Run(fmt.Sprintf("evidence=%d", count), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				scorer.ComputeConfidence(evidence)
+			}
+		})
+	}
+}
+
+// BenchmarkConflictReconcilerResolve measures conflict resolution across suggestion sets.
+func BenchmarkConflictReconcilerResolve(b *testing.B) {
+	reconciler := equivalence.NewConflictReconciler()
+	targetID := uuid.New()
+	itemID := uuid.New()
+	projectID := uuid.New()
+
+	sizes := []int{2, 5, 10}
+	for _, n := range sizes {
+		suggestions := make([]equivalence.Suggestion, n)
+		for i := range suggestions {
+			suggestions[i] = equivalence.Suggestion{
+				ID:           uuid.New(),
+				ProjectID:    projectID,
+				SourceItemID: itemID,
+				TargetItemID: targetID,
+				Confidence:   0.5 + float64(i)*0.04,
+				Strategies:   []equivalence.StrategyType{equivalence.StrategyNamingPattern},
+				Evidence: []equivalence.Evidence{
+					{
+						Strategy:    equivalence.StrategyNamingPattern,
+						Confidence:  0.7,
+						Description: "naming similarity",
+						DetectedAt:  time.Now(),
+					},
+				},
+				CreatedAt: time.Now(),
+			}
+		}
+
+		b.Run(fmt.Sprintf("suggestions=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reconciler.ResolveMultipleMatches(suggestions)
+			}
+		})
+	}
+}

--- a/backend/internal/graph/topo_queries_test.go
+++ b/backend/internal/graph/topo_queries_test.go
@@ -1,0 +1,138 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTopoSortLinearChain verifies correct ordering of a simple A->B->C chain.
+// Traces to: FR-GRAPH-001 (graph traversal correctness)
+func TestTopoSortLinearChain(t *testing.T) {
+	state := &topoState{
+		inDegree: map[string]int{
+			"a": 0,
+			"b": 1,
+			"c": 1,
+		},
+		adjacency: map[string][]string{
+			"a": {"b"},
+			"b": {"c"},
+			"c": {},
+		},
+	}
+
+	sorted := topoSort(state)
+	require.Equal(t, 3, len(sorted), "all nodes should appear in the result")
+	assert.Equal(t, "a", sorted[0], "a must come first (no in-edges)")
+	assert.Equal(t, "b", sorted[1])
+	assert.Equal(t, "c", sorted[2])
+}
+
+// TestTopoSortDiamondGraph verifies that a diamond dependency (A->{B,C}->D) resolves correctly.
+// Traces to: FR-GRAPH-001
+func TestTopoSortDiamondGraph(t *testing.T) {
+	state := &topoState{
+		inDegree: map[string]int{
+			"a": 0,
+			"b": 1,
+			"c": 1,
+			"d": 2,
+		},
+		adjacency: map[string][]string{
+			"a": {"b", "c"},
+			"b": {"d"},
+			"c": {"d"},
+			"d": {},
+		},
+	}
+
+	sorted := topoSort(state)
+	require.Equal(t, 4, len(sorted))
+	assert.Equal(t, "a", sorted[0], "root node must be first")
+	assert.Equal(t, "d", sorted[3], "sink node must be last")
+	// b and c may appear in either order in positions 1 and 2.
+	middleSet := map[string]bool{sorted[1]: true, sorted[2]: true}
+	assert.True(t, middleSet["b"] && middleSet["c"], "b and c must occupy middle positions")
+}
+
+// TestTopoSortCycle detects a cycle: A->B->A means topoSort cannot produce all nodes.
+// Traces to: FR-GRAPH-001
+func TestTopoSortCycle(t *testing.T) {
+	state := &topoState{
+		inDegree: map[string]int{
+			"a": 1,
+			"b": 1,
+		},
+		adjacency: map[string][]string{
+			"a": {"b"},
+			"b": {"a"},
+		},
+	}
+
+	sorted := topoSort(state)
+	// A cycle means neither node has in-degree 0; the queue starts empty and returns 0 nodes.
+	assert.Equal(t, 0, len(sorted), "cyclic graph should produce no sorted output")
+}
+
+// TestTopoSortSingleNode verifies a single, isolated node sorts correctly.
+// Traces to: FR-GRAPH-001
+func TestTopoSortSingleNode(t *testing.T) {
+	state := &topoState{
+		inDegree:  map[string]int{"solo": 0},
+		adjacency: map[string][]string{"solo": {}},
+	}
+
+	sorted := topoSort(state)
+	require.Equal(t, 1, len(sorted))
+	assert.Equal(t, "solo", sorted[0])
+}
+
+// TestTopoSortEmptyGraph verifies that an empty graph returns an empty slice without panicking.
+// Traces to: FR-GRAPH-001
+func TestTopoSortEmptyGraph(t *testing.T) {
+	state := &topoState{
+		inDegree:  map[string]int{},
+		adjacency: map[string][]string{},
+	}
+
+	sorted := topoSort(state)
+	assert.Empty(t, sorted)
+}
+
+// TestTopoSortDisconnectedComponents verifies two independent chains are both fully emitted.
+// Traces to: FR-GRAPH-001
+func TestTopoSortDisconnectedComponents(t *testing.T) {
+	// Chain 1: x -> y
+	// Chain 2: p -> q
+	state := &topoState{
+		inDegree: map[string]int{
+			"x": 0,
+			"y": 1,
+			"p": 0,
+			"q": 1,
+		},
+		adjacency: map[string][]string{
+			"x": {"y"},
+			"y": {},
+			"p": {"q"},
+			"q": {},
+		},
+	}
+
+	sorted := topoSort(state)
+	require.Equal(t, 4, len(sorted), "all nodes from both components must appear")
+
+	// Each root must precede its downstream node.
+	pos := func(id string) int {
+		for i, v := range sorted {
+			if v == id {
+				return i
+			}
+		}
+		return -1
+	}
+	assert.Less(t, pos("x"), pos("y"), "x must precede y")
+	assert.Less(t, pos("p"), pos("q"), "p must precede q")
+}


### PR DESCRIPTION
## Summary

- Adds `backend/benchmarks/bench_test.go`: Go performance regression benchmarks for the equivalence engine covering `NamingStrategy` (candidate pool sizes 10–500), `ConfidenceScorer` (evidence counts 1–10), and `ConflictReconciler` (suggestion counts 2–10). Each benchmark uses `-benchmem` alloc tracking. Run with: `go test ./benchmarks/... -bench=. -benchmem`.
- Adds `backend/internal/graph/topo_queries_test.go`: Six unit tests for the pure `topoSort` function covering linear chain, diamond graph, cycle detection, single node, empty graph, and disconnected components. All pass locally with no external service dependencies.
- Docs subdirectory structure (`docs/guides/`, `docs/guides/quick-start/`, `docs/reports/`, `docs/research/`, `docs/reference/`, `docs/checklists/`) already exists with substantial content; no structural changes needed.

## Test plan

- [x] `go vet ./benchmarks/... ./internal/graph/...` — exits 0
- [x] `go test ./internal/graph/ -run "^TestTopoSort" -v` — all 6 tests PASS
- [ ] `go test ./benchmarks/... -bench=. -benchmem` — run locally to capture baseline ns/op and allocs/op for regression tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)