### PR TITLE
ci: align Go workflows with backend toolchain

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,12 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25.7'
           cache-dependency-path: backend/go.sum
       - name: Run benchmarks
         working-directory: backend
-        env:
-          GOTOOLCHAIN: local
         run: go test ./benchmarks/... -bench=. -benchmem -count=3 -timeout=5m | tee benchmark-results.txt
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
 env:
   DOCKER_REGISTRY: ghcr.io
   REGISTRY_USERNAME: ${{ github.actor }}
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25.7'
   PYTHON_VERSION: '3.13'
 
 jobs:
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.23']
+        go-version: ['1.25.7']
 
     services:
       postgres:
@@ -428,9 +428,9 @@ jobs:
         go mod verify
 
     - name: Run golangci-lint (strict enforcement)
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: v1.61
+        version: latest
         working-directory: backend
         args: --timeout=5m --config=.golangci.yml
       continue-on-error: false

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.23.0'
+  GO_VERSION: '1.25.7'
   POSTGRES_DB: tracertm_test
   POSTGRES_USER: tracertm_test
   POSTGRES_PASSWORD: test_password
@@ -48,16 +48,12 @@ jobs:
 
       - name: Verify dependencies
         working-directory: backend/tests
-        env:
-          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
 
       - name: Run unit tests
         working-directory: backend/tests
-        env:
-          GOTOOLCHAIN: local
         run: |
           go test -v -short -race -coverprofile=unit-coverage.out -covermode=atomic \
             -tags=unit \
@@ -155,8 +151,6 @@ jobs:
 
       - name: Verify dependencies
         working-directory: backend/tests
-        env:
-          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
@@ -190,7 +184,6 @@ jobs:
           REDIS_URL: ${{ env.REDIS_URL }}
           NATS_URL: ${{ env.NATS_URL }}
           TEST_DATABASE_URL: postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}?sslmode=disable
-          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=integration-coverage.out -covermode=atomic \
             -tags=integration \
@@ -262,8 +255,6 @@ jobs:
 
       - name: Verify dependencies
         working-directory: backend/tests
-        env:
-          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
@@ -293,7 +284,6 @@ jobs:
           DB_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           DB_NAME: ${{ env.POSTGRES_DB }}
           TEST_DATABASE_URL: postgresql://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}?sslmode=disable
-          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=api-coverage.out -covermode=atomic \
             -tags=api \
@@ -383,7 +373,6 @@ jobs:
           REDIS_URL: redis://localhost:6379
           NATS_URL: nats://localhost:4222
           TEST_DATABASE_URL: postgresql://tracertm:tracertm_password@localhost:5432/tracertm?sslmode=disable
-          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=e2e-coverage.out -covermode=atomic \
             -tags=e2e \
@@ -452,16 +441,12 @@ jobs:
 
       - name: Verify dependencies
         working-directory: backend/tests
-        env:
-          GOTOOLCHAIN: local
         run: |
           go mod download
           go mod verify
 
       - name: Run security tests
         working-directory: backend/tests
-        env:
-          GOTOOLCHAIN: local
         run: |
           go test -v -race -coverprofile=security-coverage.out -covermode=atomic \
             -tags=security \

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -120,13 +120,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
           python-version: '3.11'
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.7'
 
       - name: Install k6
         run: |
@@ -248,13 +247,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
           python-version: '3.11'
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.7'
 
       - name: Install k6
         run: |
@@ -351,7 +349,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with:
           python-version: '3.11'
 
       - name: Install dependencies

--- a/.github/workflows/test-pyramid.yml
+++ b/.github/workflows/test-pyramid.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25.7"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-validation.yml
+++ b/.github/workflows/test-validation.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.7'
 
       - name: Setup test credentials
         env:
@@ -127,7 +127,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.7'
 
       - name: Run Go route validation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.7'
 
       - name: Install dependencies
         run: |

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -35,12 +35,16 @@ repo cleanup.
 
 ## SIZE-CI-GO-TOOLCHAIN: Deferred Go CI Lane
 
