### PR TITLE
db: widen Alembic version column for long revision

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, master]
     paths:
       - 'backend/**'
+      - 'alembic/**'
       - 'src/**'
       - 'tests/load/**'
       - '.github/workflows/performance-regression.yml'
@@ -15,6 +16,7 @@ on:
     branches: [main, master]
     paths:
       - 'backend/**'
+      - 'alembic/**'
       - 'src/**'
 
   # Allow manual trigger

--- a/alembic/versions/030_enhance_item_specs_blockchain.py
+++ b/alembic/versions/030_enhance_item_specs_blockchain.py
@@ -22,6 +22,14 @@ depends_on = None
 
 def upgrade() -> None:
     """Add blockchain/NFT-like fields to all spec tables."""
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(32),
+        type_=sa.String(128),
+        existing_nullable=False,
+    )
+
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -82,6 +82,18 @@ repo cleanup.
 - **Excluded:** backend migration redesign, making pgvector optional, k6 scenario
   behavior, and unrelated smoke/load runtime failures after migrations succeed.
 
+## SIZE-CI-ALEMBIC-VERSION-WIDTH: Migration Revision Width
+
+- **Scope:** Alembic revision table compatibility for existing long revision IDs.
+- **Reason:** after the pgvector image fix, performance smoke migrations reached
+  revision `030_enhance_item_specs_blockchain` and failed because Alembic's
+  default `alembic_version.version_num VARCHAR(32)` cannot store that 35-character
+  revision ID.
+- **Action:** widen `alembic_version.version_num` to `VARCHAR(128)` at the start
+  of revision 030 before Alembic updates the version table to that revision.
+- **Excluded:** renaming historical revision IDs, rebuilding the migration graph,
+  and fixing downstream migration/runtime failures after revision 030.
+
 ## Validation Targets
 
 ```bash

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -90,7 +90,9 @@ repo cleanup.
   default `alembic_version.version_num VARCHAR(32)` cannot store that 35-character
   revision ID.
 - **Action:** widen `alembic_version.version_num` to `VARCHAR(128)` at the start
-  of revision 030 before Alembic updates the version table to that revision.
+  of revision 030 before Alembic updates the version table to that revision, and
+  include `alembic/**` in the performance workflow path filters so migration
+  changes exercise the smoke path.
 - **Excluded:** renaming historical revision IDs, rebuilding the migration graph,
   and fixing downstream migration/runtime failures after revision 030.
 


### PR DESCRIPTION
## **User description**
## Summary
- widen `alembic_version.version_num` to `VARCHAR(128)` at the start of revision 030
- fix the CI migration failure exposed after the pgvector image lane
- record the bounded `SIZE-CI-ALEMBIC-VERSION-WIDTH` WBS item

## Evidence
- CI smoke migration failed on `UPDATE alembic_version SET version_num='030_enhance_item_specs_blockchain'` with `value too long for type character varying(32)`\n- revision `030_enhance_item_specs_blockchain` is 35 characters, longer than Alembic default `VARCHAR(32)`\n\n## Validation\n- `uv run python -m compileall -q alembic/versions/030_enhance_item_specs_blockchain.py`\n- `git diff --check`\n- full migration replay requires Docker/OrbStack, currently unavailable locally\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Touches database migration behavior by altering the `alembic_version` table, which could affect upgrade/downgrade paths if environments have unusual permissions or nonstandard schemas; changes are otherwise small and targeted.
> 
> **Overview**
> Prevents CI/production migration failures caused by long Alembic revision IDs by widening `alembic_version.version_num` from `VARCHAR(32)` to `VARCHAR(128)` at the start of revision `030_enhance_item_specs_blockchain`.
> 
> Updates the performance regression workflow path filters to include `alembic/**`, ensuring migration changes trigger the performance smoke/load pipeline, and documents the remediation decision in `docs/sessions/20260426-dependency-alert-remediation.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e693d60a08b14f656b29a58ded236deb6fe2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Keep long database revision IDs working in migrations and make migration changes trigger performance checks

### What Changed
- Widened the migration version field so the existing 35-character revision ID can be stored during upgrade runs
- Included Alembic migration files in the performance regression workflow so migration changes now run through the smoke path
- Documented the migration width issue and the fix in the remediation notes

### Impact
`✅ Fewer migration failures in CI`
`✅ Migration changes now run performance smoke checks`
`✅ Safer upgrades for long revision IDs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=v3CV7_q32IpHKMnvvqcF87tPkIfIB0jrqeb4MstIw24&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
