### PR TITLE
ci: guard performance report artifact downloads

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -327,21 +327,21 @@ jobs:
     needs: [smoke-test, load-test]
     if: |
       always() &&
-      (needs.smoke-test.result == 'success' || needs.load-test.result == 'success')
+      (needs['smoke-test'].result == 'success' || needs['load-test'].result == 'success')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Download smoke test results
-        if: needs.smoke-test.result == 'success'
+        if: needs['smoke-test'].result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: smoke-test-results
           path: results/smoke
 
       - name: Download load test results
-        if: needs.load-test.result == 'success'
+        if: needs['load-test'].result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: load-test-results

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -325,21 +325,23 @@ jobs:
     name: Generate Performance Report
     runs-on: ubuntu-latest
     needs: [smoke-test, load-test]
-    if: always()
+    if: |
+      always() &&
+      (needs.smoke-test.result == 'success' || needs.load-test.result == 'success')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Download smoke test results
-        if: needs.smoke-test.result != 'skipped'
+        if: needs.smoke-test.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: smoke-test-results
           path: results/smoke
 
       - name: Download load test results
-        if: needs.load-test.result != 'skipped'
+        if: needs.load-test.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: load-test-results
@@ -368,7 +370,7 @@ jobs:
           path: performance-report.html
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && hashFiles('results/smoke/smoke-test-summary.json') != ''
         uses: actions/github-script@v7
         with:
           script: |

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -58,6 +58,18 @@ repo cleanup.
 | Frontend npm | `frontend/**` | Separate frontend dependency lane. |
 | Archived npm snapshots | `ARCHIVE/CONFIG/default/**/package.json` | Separate archive quarantine task. |
 
+## SIZE-CI-PERF-REPORT-ARTIFACTS: Performance Report Guard
+
+- **Scope:** `performance-regression.yml` report fan-in behavior only.
+- **Reason:** after the Go toolchain fix, `Generate Performance Report` failed
+  while downloading `smoke-test-results` even though the producing smoke job had
+  failed before uploading that artifact.
+- **Action:** run the report fan-in only when at least one performance producer
+  succeeded, download artifacts only from successful producers, and only post the
+  PR smoke summary comment when the smoke summary file exists.
+- **Excluded:** fixing the underlying smoke/load runtime failures, k6 scenario
+  behavior, backend startup, and report rendering semantics.
+
 ## Validation Targets
 
 ```bash


### PR DESCRIPTION
## **User description**
## Summary
- skip the performance report fan-in unless a performance producer job succeeded
- download smoke/load artifacts only from successful producer jobs
- only post the PR smoke summary when the smoke summary artifact exists
- record the bounded WBS lane in the dependency remediation session doc

## Validation
- `actionlint -shellcheck= -ignore 'the runner of ".*" action is too old' -ignore 'input "webhook_url" is not defined' -ignore '"needs" section should not be empty' .github/workflows/performance-regression.yml`\n- `git diff --check`\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tightens GitHub Actions job gating to avoid missing-artifact failures; main risk is accidentally skipping report/comment generation in edge cases.
> 
> **Overview**
> Hardens `performance-regression.yml` so the `report` job only runs when at least one of `smoke-test`/`load-test` succeeds, and only downloads artifacts from successful producer jobs.
> 
> Also guards the PR comment step to run only when the smoke summary file exists, and documents this bounded CI change in `docs/sessions/20260426-dependency-alert-remediation.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138cf076e222beb5f8ae598780921fe38ae07666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Avoid performance report failures when test artifacts are missing

### What Changed
- The performance report now runs only when at least one of the smoke or load test jobs succeeds.
- It downloads smoke and load results only from successful jobs, so missing artifacts no longer break the report step.
- The PR smoke summary comment is posted only when the smoke summary file exists.
- The remediation session doc now records this bounded CI fix and what it does not change.

### Impact
`✅ Fewer performance report failures`
`✅ Fewer missing-artifact CI errors`
`✅ Clearer PR performance comments`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=IpmEz3kfvRP3D9C6L2K-BdOR3JBXj8NY6KZg2EB_5nw&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
