### PR TITLE
chore: ignore .hypothesis/ test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ __pycache__/
 .github/copilot-instructions.md
 .claudeignore
 .llmignore
+.hypothesis/


### PR DESCRIPTION
## Summary
- Add .hypothesis/ to .gitignore to prevent 283 untracked test artifact files from appearing as dirty

## Test plan
- [x] git status shows 0 dirty files after ignore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude a local test-artifacts directory, with no runtime or behavior changes.
> 
> **Overview**
> Adds `.hypothesis/` to `.gitignore` so Hypothesis-generated local test artifacts aren’t shown as untracked/dirty working tree state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d190ea417c8f75b8d89d000f65eead0c062ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->