### PR TITLE
ci: align Python workflows with 3.13

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -24,13 +24,13 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra dev
 
       - name: Check architecture
-        run: uv run tach check
+        run: uv run --extra dev tach check
 
       - name: Generate architecture diagram
-        run: uv run tach show --mermaid > architecture.md
+        run: uv run --extra dev tach show --mermaid > architecture.md
 
       - name: Upload architecture diagram
         uses: actions/upload-artifact@v4

--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -27,10 +27,10 @@ jobs:
         run: uv sync
 
       - name: Check architecture
-        run: tach check
+        run: uv run tach check
 
       - name: Generate architecture diagram
-        run: tach show --mermaid > architecture.md
+        run: uv run tach show --mermaid > architecture.md
 
       - name: Upload architecture diagram
         uses: actions/upload-artifact@v4

--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -21,8 +21,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: uv sync
@@ -52,4 +51,3 @@ jobs:
               repo: context.repo.repo,
               body: '## Architecture Diagram\n\n' + diagram
             });
-

--- a/.github/workflows/chaos-tests.yml
+++ b/.github/workflows/chaos-tests.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/chaos-tests.yml'
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.13'
   RECOVERY_TIME_TARGET: 30
 
 jobs:
@@ -83,7 +83,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     
     - name: Install dependencies
       run: |
@@ -88,7 +88,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ env:
   DOCKER_REGISTRY: ghcr.io
   REGISTRY_USERNAME: ${{ github.actor }}
   GO_VERSION: '1.23'
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.13'
 
 jobs:
   # Quality Guards (Naming Explosion + LOC limits)
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     services:
       postgres:
@@ -331,10 +331,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         cache: 'pip'
 
     - name: Install uv
@@ -1415,7 +1415,7 @@ jobs:
         cache-to: type=gha,mode=max
         platforms: linux/amd64,linux/arm64
         build-contexts: |
-          base=docker-image://python:3.12-slim
+          base=docker-image://python:3.13-slim
 
     - name: Extract metadata for Go Backend
       id: meta-backend

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Cache uv dependencies
         uses: actions/cache@v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -48,8 +48,6 @@ jobs:
         if: contains(steps.metadata.outputs.dependency-names, 'npm') || contains(steps.metadata.outputs.dependency-names, 'node')
         uses: actions/setup-node@v4
         with:
-          cache: 'npm'
-        with:
           node-version: '20'
           cache: 'bun'
 
@@ -57,9 +55,7 @@ jobs:
         if: contains(steps.metadata.outputs.dependency-names, 'python')
         uses: actions/setup-python@v5
         with:
-          cache: 'pip'
-        with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Set up Go

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -49,7 +49,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'bun'
 
       - name: Set up Python
         if: contains(steps.metadata.outputs.dependency-names, 'python')

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,8 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache uv dependencies

--- a/.github/workflows/test-pyramid.yml
+++ b/.github/workflows/test-pyramid.yml
@@ -29,15 +29,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'npm'
-        with:
           node-version: "20"
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Run test pyramid verification
         id: pyramid

--- a/.github/workflows/test-pyramid.yml
+++ b/.github/workflows/test-pyramid.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          cache: 'npm'
           node-version: "20"
 
       - name: Set up Python

--- a/.github/workflows/test-pyramid.yml
+++ b/.github/workflows/test-pyramid.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          cache: 'pip'
           python-version: "3.13"
 
       - name: Run test pyramid verification

--- a/.github/workflows/test-validation.yml
+++ b/.github/workflows/test-validation.yml
@@ -158,7 +158,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install UV
         uses: astral-sh/setup-uv@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.13']
     steps:
       - uses: actions/checkout@v4
 
@@ -80,8 +80,6 @@ jobs:
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false  # Continue running other tests even if one fails
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.13"]
         test-type: [unit, integration, e2e]
         include:
-          # Property-based tests run only on Python 3.12
-          - python-version: "3.12"
+          # Property-based tests run only on the supported project Python.
+          - python-version: "3.13"
             test-type: property
 
     services:
@@ -58,7 +58,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache uv dependencies
@@ -181,8 +180,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Cache uv dependencies
         uses: actions/cache@v3

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -9,14 +9,38 @@ repo cleanup.
 
 - **Cap:** one runtime/test dependency surface per PR unless alerts share the
   same lockfile.
-- **Current size:** one Tracera PR branch; GitPython `uv.lock` hotfix in scope;
-  broader Python lower-bound cleanup, Go Docker module alerts, frontend alerts,
-  and archived npm snapshots are out of this patch.
-- **Stop rule:** merge a PR that updates GitPython to the patched lockfile
-  version and fixes the invalid project metadata required for `uv lock`.
+- **Current size:** GitPython `uv.lock` hotfix is merged; CI Python compatibility
+  is the next bounded task because the hotfix PR exposed workflow pins below the
+  repository's `requires-python = ">=3.13"` contract.
+- **Stop rule:** keep each PR to one dependency/runtime surface and leave broader
+  CI, Go, frontend, and archive cleanup as explicit follow-up lanes.
 - **Spillover:** create separate WBS items for Python lower-bound cleanup, Go
   Docker module investigation, frontend package bumps, and archive manifest
   quarantine.
