### PR TITLE
ci: provision performance runtime services

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -178,6 +178,8 @@ jobs:
           echo $! > s3-placeholder.pid
           python -m http.server 7233 >/tmp/tracertm-temporal-placeholder.log 2>&1 &
           echo $! > temporal-placeholder.pid
+          timeout 15 bash -c 'until curl -fsS http://127.0.0.1:9000 >/dev/null; do sleep 1; done'
+          timeout 15 bash -c 'until curl -fsS http://127.0.0.1:7233 >/dev/null; do sleep 1; done'
 
           # Start Go API in background
           cd backend
@@ -193,11 +195,11 @@ jobs:
           NEO4J_URI: neo4j://localhost:7687
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: testpassword
-          S3_ENDPOINT: http://localhost:9000
+          S3_ENDPOINT: http://127.0.0.1:9000
           S3_ACCESS_KEY_ID: minioadmin
           S3_SECRET_ACCESS_KEY: minioadmin
           S3_BUCKET: tracertm-performance
-          TEMPORAL_HOST: localhost:7233
+          TEMPORAL_HOST: 127.0.0.1:7233
           TEMPORAL_NAMESPACE: default
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance
@@ -337,6 +339,8 @@ jobs:
           echo $! > s3-placeholder.pid
           python -m http.server 7233 >/tmp/tracertm-temporal-placeholder.log 2>&1 &
           echo $! > temporal-placeholder.pid
+          timeout 15 bash -c 'until curl -fsS http://127.0.0.1:9000 >/dev/null; do sleep 1; done'
+          timeout 15 bash -c 'until curl -fsS http://127.0.0.1:7233 >/dev/null; do sleep 1; done'
 
           cd backend
           go build -o api .
@@ -350,11 +354,11 @@ jobs:
           NEO4J_URI: neo4j://localhost:7687
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: testpassword
-          S3_ENDPOINT: http://localhost:9000
+          S3_ENDPOINT: http://127.0.0.1:9000
           S3_ACCESS_KEY_ID: minioadmin
           S3_SECRET_ACCESS_KEY: minioadmin
           S3_BUCKET: tracertm-performance
-          TEMPORAL_HOST: localhost:7233
+          TEMPORAL_HOST: 127.0.0.1:7233
           TEMPORAL_NAMESPACE: default
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -114,6 +114,25 @@ jobs:
         ports:
           - 6379:6379
 
+      nats:
+        image: nats:2.10-alpine
+        ports:
+          - 4222:4222
+
+      neo4j:
+        image: neo4j:5-community
+        env:
+          NEO4J_AUTH: neo4j/testpassword
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+        options: >-
+          --health-cmd "cypher-shell -u neo4j -p testpassword 'RETURN 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 18
+        ports:
+          - 7474:7474
+          - 7687:7687
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -155,16 +174,35 @@ jobs:
 
       - name: Start backend services
         run: |
+          python -m http.server 9000 >/tmp/tracertm-s3-placeholder.log 2>&1 &
+          echo $! > s3-placeholder.pid
+          python -m http.server 7233 >/tmp/tracertm-temporal-placeholder.log 2>&1 &
+          echo $! > temporal-placeholder.pid
+
           # Start Go API in background
           cd backend
           ./api &
           echo $! > api.pid
 
           # Wait for API to be ready
-          timeout 30 bash -c 'until curl -f http://localhost:8080/health; do sleep 1; done'
+          timeout 90 bash -c 'until curl -f http://localhost:8080/health; do sleep 1; done'
         env:
           DATABASE_URL: postgresql://tracertm:testpass@localhost:5432/tracertm
           REDIS_URL: redis://localhost:6379
+          NATS_URL: nats://localhost:4222
+          NEO4J_URI: neo4j://localhost:7687
+          NEO4J_USER: neo4j
+          NEO4J_PASSWORD: testpassword
+          S3_ENDPOINT: http://localhost:9000
+          S3_ACCESS_KEY_ID: minioadmin
+          S3_SECRET_ACCESS_KEY: minioadmin
+          S3_BUCKET: tracertm-performance
+          TEMPORAL_HOST: localhost:7233
+          TEMPORAL_NAMESPACE: default
+          WORKOS_CLIENT_ID: client_ci_performance
+          WORKOS_API_KEY: sk_test_ci_performance
+          WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
+          TRACING_ENABLED: "false"
 
       - name: Run smoke test
         run: |
