### PR TITLE
chore: align Taskfile common tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,7 @@ version: "3"
 
 tasks:
   build:
-    desc: "Build detected project components"
+    desc: Build detected Python, frontend, and Go components
     cmds:
       - |
         set -eu
@@ -12,19 +12,19 @@ tasks:
         fi
 
         if [ -d frontend ] && [ -f frontend/package.json ]; then
-          (cd frontend && bun run build)
+          bun --cwd frontend run build
+        fi
+
+        if [ -f backend/go.mod ]; then
+          (cd backend && go build ./...)
         fi
 
         if [ -f go.mod ]; then
           go build ./...
         fi
 
-        if [ -f Cargo.toml ]; then
-          cargo build
-        fi
-
   test:
-    desc: "Run detected test suites"
+    desc: Run detected Python, frontend, and Go test suites
     cmds:
       - |
         set -eu
@@ -34,19 +34,19 @@ tasks:
         fi
 
         if [ -d frontend ] && [ -f frontend/package.json ]; then
-          (cd frontend && bun test)
+          bun --cwd frontend run test
+        fi
+
+        if [ -f backend/go.mod ]; then
+          (cd backend && go test ./...)
         fi
 
         if [ -f go.mod ]; then
           go test ./...
         fi
 
-        if [ -f Cargo.toml ]; then
-          cargo test
-        fi
-
   lint:
-    desc: "Run detected linters"
+    desc: Run detected Python, frontend, and Go linters
     cmds:
       - |
         set -eu
@@ -57,35 +57,50 @@ tasks:
         fi
 
         if [ -d frontend ] && [ -f frontend/package.json ]; then
-          (cd frontend && bun run lint)
+          bun --cwd frontend run lint
+        fi
+
+        if [ -f backend/go.mod ]; then
+          if command -v golangci-lint >/dev/null 2>&1; then
+            (cd backend && golangci-lint run)
+          else
+            (cd backend && go vet ./...)
+          fi
         fi
 
         if [ -f go.mod ]; then
-          golangci-lint run
-        fi
-
-        if [ -f Cargo.toml ]; then
-          cargo clippy --all-targets --all-features -- -D warnings
+          if command -v golangci-lint >/dev/null 2>&1; then
+            golangci-lint run
+          else
+            go vet ./...
+          fi
         fi
 
   clean:
-    desc: "Remove build artifacts for detected project components"
+    desc: Remove build artifacts for detected components
     cmds:
       - |
         set -eu
 
         if [ -f pyproject.toml ]; then
           rm -rf .pytest_cache .ruff_cache .mypy_cache .coverage htmlcov dist build
+          find . -type d -name __pycache__ -prune -exec rm -rf {} +
         fi
 
         if [ -d frontend ] && [ -f frontend/package.json ]; then
-          rm -rf frontend/node_modules frontend/.turbo frontend/dist
+          if grep -q '"clean"' frontend/package.json; then
+            bun --cwd frontend run clean
+          else
+            rm -rf frontend/node_modules frontend/.turbo frontend/dist
+          fi
+        fi
+
+        if [ -f backend/go.mod ]; then
+          (cd backend && go clean ./...)
+          rm -rf backend/bin backend/coverage.out
         fi
 
         if [ -f go.mod ]; then
+          go clean ./...
           rm -rf bin coverage.out
-        fi
-
-        if [ -f Cargo.toml ]; then
-          cargo clean
         fi


### PR DESCRIPTION
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Taskfile-only changes that adjust developer workflows (build/test/lint/clean) without affecting runtime code. Main risk is unexpected behavior in repos with different directory layouts or missing tooling (e.g., `golangci-lint`, frontend `clean` script).
> 
> **Overview**
> Updates `Taskfile.yml` to **standardize `build`, `test`, `lint`, and `clean`** across Python, frontend, and Go projects, including separate handling for a `backend/go.mod` module.
> 
> Frontend commands now use `bun --cwd frontend`, Go linting falls back to `go vet` when `golangci-lint` is unavailable, and cleaning is expanded to remove Python `__pycache__` directories and optionally run a frontend `clean` script when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d204f1c120e9a3a7860ea29ddfac9f3041a3cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->