### PR TITLE
chore(ci): pin floating external actions to SHAs (ci.yml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1150,7 +1150,7 @@ jobs:
       continue-on-error: true
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # was: @master
       with:
         scan-type: 'fs'
         scan-ref: '.'


### PR DESCRIPTION
Replaces floating external action refs in `.github/workflows/ci.yml` with immutable commit SHAs.

Refs replaced: aquasecurity/trivy-action@master

Tag-pinned and internal KooshaPari refs are untouched.

Generated by API-only pin-hygiene audit.