### PR TITLE
fix(ci): correct vitepress-pages workflow YAML

### DIFF
--- a/.github/workflows/vitepress-pages.yml
+++ b/.github/workflows/vitepress-pages.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          cache: 'npm'
-        with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: docs/package.json


### PR DESCRIPTION
## Summary

- Remove duplicate `with:` key from `actions/setup-node` step in `vitepress-pages.yml`
- The duplicate key caused a YAML parse error and prevented the docs deploy workflow from running
- Pages is already enabled with `build_type=workflow`; this fix allows the workflow to run successfully

## Test plan
- [ ] Merge and verify the `VitePress Pages` workflow runs on push to main
- [ ] Confirm docs are deployed to https://kooshapari.github.io/trace/

🤖 Generated with [Claude Code](https://claude.com/claude-code)