### PR TITLE
fix(db): surface profile constraint migration errors

### DIFF
--- a/backend/internal/infrastructure/profiles_schema.go
+++ b/backend/internal/infrastructure/profiles_schema.go
@@ -28,7 +28,7 @@ func migrateAuthProfilesSchema(gormDB *gorm.DB) error {
 	END $$`).Error
 
 	for _, schema := range []string{"public", "tracertm"} {
-		_ = gormDB.Exec(fmt.Sprintf(`DO $$
+		if err := gormDB.Exec(fmt.Sprintf(`DO $$
 BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_constraint c
@@ -40,7 +40,9 @@ BEGIN
   END IF;
 EXCEPTION
   WHEN undefined_table THEN NULL;
-END $$`, schema, schema)).Error
+END $$`, schema, schema)).Error; err != nil {
+			return fmt.Errorf("failed to prepare %s.profiles email uniqueness for automigrate: %w", schema, err)
+		}
 	}
 	if err := gormDB.AutoMigrate(&models.Profile{}); err != nil {
 		return fmt.Errorf("failed to auto-migrate profiles: %w", err)


### PR DESCRIPTION
## **User description**
## Summary
- handle errors while preparing the temporary `profiles.email` uniqueness constraint
- return schema-qualified context so startup fails loudly on duplicate profile emails instead of silently running `AutoMigrate` under false assumptions

Supersedes the unresolved review thread on #369; #369/#371 contain changes that are already on `main` except this one-file fix.

## Validation
- GitHub API one-file patch against current `main`

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens migration error handling around temporary `profiles.email` uniqueness constraints, which may now cause startup to fail in environments where the constraint creation previously errored silently. Risk is limited to schema migration/startup behavior (no runtime request-path logic changes).
> 
> **Overview**
> Ensures failures while creating the temporary `uni_profiles_email` uniqueness constraint (used to let `AutoMigrate` run safely) are no longer ignored.
> 
> During `migrateAuthProfilesSchema`, the constraint-setup `Exec` now returns a schema-qualified error (e.g., `public.profiles` vs `tracertm.profiles`) so duplicate/invalid data issues fail loudly instead of proceeding under false assumptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2d157af9ccbcc0246dbee7b4529eae72aa3de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Surface profile migration errors during startup**

### What Changed
- Startup now stops with a clear error if preparing the temporary email uniqueness check for profile tables fails
- The error message identifies which schema could not be prepared, instead of letting the migration continue with hidden failures
- The rest of the profile migration flow is unchanged

### Impact
`✅ Clearer startup failures for profile migrations`
`✅ Fewer silent schema migration problems`
`✅ Easier diagnosis of duplicate profile email issues`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=7mzekgMgfb-eMuBmsPY4e-S0f9aC11QVK1QTCPJfYBc&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