@@ -204,6 +242,8 @@ jobs:
           if [ -f backend/api.pid ]; then
             kill $(cat backend/api.pid) || true
           fi
+          [ -f s3-placeholder.pid ] && kill $(cat s3-placeholder.pid) || true
+          [ -f temporal-placeholder.pid ] && kill $(cat temporal-placeholder.pid) || true
 
   # =============================================================================
   # Load Test (Standard Performance Validation)
@@ -241,6 +281,25 @@ jobs:
         ports:
           - 6379:6379
 
+      nats:
+        image: nats:2.10-alpine
+        ports:
+          - 4222:4222
+
+      neo4j:
+        image: neo4j:5-community
+        env:
+          NEO4J_AUTH: neo4j/testpassword
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+        options: >-
+          --health-cmd "cypher-shell -u neo4j -p testpassword 'RETURN 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 18
+        ports:
+          - 7474:7474
+          - 7687:7687
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -274,14 +333,33 @@ jobs:
 
       - name: Build and start services
         run: |
+          python -m http.server 9000 >/tmp/tracertm-s3-placeholder.log 2>&1 &
+          echo $! > s3-placeholder.pid
+          python -m http.server 7233 >/tmp/tracertm-temporal-placeholder.log 2>&1 &
+          echo $! > temporal-placeholder.pid
+
           cd backend
           go build -o api .
           ./api &
           echo $! > api.pid
-          timeout 30 bash -c 'until curl -f http://localhost:8080/health; do sleep 1; done'
+          timeout 90 bash -c 'until curl -f http://localhost:8080/health; do sleep 1; done'
         env:
           DATABASE_URL: postgresql://tracertm:testpass@localhost:5432/tracertm
           REDIS_URL: redis://localhost:6379
+          NATS_URL: nats://localhost:4222
+          NEO4J_URI: neo4j://localhost:7687
+          NEO4J_USER: neo4j
+          NEO4J_PASSWORD: testpassword
+          S3_ENDPOINT: http://localhost:9000
+          S3_ACCESS_KEY_ID: minioadmin
+          S3_SECRET_ACCESS_KEY: minioadmin
+          S3_BUCKET: tracertm-performance
+          TEMPORAL_HOST: localhost:7233
+          TEMPORAL_NAMESPACE: default
+          WORKOS_CLIENT_ID: client_ci_performance
+          WORKOS_API_KEY: sk_test_ci_performance
+          WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
+          TRACING_ENABLED: "false"
 
       - name: Run load test
         run: |
@@ -319,6 +397,8 @@ jobs:
         if: always()
         run: |
           [ -f backend/api.pid ] && kill $(cat backend/api.pid) || true
+          [ -f s3-placeholder.pid ] && kill $(cat s3-placeholder.pid) || true
+          [ -f temporal-placeholder.pid ] && kill $(cat temporal-placeholder.pid) || true
 
   # =============================================================================
   # Performance Report

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -199,7 +199,7 @@ jobs:
           S3_ACCESS_KEY_ID: minioadmin
           S3_SECRET_ACCESS_KEY: minioadmin
           S3_BUCKET: tracertm-performance
-          TEMPORAL_HOST: 127.0.0.1:7233
+          TEMPORAL_HOST: tcp://127.0.0.1:7233
           TEMPORAL_NAMESPACE: default
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance
@@ -358,7 +358,7 @@ jobs:
           S3_ACCESS_KEY_ID: minioadmin
           S3_SECRET_ACCESS_KEY: minioadmin
           S3_BUCKET: tracertm-performance
-          TEMPORAL_HOST: 127.0.0.1:7233
+          TEMPORAL_HOST: tcp://127.0.0.1:7233
           TEMPORAL_NAMESPACE: default
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -117,7 +117,9 @@ repo cleanup.
 - **Action:** add NATS and Neo4j service containers, provide CI-safe WorkOS/S3/
   Temporal environment values, disable tracing, and use lightweight local TCP
   listeners for S3 and Temporal because current startup only preflights those
