### PR TITLE
ci: align k6 smoke auth with csrf route

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -204,6 +204,9 @@ jobs:
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
+          WORKOS_REDIRECT_URI: http://localhost:8080/api/v1/auth/authkit/callback
+          AUTHKIT_JWT_SECRET: ci-authkit-jwt-secret-at-least-32-bytes
+          CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
           TRACING_ENABLED: "false"
 
       - name: Run smoke test
@@ -214,6 +217,7 @@ jobs:
             tests/load/k6/scenarios/smoke.js
         env:
           BASE_URL: http://localhost:8080
+          K6_AUTH_MODE: csrf-only
 
       - name: Compare with baseline
         if: needs.setup.outputs.baseline_exists == 'true'
@@ -363,6 +367,9 @@ jobs:
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
+          WORKOS_REDIRECT_URI: http://localhost:8080/api/v1/auth/authkit/callback
+          AUTHKIT_JWT_SECRET: ci-authkit-jwt-secret-at-least-32-bytes
+          CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
           TRACING_ENABLED: "false"
 
       - name: Run load test
@@ -373,6 +380,7 @@ jobs:
             tests/load/k6/scenarios/load.js
         env:
           BASE_URL: http://localhost:8080
+          K6_AUTH_MODE: csrf-only
 
       - name: Compare with baseline
         if: needs.setup.outputs.baseline_exists == 'true'

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -154,6 +154,23 @@ repo cleanup.
 - **Excluded:** fixing older internal DB migration warnings, changing health
   check semantics, redesigning the task queue, and k6 scenario behavior.
 
