### PR TITLE
ci: build performance backend from module root

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Build Go backend
         run: |
           cd backend
-          go build -o api ./cmd/api
+          go build -o api .
 
       - name: Start backend services
         run: |
@@ -275,7 +275,7 @@ jobs:
       - name: Build and start services
         run: |
           cd backend
-          go build -o api ./cmd/api
+          go build -o api .
           ./api &
           echo $! > api.pid
           timeout 30 bash -c 'until curl -f http://localhost:8080/health; do sleep 1; done'

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -96,6 +96,16 @@ repo cleanup.
 - **Excluded:** renaming historical revision IDs, rebuilding the migration graph,
   and fixing downstream migration/runtime failures after revision 030.
 
+## SIZE-CI-PERF-BACKEND-ENTRYPOINT: Performance Backend Build Target
+
+- **Scope:** `performance-regression.yml` Go build target only.
+- **Reason:** after migrations completed, smoke failed at
+  `go build -o api ./cmd/api` because `backend/cmd/api` does not exist.
+- **Action:** build the backend module root with `go build -o api .`, matching
+  `backend/Taskfile.yml` and `backend/Dockerfile`.
+- **Excluded:** startup dependency services, preflight policy, k6 auth/data
+  behavior, and stale README command examples.
+
 ## Validation Targets
 
 ```bash


### PR DESCRIPTION
## **User description**
## Summary
- replace stale `go build -o api ./cmd/api` in smoke/load performance jobs
- build the backend module root with `go build -o api .`, matching the Taskfile and Dockerfile
- document the bounded backend-entrypoint CI lane

## Evidence
- `backend/cmd/api` does not exist
- `backend/Taskfile.yml` builds with `go build -o tracertm-backend .`
- `backend/Dockerfile` builds with `go build ... -o tracertm-backend .`

## Validation
- `actionlint -shellcheck= -ignore 'the runner of ".*" action is too old' -ignore 'input "webhook_url" is not defined' -ignore '"needs" section should not be empty' .github/workflows/performance-regression.yml`\n- `go -C backend build -o /tmp/tracertm-perf-ci .`\n- `git diff --check`\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: changes only the CI build command used by `performance-regression.yml` and adds documentation, with no production code or runtime behavior modifications.
> 
> **Overview**
> Updates `performance-regression.yml` to build the Go backend from the `backend` module root (`go build -o api .`) for both smoke and load jobs, replacing the stale `./cmd/api` target.
> 
> Adds a short session note documenting this *performance backend entrypoint* CI fix and its intentionally limited scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8894ca4eaec957fd2d0e0e0e7d2856ab34b10f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix the performance CI backend build so smoke and load jobs can start the API**

### What Changed
- Performance smoke and load jobs now build the backend from the module root, so the API binary is created from the correct entry point and the jobs can start successfully.
- Added a session note explaining the CI fix and its limited scope.

### Impact
`✅ Fewer performance CI startup failures`
`✅ Successful smoke and load test setup`
`✅ Clearer documentation for the CI backend build change`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=kp8X8k9wT487fKcIZ12lngejsoHjIVyzPPhv9TzhjUM&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
