### PR TITLE
db: avoid notification automigrate policy conflict

### DIFF
--- a/alembic/versions/060_add_notification_expiration.py
+++ b/alembic/versions/060_add_notification_expiration.py
@@ -1,0 +1,32 @@
+"""Add notification expiration timestamp.
+
+Revision ID: 060_add_notification_expiration
+Revises: 311d43aa5450
+Create Date: 2026-04-26
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "060_add_notification_expiration"
+down_revision = "311d43aa5450"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the expiration timestamp used by the Go notification service."""
+    op.execute("""
+        ALTER TABLE notifications
+        ADD COLUMN IF NOT EXISTS expires_at TIMESTAMP WITH TIME ZONE
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_notifications_expires_at
+        ON notifications(expires_at)
+    """)
+
+
+def downgrade() -> None:
+    """Remove the notification expiration timestamp."""
+    op.execute("DROP INDEX IF EXISTS idx_notifications_expires_at")
+    op.execute("ALTER TABLE notifications DROP COLUMN IF EXISTS expires_at")

--- a/backend/internal/infrastructure/infrastructure.go
+++ b/backend/internal/infrastructure/infrastructure.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kooshapari/tracertm-backend/internal/cliproxy"
 	"github.com/kooshapari/tracertm-backend/internal/config"
 	"github.com/kooshapari/tracertm-backend/internal/graph"
-	"github.com/kooshapari/tracertm-backend/internal/models"
 	"github.com/kooshapari/tracertm-backend/internal/nats"
 	"github.com/kooshapari/tracertm-backend/internal/repository"
 	"github.com/kooshapari/tracertm-backend/internal/tracing"
