### PR TITLE
ci: use pgvector image for performance tests

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -89,7 +89,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: pgvector/pgvector:pg17
         env:
           POSTGRES_USER: tracertm
           POSTGRES_PASSWORD: testpass
@@ -216,7 +216,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: pgvector/pgvector:pg17
         env:
           POSTGRES_USER: tracertm
           POSTGRES_PASSWORD: testpass

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -70,6 +70,18 @@ repo cleanup.
 - **Excluded:** fixing the underlying smoke/load runtime failures, k6 scenario
   behavior, backend startup, and report rendering semantics.
 
+## SIZE-CI-PERF-PGVECTOR: Performance Database Image
+
+- **Scope:** `performance-regression.yml` Postgres service images only.
+- **Reason:** `Smoke Test - Quick Performance Check` failed during migrations
+  because the hosted `postgres:17` image does not include the `vector` extension
+  required by `backend/schema.sql`.
+- **Action:** use `pgvector/pgvector:pg17` for smoke and load performance
+  database services, matching the repository's existing pgvector test-compose
+  pattern while preserving PostgreSQL 17.
+- **Excluded:** backend migration redesign, making pgvector optional, k6 scenario
+  behavior, and unrelated smoke/load runtime failures after migrations succeed.
+
 ## Validation Targets
 
 ```bash


### PR DESCRIPTION
## **User description**
## Summary
- switch smoke/load performance Postgres services from `postgres:17` to `pgvector/pgvector:pg17`
- keep PostgreSQL 17 while providing the `vector` extension required by Alembic/schema migrations
- document the bounded `SIZE-CI-PERF-PGVECTOR` lane

## Evidence
- `alembic/versions/000_initial_schema.py` and `031_add_canonical_concepts.py` both run `CREATE EXTENSION IF NOT EXISTS vector`
- `backend/schema.sql` defines pgvector columns/indexes
- `docker manifest inspect pgvector/pgvector:pg17` succeeds

## Validation
- `actionlint -shellcheck= -ignore 'the runner of ".*" action is too old' -ignore 'input "webhook_url" is not defined' -ignore '"needs" section should not be empty' .github/workflows/performance-regression.yml`\n- `git diff --check`\n- local container probe was attempted but blocked because Docker/OrbStack socket is not running\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Changes the database container image used by CI performance smoke/load jobs, which could affect migrations and test behavior if the new image differs from vanilla Postgres or is unavailable.
> 
> **Overview**
> Updates the `performance-regression.yml` workflow so the smoke and load performance jobs use `pgvector/pgvector:pg17` instead of `postgres:17`, ensuring migrations that require the `vector` extension succeed.
> 
> Adds a short session note documenting this bounded *SIZE-CI-PERF-PGVECTOR* change and its intent (pgvector availability while keeping PostgreSQL 17).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053b3661ae9151534e172d21c61cd68e02a430cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Make performance tests use a PostgreSQL image that supports vector columns

### What Changed
- Smoke and load performance tests now start PostgreSQL with pgvector support, so migrations can create the required `vector` extension
- This keeps the database on PostgreSQL 17 while matching the test setup used elsewhere in the repo
- The session notes were updated to explain the performance lane change and why it was made

### Impact
`✅ Fewer performance test migration failures`
`✅ Clearer CI database setup`
`✅ Same PostgreSQL version with vector support`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=tq03wbTtSRMplup7O1LKk8y-jnMJmJLaAFgWyC7c0MQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
