### PR TITLE
chore: align Taskfile Bun task names

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,7 +21,7 @@ tasks:
     deps:
       - build:python
       - build:go
-      - build:frontend
+      - build:bun
 
   build:python:
     desc: Build the Python package when pyproject.toml is present
@@ -42,7 +42,7 @@ tasks:
           (cd "$module_dir" && go build ./...)
         done
 
-  build:frontend:
+  build:bun:
     desc: Build the Bun frontend workspace when frontend/package.json is present
     cmds:
       - |
@@ -56,7 +56,7 @@ tasks:
     deps:
       - test:python
       - test:go
-      - test:frontend
+      - test:bun
 
   test:python:
     desc: Run Python tests when pyproject.toml and tests/ are present
@@ -77,7 +77,7 @@ tasks:
           (cd "$module_dir" && go test ./...)
         done
 
-  test:frontend:
+  test:bun:
     desc: Run Bun frontend tests when frontend/package.json is present
     cmds:
       - |
@@ -91,7 +91,7 @@ tasks:
     deps:
       - lint:python
       - lint:go
-      - lint:frontend
+      - lint:bun
 
   lint:python:
     desc: Run Python Ruff lint and format checks when pyproject.toml is present
@@ -118,7 +118,7 @@ tasks:
           (cd "$module_dir" && go vet ./...)
         done
 
-  lint:frontend:
+  lint:bun:
     desc: Run Bun frontend lint and type checks when frontend/package.json is present
     cmds:
       - |


### PR DESCRIPTION
## **User description**
## Summary
- keep the common Taskfile entrypoints for build, test, lint, and clean
- rename frontend-specific Taskfile subtasks to Bun-oriented names so the detected language groups are Python, Go, and Bun
- leave the existing frontend package detection guards in place

## Validation
- task --list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a Taskfile naming/alignment change; the underlying commands and `frontend/package.json` guards remain the same.
> 
> **Overview**
> Aligns Taskfile language grouping to **Python/Go/Bun** by renaming `build:test:lint:frontend` subtasks to `build:test:lint:bun` and updating the top-level `build`, `test`, and `lint` dependencies to point at the new names.
> 
> Keeps the existing `frontend/package.json` detection/guard behavior and continues running the same `bun run` commands under `frontend/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ef87acb579139c11baf537411e29421d2b6d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Align common Taskfile tasks with Bun naming**

### What Changed
- Renamed the frontend-specific build, test, and lint task entrypoints to Bun-based names
- Kept the top-level build, test, and lint commands working for Python, Go, and Bun workspaces
- Left the existing checks for when the frontend workspace is present in place

### Impact
`✅ Clearer task names for Bun projects`
`✅ Easier discovery of build, test, and lint commands`
`✅ Same workspace detection behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=p0SWtlVKmT_XtZSXn6HI4LzPVBz6Xh3VTVBZqWxVYIM&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