@@ -172,69 +171,11 @@ func initGorm(databaseURL string) (*gorm.DB, error) {
 }
 
 func migrateAuthProfiles(gormDB *gorm.DB) error {
-	// One-time migration: old schema had workos_id NOT NULL; GORM model uses workos_user_id only.
-	// Try RENAME; if workos_user_id already exists (both columns), DROP workos_id instead.
-	// To run manually: psql $DATABASE_URL -f migrations/20260131_profiles_workos_id.sql
-	_ = gormDB.Exec(`DO $$ BEGIN
-		IF EXISTS (SELECT 1 FROM information_schema.columns
-			WHERE table_schema = 'public' AND table_name = 'profiles' AND column_name = 'workos_id') THEN
-			BEGIN
-				ALTER TABLE public.profiles RENAME COLUMN workos_id TO workos_user_id;
-			EXCEPTION
-				WHEN duplicate_column THEN
-					ALTER TABLE public.profiles DROP COLUMN workos_id;
-				WHEN undefined_column THEN
-					NULL;
-			END;
-		END IF;
-	END $$`).Error
-
-	// Migrate auth profile table (WorkOS profiles); schema owned by GORM, not Alembic.
-	// GORM may try to DROP constraint uni_profiles_email (without IF EXISTS).
-	// Ensure it exists in both schemas so DROP succeeds regardless of search_path.
-	// Only ADD if missing to avoid PostgreSQL "relation already exists" (which GORM logs even when EXCEPTION swallows it).
-	for _, schema := range []string{"public", "tracertm"} {
-		_ = gormDB.Exec(fmt.Sprintf(`DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON t.oid = c.conrelid
-    JOIN pg_namespace n ON n.oid = t.relnamespace
-    WHERE n.nspname = '%s' AND t.relname = 'profiles' AND c.conname = 'uni_profiles_email'
-  ) THEN
-    ALTER TABLE %s.profiles ADD CONSTRAINT uni_profiles_email UNIQUE (email);
-  END IF;
-EXCEPTION
-  WHEN undefined_table THEN NULL;
-END $$`, schema, schema)).Error
-	}
-	if err := gormDB.AutoMigrate(&models.Profile{}); err != nil {
-		return fmt.Errorf("failed to auto-migrate profiles: %w", err)
-	}
-	for _, schema := range []string{"public", "tracertm"} {
-		_ = gormDB.Exec("ALTER TABLE " + schema + ".profiles DROP CONSTRAINT IF EXISTS uni_profiles_email").Error
-	}
-	return nil
+	return migrateAuthProfilesSchema(gormDB)
 }
 
 func migrateNotifications(gormDB *gorm.DB) error {
-	// Migrate notifications table (for SSE notifications)
-	// Import services package to access Notification model
-	type Notification struct {
-		ID        string `gorm:"primaryKey"`
-		UserID    string `gorm:"index"`
-		Type      string
-		Title     string
-		Message   string
-		Link      *string
-		ReadAt    *time.Time
-		CreatedAt time.Time  `gorm:"index"`
-		ExpiresAt *time.Time `gorm:"index"`
-	}
-	if err := gormDB.AutoMigrate(&Notification{}); err != nil {
-		return fmt.Errorf("failed to auto-migrate notifications: %w", err)
-	}
-	return nil
+	return migrateNotificationsSchema(gormDB)
 }
 
 func initRepositories(infra *Infrastructure, gormDB *gorm.DB) {

--- a/backend/internal/infrastructure/notifications_schema.go
+++ b/backend/internal/infrastructure/notifications_schema.go
@@ -1,0 +1,49 @@
+// Package infrastructure wires infrastructure dependencies.
+package infrastructure
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type notificationSchema struct {
+	ID        string     `gorm:"primaryKey;type:varchar(36)"`
+	UserID    string     `gorm:"type:varchar(255);not null;index"`
+	Type      string     `gorm:"type:varchar(50);not null;default:info"`
+	Title     string     `gorm:"type:varchar(255);not null"`
+	Message   string     `gorm:"type:text;not null"`
+	Link      *string    `gorm:"type:varchar(500)"`
+	ReadAt    *time.Time `gorm:"type:timestamptz"`
+	CreatedAt time.Time  `gorm:"type:timestamptz;not null;default:now();index"`
+	UpdatedAt time.Time  `gorm:"type:timestamptz;not null;default:now()"`
+	ExpiresAt *time.Time `gorm:"type:timestamptz;index"`
+}
+
+func (notificationSchema) TableName() string {
+	return "notifications"
+}
+
+func migrateNotificationsSchema(gormDB *gorm.DB) error {
+	if !gormDB.Migrator().HasTable(&notificationSchema{}) {
+		if err := gormDB.AutoMigrate(&notificationSchema{}); err != nil {
+			return fmt.Errorf("failed to create notifications schema: %w", err)
+		}
+		return nil
+	}
+
+	if !gormDB.Migrator().HasColumn(&notificationSchema{}, "expires_at") {
+		if err := gormDB.Exec(
+			"ALTER TABLE notifications ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ",
+		).Error; err != nil {
+			return fmt.Errorf("failed to add notifications.expires_at: %w", err)
+		}
+	}
+	if err := gormDB.Exec(
+		"CREATE INDEX IF NOT EXISTS idx_notifications_expires_at ON notifications(expires_at)",
+	).Error; err != nil {
+		return fmt.Errorf("failed to index notifications.expires_at: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/infrastructure/profiles_schema.go
+++ b/backend/internal/infrastructure/profiles_schema.go
@@ -1,0 +1,52 @@
+// Package infrastructure wires infrastructure dependencies.
+package infrastructure
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/kooshapari/tracertm-backend/internal/models"
+)
+
+func migrateAuthProfilesSchema(gormDB *gorm.DB) error {
+	// One-time migration: old schema had workos_id NOT NULL; GORM model uses workos_user_id only.
+	// Try RENAME; if workos_user_id already exists (both columns), DROP workos_id instead.
+	// To run manually: psql $DATABASE_URL -f migrations/20260131_profiles_workos_id.sql
+	_ = gormDB.Exec(`DO $$ BEGIN
+		IF EXISTS (SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'public' AND table_name = 'profiles' AND column_name = 'workos_id') THEN
+			BEGIN
+				ALTER TABLE public.profiles RENAME COLUMN workos_id TO workos_user_id;
+			EXCEPTION
+				WHEN duplicate_column THEN
+					ALTER TABLE public.profiles DROP COLUMN workos_id;
+				WHEN undefined_column THEN
+					NULL;
+			END;
+		END IF;
+	END $$`).Error
+
+	for _, schema := range []string{"public", "tracertm"} {
+		_ = gormDB.Exec(fmt.Sprintf(`DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = '%s' AND t.relname = 'profiles' AND c.conname = 'uni_profiles_email'
+  ) THEN
+    ALTER TABLE %s.profiles ADD CONSTRAINT uni_profiles_email UNIQUE (email);
+  END IF;
+EXCEPTION
+  WHEN undefined_table THEN NULL;
+END $$`, schema, schema)).Error
+	}
+	if err := gormDB.AutoMigrate(&models.Profile{}); err != nil {
+		return fmt.Errorf("failed to auto-migrate profiles: %w", err)
+	}
+	for _, schema := range []string{"public", "tracertm"} {
+		_ = gormDB.Exec("ALTER TABLE " + schema + ".profiles DROP CONSTRAINT IF EXISTS uni_profiles_email").Error
+	}
+	return nil
+}

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -32,15 +32,15 @@ const (
 
 // Notification represents a user notification
 type Notification struct {
-	ID        string           `json:"id" gorm:"primaryKey"`
-	UserID    string           `json:"user_id" gorm:"index"`
-	Type      NotificationType `json:"type"`
-	Title     string           `json:"title"`
-	Message   string           `json:"message"`
-	Link      *string          `json:"link,omitempty"`
-	ReadAt    *time.Time       `json:"read_at,omitempty"`
-	CreatedAt time.Time        `json:"created_at" gorm:"index"`
-	ExpiresAt *time.Time       `json:"expires_at,omitempty" gorm:"index"`
+	ID        string           `json:"id" gorm:"primaryKey;type:varchar(36)"`
+	UserID    string           `json:"user_id" gorm:"type:varchar(255);not null;index"`
+	Type      NotificationType `json:"type" gorm:"type:varchar(50);not null;default:info"`
+	Title     string           `json:"title" gorm:"type:varchar(255);not null"`
+	Message   string           `json:"message" gorm:"type:text;not null"`
+	Link      *string          `json:"link,omitempty" gorm:"type:varchar(500)"`
+	ReadAt    *time.Time       `json:"read_at,omitempty" gorm:"type:timestamptz"`
+	CreatedAt time.Time        `json:"created_at" gorm:"type:timestamptz;not null;default:now();index"`
+	ExpiresAt *time.Time       `json:"expires_at,omitempty" gorm:"type:timestamptz;index"`
 }
 
 // NotificationEvent represents a notification event for broadcasting

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -125,6 +125,22 @@ repo cleanup.
   stacks, auth-seeding k6 scenarios, frontend performance, and broader runtime
   compose consolidation.
 
+## SIZE-CI-NOTIFICATIONS-RLS-MIGRATION: Notification Startup Schema Ownership
+
+- **Scope:** Go backend notification startup schema checks and the Alembic
+  notification expiration column.
+- **Reason:** after the runtime service lane, performance smoke reached backend
+  infrastructure initialization and failed because GORM tried to alter
+  `notifications.user_id` from Alembic's `VARCHAR(255)` to `TEXT` while RLS
+  policies depended on that column.
+- **Action:** stop broad GORM `AutoMigrate` against an existing Alembic-owned
+  `notifications` table, align Go notification GORM tags with Alembic types,
+  add only the missing `expires_at` column/index additively, and add Alembic
+  revision `060_add_notification_expiration` as the canonical schema owner for
+  that column.
+- **Excluded:** dropping/recreating RLS policies, changing notification policy
+  semantics, broad GORM/Alembic ownership redesign, and k6 auth/data seeding.
+
 ## Validation Targets
 
 ```bash


### PR DESCRIPTION
## **User description**
## Summary
- stop broad GORM AutoMigrate from mutating existing Alembic-owned notifications tables
- align Go notification GORM tags with the Alembic notification schema
- add additive Alembic revision 060 for notifications.expires_at and its index
- split profile/notification schema startup helpers out of the oversized infrastructure file

## Validation
- go test ./internal/infrastructure ./internal/services
- uv run python -m compileall -q alembic/versions/060_add_notification_expiration.py
- uv run alembic heads
- git diff --check

Note: `uv run alembic upgrade head --sql` is blocked by pre-existing offline rendering behavior in `006_add_priority_owner_to_items.py`, which calls SQLAlchemy inspection on Alembic's mock offline connection.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Touches database migration/startup schema code for `notifications`, so mistakes could break bootstrapping or RLS-dependent columns; changes are mostly additive and type-alignment to reduce that risk.
> 
> **Overview**
> Adds Alembic revision `060_add_notification_expiration` to *additively* introduce `notifications.expires_at` plus an index.
> 
> Refactors Go startup DB migration logic to avoid broad `AutoMigrate` against an existing Alembic-owned `notifications` table: new `migrateNotificationsSchema` only creates the table when missing, otherwise it only adds `expires_at`/index if absent.
> 
> Aligns the Go `Notification` GORM tags (and the new `notificationSchema` struct) with explicit column types/defaults to prevent unintended type changes (e.g., `user_id`) that can conflict with RLS policies, and splits the profile/notification schema helpers out of `infrastructure.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de96b690353a9154d88d92c46c9179e994bffeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep notification startup migrations aligned with the existing database schema**

### What Changed
- Notification startup no longer tries to remap the whole notifications table, which avoids schema changes that can break existing access rules.
- Notification fields now use the same column shapes as the database, reducing the chance of startup conflicts or unwanted column changes.
- The new expiration timestamp for notifications is added through a dedicated database migration, along with its index.
- Profile schema setup is split into a separate startup helper, making the initialization flow clearer.

### Impact
`✅ Fewer notification startup failures`
`✅ Safer schema updates for existing installs`
`✅ Clearer notification expiration lookups`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=vMXhmzvNfHa2AoJL_9cREDaLtpYz5RaWN918rVS0aac&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
