### PR TITLE
db: add agent task alembic migration

### DIFF
--- a/alembic/versions/061_add_agent_tasks.py
+++ b/alembic/versions/061_add_agent_tasks.py
@@ -1,0 +1,45 @@
+"""Add agent task persistence table.
+
+Revision ID: 061_add_agent_tasks
+Revises: 060_add_notification_expiration
+Create Date: 2026-04-26
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "061_add_agent_tasks"
+down_revision = "060_add_notification_expiration"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the durable task queue table used by the Go agent runtime."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS agent_tasks (
+            id VARCHAR(255) PRIMARY KEY,
+            project_id VARCHAR(255) NOT NULL,
+            status VARCHAR(50) NOT NULL DEFAULT 'pending',
+            priority INTEGER NOT NULL DEFAULT 1,
+            data JSONB NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agent_tasks_project_id ON agent_tasks(project_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agent_tasks_status ON agent_tasks(status)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_agent_tasks_priority ON agent_tasks(priority)")
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent_tasks_project_status
+        ON agent_tasks(project_id, status)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent_tasks_project_priority
+        ON agent_tasks(project_id, priority)
+    """)
+
+
+def downgrade() -> None:
+    """Drop the durable task queue table."""
+    op.execute("DROP TABLE IF EXISTS agent_tasks")

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -141,6 +141,19 @@ repo cleanup.
 - **Excluded:** dropping/recreating RLS policies, changing notification policy
   semantics, broad GORM/Alembic ownership redesign, and k6 auth/data seeding.
 
+## SIZE-CI-AGENT-TASKS-ALEMBIC: Agent Task Persistence Table
+
+- **Scope:** Alembic ownership for the Go agent task queue persistence table.
+- **Reason:** after the notification schema fix, performance smoke reached the
+  infrastructure health loop and failed because `VerifyTaskBackendPersistence`
+  inserts into `agent_tasks`, but the CI pre-start Alembic migration path did
+  not create that table.
+- **Action:** add Alembic revision `061_add_agent_tasks` mirroring the existing
+  backend raw SQL migration for `agent_tasks` and its indexes so CI databases
+  created by Alembic match the Go runtime's durable task queue expectations.
+- **Excluded:** fixing older internal DB migration warnings, changing health
+  check semantics, redesigning the task queue, and k6 scenario behavior.
+
 ## Validation Targets
 
 ```bash


### PR DESCRIPTION
## **User description**
## Summary
- add Alembic revision 061 for the `agent_tasks` table used by the Go agent runtime
- mirror the existing backend raw SQL schema and indexes in the CI Alembic path
- document the bounded SIZE-CI-AGENT-TASKS-ALEMBIC lane

## Validation
- uv run python -m compileall -q alembic/versions/061_add_agent_tasks.py
- uv run alembic heads
- go test ./internal/agents ./internal/infrastructure
- git diff --check

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new database table and indexes via Alembic, which impacts schema/migrations and could affect deployments if the table definition diverges from runtime expectations. Changes are otherwise additive and localized.
> 
> **Overview**
> Adds Alembic revision `061_add_agent_tasks` to create the `agent_tasks` durable task queue table (with status/priority/data columns) and supporting indexes so CI databases migrated via Alembic match the Go agent runtime’s persistence expectations.
> 
> Updates the dependency remediation session doc to record the new bounded lane (*SIZE-CI-AGENT-TASKS-ALEMBIC*) and its rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b930edbb3913472a16b8b0704e0a63e4b28676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Create the agent task table in the CI Alembic migration path**

### What Changed
- Adds a database migration that creates the `agent_tasks` table used by the Go agent runtime
- Creates the same indexes needed for looking up tasks by project, status, and priority
- Removes the table if the migration is rolled back
- Documents the CI lane fix for the missing agent task persistence table

### Impact
`✅ Fewer CI failures in agent task checks`
`✅ Reliable agent task persistence in pre-start databases`
`✅ Clearer alignment between CI databases and runtime expectations`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=4ZBryXsidJOHIEIXKFzyMqYtMNhpuSIvib971jSGZVo&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
