### PR TITLE
chore: scope Taskfile module detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,7 +22,12 @@ tasks:
     cmds:
       - |
         set -eu
-        find . -name go.mod -not -path './vendor/*' -print | while IFS= read -r module; do
+        find . -name go.mod \
+          -not -path './vendor/*' \
+          -not -path './ARCHIVE/*' \
+          -not -path './.archive/*' \
+          -not -path './default/*' \
+          -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           (cd "$module_dir" && go build ./...)
         done
@@ -57,7 +62,12 @@ tasks:
     cmds:
       - |
         set -eu
-        find . -name go.mod -not -path './vendor/*' -print | while IFS= read -r module; do
+        find . -name go.mod \
+          -not -path './vendor/*' \
+          -not -path './ARCHIVE/*' \
+          -not -path './.archive/*' \
+          -not -path './default/*' \
+          -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           (cd "$module_dir" && go test ./...)
         done
@@ -93,7 +103,12 @@ tasks:
     cmds:
       - |
         set -eu
-        find . -name go.mod -not -path './vendor/*' -print | while IFS= read -r module; do
+        find . -name go.mod \
+          -not -path './vendor/*' \
+          -not -path './ARCHIVE/*' \
+          -not -path './.archive/*' \
+          -not -path './default/*' \
+          -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           unformatted="$(cd "$module_dir" && gofmt -l .)"
           if [ -n "$unformatted" ]; then
@@ -121,7 +136,12 @@ tasks:
         rm -rf .pytest_cache .ruff_cache .mypy_cache .coverage htmlcov dist build
         find . -type d -name __pycache__ -prune -exec rm -rf {} +
 
-        find . -name go.mod -not -path './vendor/*' -print | while IFS= read -r module; do
+        find . -name go.mod \
+          -not -path './vendor/*' \
+          -not -path './ARCHIVE/*' \
+          -not -path './.archive/*' \
+          -not -path './default/*' \
+          -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           (cd "$module_dir" && go clean -cache -testcache)
         done


### PR DESCRIPTION
## **User description**
Exclude archived dependency snapshots when detecting Go modules for build, test, lint, and clean tasks.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk change limited to task automation; it only adjusts `find` filters for Go module detection and could only affect which modules get built/tested/linted/cleaned.
> 
> **Overview**
> Scopes Go module detection in `Taskfile.yml` by excluding `ARCHIVE/`, `.archive/`, and `default/` (in addition to `vendor/`) from the `find . -name go.mod` queries.
> 
> This change applies consistently across `build:go`, `test:go`, `lint:go`, and `clean`, preventing archived snapshots/templates from being built, tested, linted, or cleaned as part of the automated tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc8f24feef93cba058c7b33a1126e6f90b581fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Skip archived Go modules during build, test, lint, and clean tasks**

### What Changed
- Go tasks now ignore modules inside `ARCHIVE/`, `.archive/`, and `default/`, in addition to `vendor/`
- Build, test, lint, and clean only run against active Go modules, so archived snapshots are no longer treated as part of routine project checks
- Cleaning no longer removes caches for archived module snapshots

### Impact
`✅ Fewer failures from archived Go code`
`✅ Faster build and test runs`
`✅ Cleaner maintenance of active modules`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=OTYFBQKcBsZRFuifCPws-lyzmNgWwRSj6eAjZIV-slI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