+
+## SIZE-CI-PYTHON-313: Python CI Compatibility
+
+- **Scope:** PR-triggered Python workflow setup and local Python type-tool
+  version alignment.
+- **Reason:** `CI/CD Pipeline / Python Tests (3.12)` failed because workflows
+  installed the project on Python 3.12 while `pyproject.toml` requires Python
+  3.13 or newer.
+- **Included:** `.github/workflows/ci.yml`, `quality.yml`, `tests.yml`,
+  `pre-commit.yml`, `test-pyramid.yml`, `contracts.yml`, `chaos-tests.yml`,
+  `architecture.yml`, `dependabot-auto-merge.yml`, `test-validation.yml`,
+  `test.yml`, `ci-cd.yml`, and `[tool.ty.environment]`.
+- **Excluded:** Go toolchain/race failures, old action-version upgrades,
+  shellcheck cleanups, `requirements.txt` workflow migration, contract
+  `scripts/.venv` repair, and archive dependency manifests.
+
+## SIZE-CI-GO-TOOLCHAIN: Deferred Go CI Lane
+
+- **Scope:** reusable workflow/toolchain ownership, not this Python PR.
+- **Current evidence:** the Go failure used Go 1.23 wrappers while logs resolved
+  a Go 1.25.7 target, then failed golangci-lint/covdata/race-test steps.
+- **Next action:** inspect the reusable workflow owner and align `go version`,
+  `GOTOOLCHAIN`, golangci-lint, coverage, and race-test execution under one
+  source of truth.
 
 ## Alert Buckets
 
@@ -24,7 +48,9 @@ repo cleanup.
 |---|---|---|
 | GitPython | `uv.lock` | Patch in this lane. |
 | Other Python | `pyproject.toml`, `uv.lock` | Separate Python dependency cleanup lane. |
+| Python CI | `.github/workflows/*.yml`, `pyproject.toml` | Align PR-triggered Python setup to 3.13. |
 | Go Docker module | `backend/**/go.mod` | Defer until a published fixed module tag or replacement module path is confirmed. |
+| Go CI toolchain | reusable workflow / Go wrappers | Separate toolchain lane. |
 | Frontend npm | `frontend/**` | Separate frontend dependency lane. |
 | Archived npm snapshots | `ARCHIVE/CONFIG/default/**/package.json` | Separate archive quarantine task. |
 
@@ -33,5 +59,8 @@ repo cleanup.
 ```bash
 uv lock --locked
 uv run python -m compileall -q src
+actionlint -shellcheck= -ignore 'the runner of ".*" action is too old' \
+  -ignore 'input "webhook_url" is not defined' \
+  -ignore '"needs" section should not be empty' .github/workflows/<changed>.yml
 git diff --check
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1665,7 +1665,7 @@ invalid-return-type = "ignore"
 invalid-await = "ignore"
 
 [tool.ty.environment]
-python-version = "3.12"
+python-version = "3.13"
 
 [tool.ty.rules]
 unused-ignore-comment = "error"


### PR DESCRIPTION
## **User description**
## Summary
- align PR-triggered Python workflow setup with `requires-python = ">=3.13"`
- update `[tool.ty.environment]` to Python 3.13
- collapse malformed duplicate `with:` blocks touched by the Python setup updates
- extend the dependency remediation session note with `SIZE-CI-PYTHON-313` and deferred `SIZE-CI-GO-TOOLCHAIN` lanes

## Validation
- `actionlint -shellcheck= -ignore 'the runner of \\".*\\" action is too old' -ignore 'input \\"webhook_url\\" is not defined' -ignore '\\"needs\\" section should not be empty' .github/workflows/ci.yml .github/workflows/quality.yml .github/workflows/tests.yml .github/workflows/pre-commit.yml .github/workflows/test-pyramid.yml .github/workflows/contracts.yml .github/workflows/chaos-tests.yml .github/workflows/architecture.yml .github/workflows/dependabot-auto-merge.yml .github/workflows/test-validation.yml .github/workflows/test.yml .github/workflows/ci-cd.yml`\n- `uv lock --locked`\n- `git diff --check`\n\n## Scope Control\n- Go toolchain/race failures stay deferred to `SIZE-CI-GO-TOOLCHAIN`.\n- Legacy action-version upgrades and shellcheck cleanup stay out of this PR unless required by branch protection.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Touches many GitHub Actions workflows and test matrices; mistakes could break CI execution or reduce coverage across previously-tested Python versions. No production application logic changes, but CI/runtime tooling alignment is broad.
> 
> **Overview**
> Aligns PR-triggered GitHub Actions workflows to **Python 3.13** (matching `requires-python = ">=3.13"`), including test/quality/architecture/contracts/chaos/pre-commit/validation pipelines and the Docker build base image.
> 
> Cleans up malformed workflow YAML (duplicate `with:` blocks) and updates a few steps to run tools via `uv` (e.g., `tach` in `architecture.yml`) while narrowing Python version matrices to the supported version.
> 
> Updates local type-checker config (`[tool.ty.environment]`) to `python-version = "3.13"` and expands the dependency remediation session note with a bounded CI-compatibility lane and deferred Go toolchain follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a3e7a4fbb60f6987aa27717a5af76d4bce28c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Align CI and test workflows with Python 3.13

### What Changed
- Updated Python setup across PR checks, tests, quality, pre-commit, contracts, chaos, architecture, and release workflows to use Python 3.13
- Reduced test matrix coverage to the project-supported Python version, including property-based tests
- Fixed broken workflow setup blocks and removed conflicting cache settings that could stop CI jobs from running
- Updated the architecture checks to run with the expected project tools and Python setup
- Refreshed the dependency-remediation note to track the Python 3.13 CI lane separately from deferred Go work

### Impact
`✅ Fewer CI failures on Python checks`
`✅ Consistent test coverage on the supported Python version`
`✅ Clearer workflow runs during PR checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=rSh5efOQkU_lELiiWi1c1cS_KHSsfydfqL24rhu4noU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
