### PR TITLE
ci(perf): add Go benchmark CI workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,31 @@
+name: Performance Benchmarks
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * 1'
+
+jobs:
+  go-benchmarks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: backend/go.sum
+      - name: Run benchmarks
+        working-directory: backend
+        env:
+          GOTOOLCHAIN: local
+        run: go test ./benchmarks/... -bench=. -benchmem -count=3 -timeout=5m | tee benchmark-results.txt
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-benchmark-results
+          path: backend/benchmark-results.txt
+          retention-days: 90


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/benchmarks.yml` to run Go benchmarks from `backend/benchmarks/...` on push, PR, and weekly Monday 2am schedule
- Uses `go test -bench=. -benchmem -count=3 -timeout=5m` for reliable, reproducible results
- Uploads `benchmark-results.txt` as artifact with 90-day retention

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Confirm `backend/benchmarks/bench_test.go` is picked up by `./benchmarks/...`
- [ ] Artifact upload path matches `backend/benchmark-results.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated performance benchmarking to monitor application performance and detect regressions during development cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->