### PR TITLE
fix Taskfile shell workspace detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,8 +10,6 @@ vars:
     -not -path './.archive/*'
     -not -path './default/*'
   FRONTEND_DIR: frontend
-  BUN_WORKSPACE_DIR: >-
-    {{if eq (OS "test -f frontend/package.json && printf yes || printf no") "yes"}}frontend{{else}}.{{end}}
 
 tasks:
   default:
@@ -54,8 +52,13 @@ tasks:
           node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
         }
 
-        if [ -f "{{.BUN_WORKSPACE_DIR}}/package.json" ] && (cd "{{.BUN_WORKSPACE_DIR}}" && has_script build); then
-          (cd "{{.BUN_WORKSPACE_DIR}}" && bun run build)
+        bun_dir="."
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+          bun_dir="{{.FRONTEND_DIR}}"
+        fi
+
+        if [ -f "$bun_dir/package.json" ] && (cd "$bun_dir" && has_script build); then
+          (cd "$bun_dir" && bun run build)
         fi
 
   test:
@@ -93,8 +96,13 @@ tasks:
           node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
         }
 
-        if [ -f "{{.BUN_WORKSPACE_DIR}}/package.json" ] && (cd "{{.BUN_WORKSPACE_DIR}}" && has_script test); then
-          (cd "{{.BUN_WORKSPACE_DIR}}" && bun run test)
+        bun_dir="."
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+          bun_dir="{{.FRONTEND_DIR}}"
+        fi
+
+        if [ -f "$bun_dir/package.json" ] && (cd "$bun_dir" && has_script test); then
+          (cd "$bun_dir" && bun run test)
         fi
 
   lint:
@@ -138,8 +146,13 @@ tasks:
           node -e "const p=require('./package.json'); process.exit(p.scripts?.[process.argv[1]] ? 0 : 1)" "$1"
         }
 
-        if [ -f "{{.BUN_WORKSPACE_DIR}}/package.json" ]; then
-          cd "{{.BUN_WORKSPACE_DIR}}"
+        bun_dir="."
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+          bun_dir="{{.FRONTEND_DIR}}"
+        fi
+
+        if [ -f "$bun_dir/package.json" ]; then
+          cd "$bun_dir"
           if has_script lint; then
             bun run lint
           fi
@@ -162,12 +175,17 @@ tasks:
           (cd "$module_dir" && go clean -cache -testcache)
         done
 
-        if [ -f "{{.BUN_WORKSPACE_DIR}}/package.json" ]; then
-          if node -e "const p=require('./{{.BUN_WORKSPACE_DIR}}/package.json'); process.exit(p.scripts?.clean ? 0 : 1)"; then
-            cd "{{.BUN_WORKSPACE_DIR}}"
+        bun_dir="."
+        if [ -f "{{.FRONTEND_DIR}}/package.json" ]; then
+          bun_dir="{{.FRONTEND_DIR}}"
+        fi
+
+        if [ -f "$bun_dir/package.json" ]; then
+          if (cd "$bun_dir" && node -e "const p=require('./package.json'); process.exit(p.scripts?.clean ? 0 : 1)"); then
+            cd "$bun_dir"
             bun run clean
           else
-            rm -rf "{{.BUN_WORKSPACE_DIR}}/.turbo" "{{.BUN_WORKSPACE_DIR}}/coverage" "{{.BUN_WORKSPACE_DIR}}"/apps/*/dist "{{.BUN_WORKSPACE_DIR}}"/apps/*/build
-            find "{{.BUN_WORKSPACE_DIR}}" -type d \( -name dist -o -name build -o -name coverage \) -prune -exec rm -rf {} +
+            rm -rf "$bun_dir/.turbo" "$bun_dir/coverage" "$bun_dir"/apps/*/dist "$bun_dir"/apps/*/build
+            find "$bun_dir" -type d \( -name dist -o -name build -o -name coverage \) -prune -exec rm -rf {} +
           fi
         fi


### PR DESCRIPTION
## **User description**
## Summary
- fix the common Taskfile Bun workspace detection that was introduced in the previous Taskfile merge
- remove the invalid Task template shell probe and perform frontend/root package detection inside each shell task
- keep the common `build`, `test`, `lint`, and `clean` tasks for detected Python, Go, and Bun workspaces

## Validation
- `task --taskfile /tmp/wt-taskfile-Tracera/Taskfile.yml --list` passes against the updated Taskfile content fetched from the branch
- Earlier full-suite task attempts exposed existing repo/tooling failures unrelated to this Taskfile syntax fix: frontend build fails in `@tracertm/ui`, frontend tests fail on missing `@vitest/globals`, frontend lint reports existing app/package lint violations, and Go build/test fail under the local Go toolchain/cache with missing stdlib/cache paths

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: changes only Taskfile shell logic to choose the correct Bun workspace directory and should only affect task execution paths.
> 
> **Overview**
> Fixes Bun workspace detection in `Taskfile.yml` by removing the `BUN_WORKSPACE_DIR` template probe and instead determining `bun_dir` inside each Bun-related task (preferring `frontend/` when it has a `package.json`, otherwise `.`).
> 
> Updates `build:bun`, `test:bun`, `lint:bun`, and the Bun portion of `clean` to run scripts and cleanup against the resolved `bun_dir`, including making the `clean` script check execute within that directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f04c8a98b5c22d918e37938196b4bde08589115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Fix Bun task detection so tasks run in the right workspace

### What Changed
- Bun build, test, and lint tasks now detect the frontend workspace when it exists, and otherwise run from the repository root
- The Bun clean step now checks for a workspace clean script in the correct directory before running it
- When no clean script is present, cleanup now targets the resolved workspace instead of assuming a fixed path

### Impact
`✅ Fewer failed Bun task runs`
`✅ Correct cleanup in frontend or root workspaces`
`✅ More reliable build, test, and lint commands`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=qdjmb6TwbKeL0U3zFcEoYRyw8dW-dlnZJVHnx6gZj8E&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
