### PR TITLE
chore: align Taskfile common tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,11 +43,13 @@ tasks:
         done
 
   build:bun:
-    desc: Build the Bun frontend workspace when frontend/package.json is present
+    desc: Build the Bun workspace when a package.json build script is present
     cmds:
       - |
         set -eu
-        if [ -f frontend/package.json ]; then
+        if [ -f package.json ]; then
+          bun run build
+        elif [ -f frontend/package.json ]; then
           (cd frontend && bun run build)
         fi
 
@@ -78,11 +80,13 @@ tasks:
         done
 
   test:bun:
-    desc: Run Bun frontend tests when frontend/package.json is present
+    desc: Run Bun workspace tests when a package.json test script is present
     cmds:
       - |
         set -eu
-        if [ -f frontend/package.json ]; then
+        if [ -f package.json ]; then
+          bun run test
+        elif [ -f frontend/package.json ]; then
           (cd frontend && bun run test)
         fi
 
@@ -119,11 +123,14 @@ tasks:
         done
 
   lint:bun:
-    desc: Run Bun frontend lint and type checks when frontend/package.json is present
+    desc: Run Bun workspace lint and type checks when package scripts are present
     cmds:
       - |
         set -eu
-        if [ -f frontend/package.json ]; then
+        if [ -f package.json ]; then
+          bun run lint
+          bun run typecheck
+        elif [ -f frontend/package.json ]; then
           (cd frontend && bun run lint && bun run typecheck)
         fi
 
@@ -141,7 +148,9 @@ tasks:
           (cd "$module_dir" && go clean -cache -testcache)
         done
 
-        if [ -d frontend ]; then
+        if [ -f package.json ]; then
+          bun run clean
+        elif [ -d frontend ]; then
           rm -rf frontend/.turbo frontend/coverage frontend/apps/*/dist frontend/apps/*/build
           find frontend -type d \( -name dist -o -name build -o -name coverage \) -prune -exec rm -rf {} +
         fi


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Taskfile conditionals for Bun build/test/lint/clean to prefer a root `package.json`, which may change what scripts run in repos that also have `frontend/package.json`.
> 
> **Overview**
> Updates `Taskfile.yml` Bun tasks to **prefer root workspace scripts** when `package.json` exists, falling back to `frontend/package.json` for legacy layouts.
> 
> This changes `build:bun`, `test:bun`, and `lint:bun` to run `bun run ...` from the repo root (including separate `lint` + `typecheck`), and updates `clean` to call `bun run clean` when a root `package.json` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116db7b5f7abc1b9a1cc526da8fccaa033af7f85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Use root Bun scripts when they exist for build, test, lint, and clean tasks

### What Changed
- Bun build, test, and lint tasks now run from the repository root when a root `package.json` is present
- If no root Bun workspace is available, the tasks still fall back to the existing `frontend/` setup
- Root linting now runs both lint and type checks, and clean now uses the root cleanup script when available

### Impact
`✅ Works with root Bun workspaces`
`✅ Fewer missed lint and type-check runs`
`✅ Cleaner cleanup in projects with root scripts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=UPTx5GmM3Wt68XL7_5X98bTzcbD7kFxQnUMcw64X7AY&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