-- **Scope:** reusable workflow/toolchain ownership, not this Python PR.
+- **Scope:** active Tracera Go workflow pins and toolchain ownership.
 - **Current evidence:** the Go failure used Go 1.23 wrappers while logs resolved
   a Go 1.25.7 target, then failed golangci-lint/covdata/race-test steps.
-- **Next action:** inspect the reusable workflow owner and align `go version`,
-  `GOTOOLCHAIN`, golangci-lint, coverage, and race-test execution under one
-  source of truth.
+- **Action:** align PR-triggered Go workflow setup to the backend `go 1.25.7`
+  module contract, remove `GOTOOLCHAIN: local` overrides from Go test wrappers,
+  and move the strict golangci-lint action to the current Go-1.25-capable line.
+- **Included:** `ci.yml`, `go-tests.yml`, `test.yml`, `test-validation.yml`,
+  `test-pyramid.yml`, `benchmarks.yml`, and `performance-regression.yml`.
+- **Excluded:** Go race-test code failures, coverage artifact semantics, stale
+  non-PR docs/schema/contract helper pins, and broader workflow action upgrades.
 
 ## Alert Buckets
 


### PR DESCRIPTION
## **User description**
## Summary
- align active Go workflow pins to backend Go 1.25.7
- remove `GOTOOLCHAIN: local` overrides from Go test wrappers
- move strict golangci-lint workflow usage to the current v9 action line
- fix duplicate `with:` keys in `performance-regression.yml` while touching its Go setup pins

## Validation
- `actionlint -shellcheck= -ignore 'the runner of ".*" action is too old' -ignore 'input "webhook_url" is not defined' -ignore '"needs" section should not be empty' .github/workflows/ci.yml .github/workflows/go-tests.yml .github/workflows/test.yml .github/workflows/benchmarks.yml .github/workflows/performance-regression.yml .github/workflows/test-validation.yml .github/workflows/test-pyramid.yml`\n- `git diff --check`\n- `go -C backend env GOVERSION GOTOOLCHAIN` -> `go1.25.7`, `auto`\n- `go -C backend/tests env GOVERSION GOTOOLCHAIN` -> `go1.25.7`, `auto`\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> CI behavior changes across multiple workflows (Go toolchain version bump, lint action upgrade, and removal of `GOTOOLCHAIN` overrides) could break builds or change lint/test outcomes, but no production runtime code is modified.
> 
> **Overview**
> Aligns all PR-triggered Go workflows to use Go `1.25.7` (replacing `1.21`/`1.23`) across CI, tests, benchmarks, test validation, and performance regression runs.
> 
> Removes `GOTOOLCHAIN: local` environment overrides from Go test/verify steps so the default toolchain resolution is used, and upgrades the strict lint step in `ci.yml` from `golangci-lint-action@v6`/pinned linter to `@v9` with `version: latest`.
> 
> Fixes a workflow YAML issue in `performance-regression.yml` (duplicate `with:` nesting) while updating its Go setup pin, and updates the session doc to reflect the Go CI toolchain remediation scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e5a45963ab8e932ace7d18e7b128f1bb4e519d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Align Go CI checks with the backend toolchain**

### What Changed
- Updated Go CI, test, benchmark, validation, and regression workflows to use Go 1.25.7 so checks run against the same version as the backend.
- Removed `GOTOOLCHAIN: local` from Go test and verification steps, so workflows use the default toolchain setup instead of forcing a local override.
- Upgraded the strict Go lint step to the current action line and fixed a workflow YAML nesting issue in performance regression runs.

### Impact
`✅ Fewer Go CI version mismatches`
`✅ More reliable test and lint runs`
`✅ Fewer workflow failures from invalid YAML`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=zXmv7tQafWYXdEMA1Z2MLgaw9MV0e2QiGd6sxHmGn0w&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