-  endpoints and does not initialize real S3 or Temporal clients.
+  endpoints and does not initialize real S3 or Temporal clients. Bind those
+  placeholders through `127.0.0.1` and wait for them before launching the API so
+  Go preflight does not race Python startup or resolve `localhost` to IPv6.
 - **Excluded:** changing backend preflight policy, adding real MinIO/Temporal
   stacks, auth-seeding k6 scenarios, frontend performance, and broader runtime
   compose consolidation.

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -119,7 +119,8 @@ repo cleanup.
   listeners for S3 and Temporal because current startup only preflights those
   endpoints and does not initialize real S3 or Temporal clients. Bind those
   placeholders through `127.0.0.1` and wait for them before launching the API so
-  Go preflight does not race Python startup or resolve `localhost` to IPv6.
+  Go preflight does not race Python startup or resolve `localhost` to IPv6; keep
+  Temporal in URL form (`tcp://127.0.0.1:7233`) so Go URL parsing accepts it.
 - **Excluded:** changing backend preflight policy, adding real MinIO/Temporal
   stacks, auth-seeding k6 scenarios, frontend performance, and broader runtime
   compose consolidation.

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -106,6 +106,22 @@ repo cleanup.
 - **Excluded:** startup dependency services, preflight policy, k6 auth/data
   behavior, and stale README command examples.
 
+## SIZE-CI-PERF-RUNTIME-SERVICES: Performance Backend Startup Dependencies
+
+- **Scope:** `performance-regression.yml` smoke/load backend startup services
+  and CI-only preflight environment.
+- **Reason:** after the backend entrypoint fix, smoke built the Go backend and
+  then failed during startup preflight because CI only provided Postgres and
+  Redis while the backend requires NATS, Neo4j, S3 endpoint/env, Temporal
+  host/env, WorkOS env, and disabled tracing when no collector is present.
+- **Action:** add NATS and Neo4j service containers, provide CI-safe WorkOS/S3/
+  Temporal environment values, disable tracing, and use lightweight local TCP
+  listeners for S3 and Temporal because current startup only preflights those
+  endpoints and does not initialize real S3 or Temporal clients.
+- **Excluded:** changing backend preflight policy, adding real MinIO/Temporal
+  stacks, auth-seeding k6 scenarios, frontend performance, and broader runtime
+  compose consolidation.
+
 ## Validation Targets
 
 ```bash


### PR DESCRIPTION
## **User description**
## Summary
- add NATS and Neo4j services to the performance smoke/load jobs
- provide CI-safe backend preflight env for S3, Temporal, WorkOS, and disabled tracing
- start lightweight local TCP placeholders for S3 and Temporal preflight-only endpoints
- document the bounded SIZE-CI-PERF-RUNTIME-SERVICES lane

## Validation
- actionlint .github/workflows/performance-regression.yml
- git diff --check
- go -C backend build -o /tmp/tracertm-perf-ci .

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI orchestration for performance jobs (new service containers, extra env vars, and startup timing), which could introduce new flakiness or longer runtimes, but does not affect production code paths.
> 
> **Overview**
> Updates `performance-regression.yml` so the smoke/load performance jobs can start the backend with its required runtime dependencies.
> 
> Adds NATS and Neo4j service containers, injects CI-safe preflight environment for NATS/Neo4j/S3/Temporal/WorkOS and disables tracing, and starts/tears down lightweight local placeholder listeners for S3 and Temporal endpoints; also increases the API healthcheck wait to 90s.
> 
> Documents this bounded CI lane in `docs/sessions/20260426-dependency-alert-remediation.md` under `SIZE-CI-PERF-RUNTIME-SERVICES`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023b632f5530963e34034ef8fa7d3500ebc57151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Run performance smoke and load checks with the services they need**

### What Changed
- Performance smoke and load jobs now start NATS and Neo4j, so the backend can pass startup checks in CI.
- The jobs now provide CI-safe values for S3, Temporal, WorkOS, and tracing, instead of failing on missing runtime settings.
- Temporary local placeholders are started for S3 and Temporal and waited on before the API launches, which avoids startup races.
- The API health wait was extended, and the service cleanup now stops the placeholder processes too.

### Impact
`✅ Fewer performance job startup failures`
`✅ More reliable smoke and load runs in CI`
`✅ Less waiting on backend health checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=3PqIjSmz3JcXJxSI7UrK9kNGMbxWIhgZIjbOQ_rqLaI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
