### PR TITLE
fix(ci): commit regenerated OpenAPI artifact (audit #118)

### DIFF
--- a/.github/workflows/openapi-docs.yml
+++ b/.github/workflows/openapi-docs.yml
@@ -128,10 +128,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-and-validate
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download OpenAPI spec
         uses: actions/download-artifact@v4
@@ -149,10 +155,15 @@ jobs:
 
       - name: Commit and push if changed
         run: |
-          git config --global user.name 'OpenAPI Bot'
-          git config --global user.email 'openapi-bot@github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add docs/public/openapi.json docs/public/openapi.yaml
-          git diff --quiet && git diff --staged --quiet || (git commit -m "chore: update OpenAPI spec [skip ci]" && git push)
+          if [ -n "$(git status --porcelain docs/public/openapi.json docs/public/openapi.yaml)" ]; then
+            git commit -m "chore(openapi): regenerate spec artifact [skip ci]"
+            git push origin HEAD:main
+          else
+            echo "No OpenAPI spec changes to commit."
+          fi
 
   # Optional: Generate client SDKs
   generate-clients:


### PR DESCRIPTION
## **User description**
## Summary

Audit #118 flagged that `.github/workflows/openapi-docs.yml` regenerates the OpenAPI spec on every push but the spec artifact never reaches `origin` — "invisible generator" drift. Consumers (SDK generators, docs site, contract tests) cannot fetch a current contract from the repo.

Root cause: the `deploy-to-docs-site` job already contained a commit-and-push step, but was missing `permissions: contents: write` (so the default `GITHUB_TOKEN` could not push) and the checkout did not persist credentials against `main`.

## Changes

- Add `permissions: contents: write` to `deploy-to-docs-site` job.
- Checkout with explicit `ref: main`, `persist-credentials: true`, `token: ${{ secrets.GITHUB_TOKEN }}`.
- Scope the diff check to the two spec files; explicit `git push origin HEAD:main`.
- Use `github-actions[bot]` noreply identity (Phenotype convention).
- Keep `[skip ci]` on the commit message to avoid recursive triggers.

## Why Option A (auto-commit) vs C (PR)

Job was already wired for auto-commit — just broken. Kept intent; documented that `peter-evans/create-pull-request@v7` is an easy swap if the team later wants human review on contract changes.

## .gitignore

`backend/docs/` is ignored intentionally (swag build artifact). Canonical committed spec lives at `docs/public/openapi.{json,yaml}` which is not ignored. No negation needed.

## Test plan

- [ ] Merge; next push to `main` touching `backend/**/*.go` triggers regeneration.
- [ ] Confirm a follow-up `chore(openapi): regenerate spec artifact [skip ci]` commit appears on `main` with updated `docs/public/openapi.{json,yaml}`.
- [ ] Confirm `[skip ci]` prevents recursive workflow trigger.

Ref: `worklogs/ARCHITECTURE.md` 2026-04-24 OpenAPI/spec coverage audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Changes CI to push commits to `main` using `GITHUB_TOKEN`, which can create unintended repo writes or loops if misconfigured, but scope is limited to two spec files and uses `[skip ci]`.
> 
> **Overview**
> Ensures the `deploy-to-docs-site` GitHub Actions job can **commit and push regenerated OpenAPI specs** back to `main`.
> 
> The workflow now grants `contents: write`, checks out `main` with persisted credentials, and only commits when `docs/public/openapi.{json,yaml}` changed, pushing explicitly via `git push origin HEAD:main` with the `github-actions[bot]` identity and a `[skip ci]` commit message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd90b5075b10a54dc7382d2845fa7b9008cc3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep the OpenAPI spec committed to the repo after regeneration**

### What Changed
- The OpenAPI docs workflow can now push updated spec files back to `main` after regeneration.
- If the generated `openapi.json` or `openapi.yaml` changes, the workflow commits them with a bot identity and skips CI to avoid повторный trigger loops.
- If the spec files do not change, the workflow exits without creating a commit.

### Impact
`✅ Current OpenAPI specs stay available in the repo`
`✅ Fewer stale contract files after backend changes`
`✅ No extra CI runs from spec auto-updates`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=0vGpFMt4AdR-w6w-HiK4dg9RFyZoGaNUzWGBNArwxpM&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
