### PR TITLE
codex/add common taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,6 +9,7 @@ vars:
     -not -path './ARCHIVE/*'
     -not -path './.archive/*'
     -not -path './default/*'
+  FRONTEND_DIR: frontend
 
 tasks:
   default:
@@ -47,10 +48,14 @@ tasks:
     cmds:
       - |
         set -eu
-        if [ -f package.json ]; then
+        has_script() {
+          node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
+        }
+
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ] && (cd "{{.FRONTEND_DIR}}" && has_script build); then
+          bun --cwd "{{.FRONTEND_DIR}}" run build
+        elif [ -f package.json ] && has_script build; then
           bun run build
-        elif [ -f frontend/package.json ]; then
-          (cd frontend && bun run build)
         fi
 
   test:
@@ -84,10 +89,14 @@ tasks:
     cmds:
       - |
         set -eu
-        if [ -f package.json ]; then
+        has_script() {
+          node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
+        }
+
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ] && (cd "{{.FRONTEND_DIR}}" && has_script test); then
+          bun --cwd "{{.FRONTEND_DIR}}" run test
+        elif [ -f package.json ] && has_script test; then
           bun run test
-        elif [ -f frontend/package.json ]; then
-          (cd frontend && bun run test)
         fi
 
   lint:
@@ -127,11 +136,27 @@ tasks:
     cmds:
       - |
         set -eu
-        if [ -f package.json ]; then
-          bun run lint
-          bun run typecheck
-        elif [ -f frontend/package.json ]; then
-          (cd frontend && bun run lint && bun run typecheck)
+        has_script() {
+          node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
+        }
+
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+          (
+            cd "{{.FRONTEND_DIR}}"
+            if has_script lint; then
+              bun run lint
+            fi
+            if has_script typecheck; then
+              bun run typecheck
+            fi
+          )
+        elif [ -f package.json ]; then
+          if has_script lint; then
+            bun run lint
+          fi
+          if has_script typecheck; then
+            bun run typecheck
+          fi
         fi
 
   clean:
@@ -148,9 +173,15 @@ tasks:
           (cd "$module_dir" && go clean -cache -testcache)
         done
 
-        if [ -f package.json ]; then
-          bun run clean
-        elif [ -d frontend ]; then
-          rm -rf frontend/.turbo frontend/coverage frontend/apps/*/dist frontend/apps/*/build
-          find frontend -type d \( -name dist -o -name build -o -name coverage \) -prune -exec rm -rf {} +
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+          if node -e "const p=require('./{{.FRONTEND_DIR}}/package.json'); process.exit(p.scripts?.clean ? 0 : 1)"; then
+            bun --cwd "{{.FRONTEND_DIR}}" run clean
+          else
+            rm -rf "{{.FRONTEND_DIR}}/.turbo" "{{.FRONTEND_DIR}}/coverage" "{{.FRONTEND_DIR}}"/apps/*/dist "{{.FRONTEND_DIR}}"/apps/*/build
+            find "{{.FRONTEND_DIR}}" -type d \( -name dist -o -name build -o -name coverage \) -prune -exec rm -rf {} +
+          fi
+        elif [ -f package.json ]; then
+          if node -e "const p=require('./package.json'); process.exit(p.scripts?.clean ? 0 : 1)"; then
+            bun run clean
+          fi
         fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,10 +52,10 @@ tasks:
           node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
         }
 
-        if [ -f "{{.FRONTEND_DIR}}/package.json" ] && (cd "{{.FRONTEND_DIR}}" && has_script build); then
-          bun --cwd "{{.FRONTEND_DIR}}" run build
-        elif [ -f package.json ] && has_script build; then
+        if [ -f package.json ] && has_script build; then
           bun run build
+        elif [ -f "{{.FRONTEND_DIR}}/package.json" ] && (cd "{{.FRONTEND_DIR}}" && has_script build); then
+          (cd "{{.FRONTEND_DIR}}" && bun run build)
         fi
 
   test:
@@ -93,10 +93,10 @@ tasks:
           node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
         }
 
-        if [ -f "{{.FRONTEND_DIR}}/package.json" ] && (cd "{{.FRONTEND_DIR}}" && has_script test); then
-          bun --cwd "{{.FRONTEND_DIR}}" run test
-        elif [ -f package.json ] && has_script test; then
+        if [ -f package.json ] && has_script test; then
           bun run test
+        elif [ -f "{{.FRONTEND_DIR}}/package.json" ] && (cd "{{.FRONTEND_DIR}}" && has_script test); then
+          (cd "{{.FRONTEND_DIR}}" && bun run test)
         fi
 
   lint:
@@ -140,7 +140,14 @@ tasks:
           node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
         }
 
-        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+        if [ -f package.json ]; then
+          if has_script lint; then
+            bun run lint
+          fi
+          if has_script typecheck; then
+            bun run typecheck
+          fi
+        elif [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
           (
             cd "{{.FRONTEND_DIR}}"
             if has_script lint; then
@@ -150,13 +157,6 @@ tasks:
               bun run typecheck
             fi
           )
-        elif [ -f package.json ]; then
-          if has_script lint; then
-            bun run lint
-          fi
-          if has_script typecheck; then
-            bun run typecheck
-          fi
         fi
 
   clean:
@@ -173,15 +173,15 @@ tasks:
           (cd "$module_dir" && go clean -cache -testcache)
         done
 
-        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+        if [ -f package.json ]; then
+          if node -e "const p=require('./package.json'); process.exit(p.scripts?.clean ? 0 : 1)"; then
+            bun run clean
+          fi
+        elif [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
           if node -e "const p=require('./{{.FRONTEND_DIR}}/package.json'); process.exit(p.scripts?.clean ? 0 : 1)"; then
-            bun --cwd "{{.FRONTEND_DIR}}" run clean
+            (cd "{{.FRONTEND_DIR}}" && bun run clean)
           else
             rm -rf "{{.FRONTEND_DIR}}/.turbo" "{{.FRONTEND_DIR}}/coverage" "{{.FRONTEND_DIR}}"/apps/*/dist "{{.FRONTEND_DIR}}"/apps/*/build
             find "{{.FRONTEND_DIR}}" -type d \( -name dist -o -name build -o -name coverage \) -prune -exec rm -rf {} +
-          fi
-        elif [ -f package.json ]; then
-          if node -e "const p=require('./package.json'); process.exit(p.scripts?.clean ? 0 : 1)"; then
-            bun run clean
           fi
         fi


### PR DESCRIPTION
- **chore: align common Taskfile tasks**
- **fix Taskfile Bun script dispatch**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `build`, `test`, `lint`, and `clean` locate and execute Bun workspace scripts, which could break local/CI automation if the workspace path detection is wrong.
> 
> **Overview**
> Updates `Taskfile.yml` to **standardize Bun workspace execution** by introducing `BUN_WORKSPACE_DIR`, which auto-selects `frontend/` when it contains a `package.json` and otherwise falls back to the repo root.
> 
> `build:bun`, `test:bun`, and `lint:bun` now run scripts exclusively from the resolved workspace directory, and `clean` is adjusted to either run a `clean` script (if present) or perform a best-effort removal of common Bun/Turbo build artifacts under that workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30663d9ea6241d95baafdd0595c7668f901e860e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->