### PR TITLE
Replace hardcoded paths with $AGILEPLUS_CLI placeholder

### DIFF
--- a/docs/plans/AGILEPLUS_SPEC.md
+++ b/docs/plans/AGILEPLUS_SPEC.md
@@ -175,7 +175,7 @@ AgilePlus provides CLI commands for spec management:
 Create a new specification:
 
 ```bash
-cd /Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus
+cd $AGILEPLUS_CLI
 agileplus specify <feature-id> [--title "Title"] [--template default|experimental]
 ```
 
@@ -330,8 +330,8 @@ Specs are stored in `.agileplus/specs/<feature-id>/`:
 - `.agileplus/specs/<feature-id>/meta.json` - id, title, status
 - `.agileplus/specs/<feature-id>/tasks.md` - work packages
 
-Reference: `/Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus`
-CLI: `cd /Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus && agileplus <command>`
+Reference: `$AGILEPLUS_CLI`
+CLI: `cd $AGILEPLUS_CLI && agileplus <command>`
 ```
 
 ### 9.2 MCP Tools
@@ -384,7 +384,7 @@ For TracerTM's existing spec-like documents, convert to AgilePlus format:
 
 ## 12. Reference
 
-- **AgilePlus CLI**: `/Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus`
+- **AgilePlus CLI**: `$AGILEPLUS_CLI`
 - **TracerTM PRD**: [`PRD.md`](./PRD.md)
 - **TracerTM Plan**: [`docs/plans/PLAN.md`](./PLAN.md)
 - **BMM Methodology**: See `.archive/.bmad/bmm/` for scale-adaptive planning


### PR DESCRIPTION
## Summary
- Replace hardcoded absolute path with $AGILEPLUS_CLI environment variable placeholder in AGILEPLUS_SPEC.md

## Changes (4 locations)
- Line 178: CLI example path
- Lines 333-334: Claude Integration section Reference and CLI fields
- Line 387: Reference section AgilePlus CLI path

Fixes rework bead b433e819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AgilePlus CLI documentation to reference paths via environment variables instead of hard-coded filesystem paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->