+## SIZE-CI-K6-CSRF-SMOKE: Performance k6 Auth Harness Drift
+
+- **Scope:** k6 performance helper auth/session setup and smoke scenario
+  project fixture creation.
+- **Reason:** after the agent task table fix, performance smoke reached a live
+  backend, `/health` returned OK, and k6 failed because the helper still called
+  removed/stale auth endpoints (`/api/v1/auth/csrf`, `/api/v1/auth/login`).
+  The backend now exposes `/api/v1/csrf-token`, returns `{ "token": ... }`,
+  and removed password login in favor of AuthKit.
+- **Action:** add CI `csrf-only` k6 auth mode that prepares CSRF headers/cookie
+  without reintroducing password login, set required CI auth/CSRF environment
+  values in the performance workflow, guard smoke iterations when session
+  preparation fails, and create a real smoke project before item creation so
+  item CRUD uses a valid UUID project ID.
+- **Excluded:** re-adding password auth, mocking WorkOS in production code,
+  changing protected route policy, and broad load/stress data-model cleanup.
+
 ## Validation Targets
 
 ```bash

--- a/tests/load/k6/helpers/auth.js
+++ b/tests/load/k6/helpers/auth.js
@@ -12,6 +12,7 @@ import { SharedArray } from 'k6/data';
 // Base configuration
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:4000';
 const API_BASE_URL = `${BASE_URL}/api/v1`;
+const AUTH_MODE = __ENV.K6_AUTH_MODE || (__ENV.TEST_ENV === 'ci' ? 'csrf-only' : 'workos-password');
 
 // Load test users from environment or use default test users
 const TEST_USERS = new SharedArray('users', function () {
@@ -47,22 +48,24 @@ export function getTestUser() {
  * @returns {Object} - { token, sessionId, userId }
  */
 export function authenticate(user) {
+  if (AUTH_MODE === 'csrf-only') {
+    return getCsrfOnlySession();
+  }
+
   // Step 1: Get CSRF token
-  const csrfResponse = http.get(`${API_BASE_URL}/auth/csrf`, {
-    tags: { name: 'auth_get_csrf' },
-  });
+  const csrfResponse = getCsrfTokenResponse();
 
   const csrfCheck = check(csrfResponse, {
     'CSRF token retrieved': (r) => r.status === 200,
-    'CSRF token in response': (r) => r.json('csrf_token') !== undefined,
+    'CSRF token in response': (r) => r.json('token') !== undefined,
   });
 
   if (!csrfCheck) {
     fail('Failed to retrieve CSRF token');
   }
 
-  const csrfToken = csrfResponse.json('csrf_token');
-  const sessionCookie = csrfResponse.cookies['session'][0].value;
+  const csrfToken = csrfResponse.json('token');
+  const csrfCookie = extractCookie(csrfResponse, 'csrf_token');
 
   // Step 2: Authenticate with WorkOS (or mock auth endpoint)
   const authPayload = JSON.stringify({
@@ -77,7 +80,7 @@ export function authenticate(user) {
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-Token': csrfToken,
-        'Cookie': `session=${sessionCookie}`,
+        'Cookie': `csrf_token=${csrfCookie}`,
       },
       tags: { name: 'auth_login' },
     }
@@ -106,9 +109,47 @@ export function authenticate(user) {
 
   return {
     token: authToken,
-    sessionId: sessionCookie,
+    sessionId: csrfCookie,
     userId: authResponse.json('user_id') || authResponse.json('user.id'),
     csrfToken: csrfToken,
+    csrfCookie: csrfCookie,
+    mode: AUTH_MODE,
+  };
+}
+
+function getCsrfTokenResponse() {
+  return http.get(`${API_BASE_URL}/csrf-token`, {
+    tags: { name: 'auth_get_csrf' },
+  });
+}
+
+function extractCookie(response, name) {
+  const cookie = response.cookies[name];
+  return cookie && cookie.length > 0 ? cookie[0].value : undefined;
+}
+
+function getCsrfOnlySession() {
+  const csrfResponse = getCsrfTokenResponse();
+
+  const csrfCheck = check(csrfResponse, {
+    'CSRF token retrieved': (r) => r.status === 200,
+    'CSRF token in response': (r) => r.json('token') !== undefined,
+  });
+
+  if (!csrfCheck) {
+    fail('Failed to retrieve CSRF token');
+  }
+
+  const csrfToken = csrfResponse.json('token');
+  const csrfCookie = extractCookie(csrfResponse, 'csrf_token');
+
+  return {
+    token: undefined,
+    sessionId: undefined,
+    userId: 'ci-performance-user',
+    csrfToken: csrfToken,
+    csrfCookie: csrfCookie,
+    mode: AUTH_MODE,
   };
 }
 
@@ -124,15 +165,17 @@ export function getAuthHeaders(authData) {
     'Accept': 'application/json',
   };
 
-  if (authData.token) {
+  if (authData && authData.token) {
     headers['Authorization'] = `Bearer ${authData.token}`;
   }
 
-  if (authData.csrfToken) {
+  if (authData && authData.csrfToken) {
     headers['X-CSRF-Token'] = authData.csrfToken;
   }
 
-  if (authData.sessionId) {
+  if (authData && authData.csrfCookie) {
+    headers['Cookie'] = `csrf_token=${authData.csrfCookie}`;
+  } else if (authData && authData.sessionId) {
     headers['Cookie'] = `session=${authData.sessionId}`;
   }
 

--- a/tests/load/k6/scenarios/smoke.js
+++ b/tests/load/k6/scenarios/smoke.js
@@ -90,7 +90,7 @@ export default function (data) {
       authDuration.add(Date.now() - startAuth);
 
       check(authData, {
-        'Authentication successful': (d) => d.token !== undefined,
+        'Request session prepared': (d) => d.token !== undefined || d.csrfToken !== undefined,
       });
     } catch (error) {
       console.error(`Authentication failed: ${error}`);
@@ -98,6 +98,10 @@ export default function (data) {
       return; // Skip rest of test if auth fails
     }
   });
+
+  if (!authData || (!authData.token && !authData.csrfToken)) {
+    return;
+  }
 
   sleep(1);
 
@@ -140,9 +144,37 @@ export default function (data) {
   // Group: Items CRUD
   group('Items Operations', () => {
     const headers = getAuthHeaders(authData);
+    const projectResponse = http.post(
+      `${API_BASE_URL}/projects`,
+      JSON.stringify({
+        name: `Smoke Project ${__VU}-${__ITER}`,
+        description: 'CI smoke test project',
+        metadata: { source: 'k6-smoke' },
+      }),
+      {
+        headers,
+        tags: { name: 'create_project_for_item' },
+      }
+    );
+
+    requestCounter.add(1);
+    apiResponseTime.add(projectResponse.timings.duration);
+
+    const projectCheck = check(projectResponse, {
+      'Project created for item': (r) => r.status === 200 || r.status === 201,
+      'Project create response time OK': (r) => r.timings.duration < 500,
+    });
+
+    if (!projectCheck) {
+      errorRate.add(1);
+      return;
+    }
+
+    const createdProject = projectResponse.json();
+    const projectId = createdProject.id || createdProject.project_id;
 
     // Create a new item
-    const newItem = generateItem({ projectId: 1 });
+    const newItem = generateItem({ projectId: projectId, priority: 2 });
     const createResponse = http.post(
       `${API_BASE_URL}/items`,
       JSON.stringify(newItem),


### PR DESCRIPTION
## **User description**
## Summary
- add CI csrf-only k6 auth mode that uses `/api/v1/csrf-token` instead of removed password login endpoints
- provide CI auth/CSRF env needed by backend startup for smoke/load jobs
- make smoke create a real project before item CRUD so item creation uses a UUID project ID
- record the bounded lane in the dependency remediation WBS

## Validation
- `node --check tests/load/k6/helpers/auth.js`
- `node --check tests/load/k6/scenarios/smoke.js`
- `node --check tests/load/k6/scenarios/load.js`
- `k6 inspect tests/load/k6/scenarios/smoke.js`
- `k6 inspect tests/load/k6/scenarios/load.js`
- `go test ./internal/server ./internal/middleware ./internal/handlers`
- `actionlint -shellcheck= -ignore 'the runner of ".*" action is too old' -ignore 'input "webhook_url" is not defined' -ignore '"needs" section should not be empty' .github/workflows/performance-regression.yml`\n- `git diff --check`\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI performance workflow environment and k6 auth/session handling; mistakes could cause false CI failures or hide auth regressions, but it’s confined to test harness and workflow config.
> 
> **Overview**
> Aligns CI performance regression jobs with the updated backend auth surface by adding required AuthKit/CSRF environment variables and running k6 in a new `csrf-only` mode.
> 
> Updates the k6 auth helper to fetch CSRF data from `/api/v1/csrf-token`, propagate the correct `csrf_token` cookie/header, and tolerate missing bearer tokens when running in CI. The smoke scenario now aborts iterations when session prep fails and creates a real project to obtain a UUID `projectId` before item CRUD.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8fbe8364c1ebac2377ea9ce1670cfc159a6803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Align CI performance tests with the current CSRF-based login flow**

### What Changed
- CI smoke and load tests now use the current CSRF token route and a CSRF-only session path instead of removed password login endpoints.
- Smoke tests create a real project before item creation, so item CRUD uses a valid project ID instead of a hardcoded one.
- The performance workflow now provides the extra auth settings needed for the backend to start and for the k6 tests to authenticate successfully.

### Impact
`✅ Fewer CI auth failures`
`✅ More reliable smoke and load runs`
`✅ Fewer item-creation failures in smoke tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=23Ab9l1R-axWeIKFhSTt4nco36kiU0UZnNoQOQW7qjk&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
