### PR TITLE
chore: refine common Taskfile tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,8 +1,23 @@
 version: "3"
 
+vars:
+  GO_MODULE_FIND_ARGS: >-
+    -name go.mod
+    -not -path './.git/*'
+    -not -path './vendor/*'
+    -not -path './node_modules/*'
+    -not -path './ARCHIVE/*'
+    -not -path './.archive/*'
+    -not -path './default/*'
+
 tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+
   build:
-    desc: Build all detected project workspaces
+    desc: Build all detected Python, Go, and Bun workspaces
     deps:
       - build:python
       - build:go
@@ -22,12 +37,7 @@ tasks:
     cmds:
       - |
         set -eu
-        find . -name go.mod \
-          -not -path './vendor/*' \
-          -not -path './ARCHIVE/*' \
-          -not -path './.archive/*' \
-          -not -path './default/*' \
-          -print | while IFS= read -r module; do
+        find . {{.GO_MODULE_FIND_ARGS}} -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           (cd "$module_dir" && go build ./...)
         done
@@ -42,7 +52,7 @@ tasks:
         fi
 
   test:
-    desc: Run all detected test suites
+    desc: Run all detected Python, Go, and Bun test suites
     deps:
       - test:python
       - test:go
@@ -62,12 +72,7 @@ tasks:
     cmds:
       - |
         set -eu
-        find . -name go.mod \
-          -not -path './vendor/*' \
-          -not -path './ARCHIVE/*' \
-          -not -path './.archive/*' \
-          -not -path './default/*' \
-          -print | while IFS= read -r module; do
+        find . {{.GO_MODULE_FIND_ARGS}} -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           (cd "$module_dir" && go test ./...)
         done
@@ -82,7 +87,7 @@ tasks:
         fi
 
   lint:
-    desc: Run all detected lint and format checks
+    desc: Run all detected Python, Go, and Bun lint and format checks
     deps:
       - lint:python
       - lint:go
@@ -103,12 +108,7 @@ tasks:
     cmds:
       - |
         set -eu
-        find . -name go.mod \
-          -not -path './vendor/*' \
-          -not -path './ARCHIVE/*' \
-          -not -path './.archive/*' \
-          -not -path './default/*' \
-          -print | while IFS= read -r module; do
+        find . {{.GO_MODULE_FIND_ARGS}} -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           unformatted="$(cd "$module_dir" && gofmt -l .)"
           if [ -n "$unformatted" ]; then
@@ -136,12 +136,7 @@ tasks:
         rm -rf .pytest_cache .ruff_cache .mypy_cache .coverage htmlcov dist build
         find . -type d -name __pycache__ -prune -exec rm -rf {} +
 
-        find . -name go.mod \
-          -not -path './vendor/*' \
-          -not -path './ARCHIVE/*' \
-          -not -path './.archive/*' \
-          -not -path './default/*' \
-          -print | while IFS= read -r module; do
+        find . {{.GO_MODULE_FIND_ARGS}} -print | while IFS= read -r module; do
           module_dir="$(dirname "$module")"
           (cd "$module_dir" && go clean -cache -testcache)
         done


### PR DESCRIPTION
## **User description**
Detect the repo's Python, Go, and Bun workspaces through shared Taskfile logic and expose the standard build, test, lint, and clean entrypoints.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Taskfile task definitions and Go module discovery filters; main risk is skipping intended Go modules if directory exclusions are too broad.
> 
> **Overview**
> Refines `Taskfile.yml` by **centralizing Go module discovery** into `GO_MODULE_FIND_ARGS` (now also excluding `.git` and `node_modules`) and reusing it across `build:go`, `test:go`, `lint:go`, and `clean`.
> 
> Adds a `default` task that lists available tasks, and updates top-level `build`/`test`/`lint` descriptions to explicitly cover **Python, Go, and Bun** workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3fad4d17d47b7b2af357d14594cf6dcfc468a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Make common Taskfile commands easier to find and keep Go workspace handling consistent**

### What Changed
- Running the Taskfile with no target now lists available tasks
- Build, test, lint, and clean now use the same Go module search rules, so they skip ignored folders consistently
- Task descriptions now clearly say they cover Python, Go, and Bun workspaces

### Impact
`✅ Easier task discovery`
`✅ Fewer runs in ignored code`
`✅ More consistent cleanup across workspaces`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=wU4OMq380DM5SPv4MysCDu0WG9EuaWrjm6DRBCQhB7M&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
