### PR TITLE
docs: add tooling reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,200 +1,95 @@
 # TracerTM - CLAUDE.md
 
-## Project Overview
+## Overview
 
-**TracerTM** is an agent-native, multi-view requirements traceability and project management system. It enables tracking of requirements across the software development lifecycle with tight integration into Kilo Gastown for multi-agent orchestration.
+TracerTM is an agent-native, multi-view requirements traceability and project management system.
 
-- **Rig ID**: `9614f3ef-45c8-4bdc-bdf2-906899b5f052`
-- **Town**: `78a8d430-a206-4a25-96c0-5cd9f5caf984`
-- **Branch**: `convoy/methodology-trace/a8883763/head`
-
-## Stack
-
-| Layer | Technology |
-|-------|------------|
-| Backend API | Go |
-| Python Services | FastAPI, SQLAlchemy, Pydantic |
-| Frontend | React 19, TypeScript, TanStack Router, Zustand |
-| Relational DB | PostgreSQL 17+ |
-| Graph DB | Neo4j 5.0+ |
-| Cache | Redis 7+ |
-| Messaging | NATS 2.9+ |
-| Workflow Engine | Temporal |
-| Observability | Prometheus, Loki, Jaeger |
+This checkout is primarily a Python `src/` package with supporting frontend and container tooling. The root package entry points are defined in `pyproject.toml`, including `rtm`, `tracertm`, `tracertm-mcp`, and `rtm-mcp`.
 
 ## Architecture
 
-```
-frontend/          # React/TypeScript SPA
-backend/           # Go API server (separate repo)
-src/tracertm/      # Python services & CLI
-├── api/           # FastAPI routes
-├── services/      # Business logic
-├── repositories/  # Data access
-├── storage/       # File/markdown handling
-├── mcp/           # MCP server tools
-├── agent/         # Agent coordination
-└── tui/           # Textual TUI
-```
+- `src/tracertm/`: main Python package
+- `src/tracertm/api/`: FastAPI routes, middleware, and HTTP client glue
+- `src/tracertm/services/`: business logic and orchestration
+- `src/tracertm/repositories/`: data access layer
+- `src/tracertm/storage/`: file and markdown handling
+- `src/tracertm/mcp/`: MCP server implementation and tools
+- `src/tracertm/agent/`: agent coordination, sessions, and sandbox helpers
+- `src/tracertm/tui/`: Textual-based terminal UI
+- `frontend/`: Bun-based React/TypeScript workspace
+- `Taskfile.yml`: repo-wide build, test, lint, and cleanup orchestration
+- `.devcontainer/Dockerfile`: development image with Go 1.23, Python 3.11, Node.js 20, Bun, uv, and helper tooling
 
-## Code Conventions
+Notes:
 
-### Python (Primary)
+- The repo currently does not have a root `go.mod`; Go tasks in `Taskfile.yml` only act on detected nested modules.
+- The package metadata in `pyproject.toml` requires Python `>=3.13`, even though the devcontainer installs Python 3.11.
 
-- **Linting**: `ruff check .`
-- **Formatting**: `ruff format .`
-- **Type checking**: `ty check src/`
-- **Testing**: `pytest` (unit: `pytest -m unit`, integration: `pytest -m integration`)
-- **Quality gates**: `task quality`
+## Build Commands
 
-### Frontend
-
-- Use `bun` instead of `npm` for all package management
-- Commands: `bun run dev`, `bun run build`, `bun run lint`, `bun test`
-
-### Key Files
-
-| Path | Purpose |
-|------|---------|
-| `pyproject.toml` | Python package config, pytest/ruff settings |
-| `Taskfile.yml` | Task automation |
-| `Makefile` | Naming convention checks |
-| `frontend/package.json` | Frontend dependencies |
-| `src/tracertm/` | Main Python source |
-| `tests/` | Test suite |
-
-### Code Quality Non-Negotiables
-
-- Zero new lint suppressions without inline justification
-- All new code must pass: `ruff check`, `ty check`, tests
-- Max function: 40 lines. Max cognitive complexity: 15
-- No placeholder TODOs in committed code
-- Hook-backed enforcement for complexity and imports
-
-### Library Preferences
-
-| Need | Use | NOT |
-|------|-----|-----|
-| Retry/resilience | tenacity | Custom retry loops |
-| HTTP client | httpx | Custom wrappers |
-| Logging | loguru + structlog | print() or logging.getLogger |
-| Config | pydantic-settings | Manual env parsing |
-| CLI | typer | argparse |
-| Validation | pydantic | Manual if/else |
-| Database ORM | SQLAlchemy (async) | Raw SQL strings |
-| API framework | FastAPI + uvicorn | Flask / custom ASGI |
-| MCP tools | fastmcp | Custom MCP protocol handling |
-| Workflow orchestration | temporalio | Custom job queues |
-
-## Agent Behavior Rules
-
-### Work Delegation
-
-Use `gt_sling` and `gt_sling_batch` for delegating work to other agents:
+Use the task runner first when possible.
 
 ```bash
-gt_sling <bead_id> <agent_id>  # Delegate single bead
-gt_sling_batch <bead_ids> <agent_id>  # Delegate multiple beads
+task build
 ```
 
-### Context Management
-
-**Manager Pattern**: Operate as a strategic manager, not a worker. Delegate to subagents.
-
-**Keep in Main Context**:
-- User intent and requirements
-- Strategic decisions and trade-offs
-- Summaries of completed work
-- Critical architectural knowledge
-
-**Delegate to Subagents**:
-- File exploration (>3 files)
-- Pattern searches across codebase
-- Multi-file implementations
-- Long command sequences
-- Test execution
-
-### Development Commands
+Scoped builds:
 
 ```bash
-# Install dependencies
-task install        # or: uv sync
+task build:python   # uv build when pyproject.toml is present
+task build:go       # build any detected Go modules
+task build:bun      # bun build for the frontend workspace when available
+```
 
-# Run tests
-pytest              # or: task test
+Direct frontend build:
 
-# Lint & format
-ruff check . && ruff format .
+```bash
+cd frontend
+bun run build
+```
 
-# Type checking
-ty check src/
+## Test Commands
 
-# Quality gates (full)
+Repo-wide:
+
+```bash
+task test
+```
+
+Scoped test commands:
+
+```bash
+pytest
+pytest -m unit
+pytest -m integration
+task test:python
+task test:go
+task test:bun
+```
+
+Common validation gates:
+
+```bash
 task quality
-
-# Database migrations
-task db:migrate
-task db-rollback
-
-# All Services (TUI Dashboard)
-task dev:tui        # Start all services with interactive TUI
-task dev            # Standard dev mode
+ruff check .
+ruff format --check .
+ty check src/
 ```
 
-### Dev Environment Rules
-
-- **The user runs `make dev-tui`** in their own terminal as the primary observation dashboard
-- **Never** run `make dev`, `make dev-tui`, or `make dev-down` — those are user-only commands
-- **Hot reload** handles code changes — do not restart services just because you edited code
-- **Config/env changes** require restart of affected service only
-
-### CLI Commands for Introspection
-
-| Action | Command |
-|--------|---------|
-| Check all service health | `make dev-status` |
-| Restart one service | `make dev-restart SERVICE=go-backend` |
-| Tail logs (all) | `make dev-logs` |
-| Tail logs (one service) | `make dev-logs SERVICE=python-backend` |
-
-### Quality Gates (Pre-Commit)
-
-1. `pytest` - All tests pass
-2. `ruff check .` - No lint errors
-3. `ruff format --check .` - Code properly formatted
-4. `ty check src/` - Type annotations valid
-
-### Worktree Discipline
-
-- Feature work goes in `.worktrees/<topic>/`
-- Legacy `PROJECT-wtrees/` and `repo-wtrees/` roots are for migration only
-- Canonical repository remains on `main` for final integration
-
-### Governance
-
-- Worktree discipline, reuse protocol, git delivery, stability, CI, child-agent delegation
-- Source: `KooshaPari/thegent` -> `templates/claude/governance-blocks/`
-- Reference the source instead of duplicating blocks
-
-### Child Agent Usage
-
-- Use child agents liberally for discovery-heavy, migration-heavy, and high-context work
-- Delegate broad scans, decomposition, and implementation waves to subagents
-- Keep the parent lane focused on deterministic integration and finalization
-- Preserve explicit handoffs and cross-agent context in session notes and audits
-
-## Environment Setup
+Frontend validation:
 
 ```bash
-# Prerequisites
-go 1.21+, python 3.13+, node/bun
-postgresql 17+, redis 7+, neo4j 5.0+, nats 2.9+
-task (taskfile.dev), process-compose
-
-# First run
-task install
-task db:migrate
-task dev:tui
+cd frontend
+bun run lint
+bun run typecheck
+bun test
 ```
 
-Access services at `http://localhost:4000` (Gateway), `http://localhost:3000` (Grafana), `http://localhost:16686` (Jaeger).
+## Branch Discipline
+
+- Use a dedicated branch for every change.
+- Prefer `feature/<topic>` for new work and `fix/<topic>` for bug fixes.
+- Keep the branch focused on one concern; avoid mixing unrelated edits.
+- Do not commit directly to `main`.
+- Open a pull request after the change is committed, and expect maintainer review plus CI quality gates.
+- Keep commit messages concise and descriptive.

--- a/docs/services/traceability_matrix_service.md
+++ b/docs/services/traceability_matrix_service.md
@@ -1,5 +1,17 @@
 # Traceability Matrix Service
 
+## Implementation status (complete-polish lane)
+
+| Area | Status | Notes |
+|------|--------|-------|
+| `TraceabilityMatrixService.generate_matrix` | Done | Async batch matrix with view filters |
+| `TraceabilityMatrix.to_dict` | Done | MCP `get_trace_matrix` / `trace_analyze` serialization |
+| `export_matrix_csv` / `export_matrix_html` | Done | Unit-tested export helpers |
+| `get_uncovered_items` | Done | Source/target gap detection from matrix |
+| MCP `trace_analyze` dispatch | Done | `params/common.py` routes to `mcp.tools.traceability` |
+| MCP module load (`_load.py`) | Deferred | Avoid duplicate registration with `core_tools` HTTP tools |
+| TUI storage traceability summary | Deferred | Use MCP/CLI matrix; no `frontend/` changes |
+
 ## Overview
 
 The Traceability Matrix Service provides high-performance traceability matrix generation and analysis for requirements, tests, and implementation items. It uses optimized PostgreSQL batch queries and Redis caching to deliver sub-500ms response times for projects with 1000+ items.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,253 @@
+# Tooling Reference
+
+This document is the quick reference for local development in TraceRTM.
+
+TraceRTM is a Python-first monorepo with a small amount of frontend and Go support:
+
+- Python lives under `src/tracertm/` and is the primary application surface.
+- The frontend is a Bun-managed workspace under `frontend/`.
+- Infrastructure is driven by `docker-compose.yml` and `docker-compose.prod.yml`.
+- Shared developer commands are exposed through `Taskfile.yml` and the root `package.json` scripts.
+
+---
+
+## 1. Overview
+
+The default dev stack is a local multi-service environment for the Python API, Go API, and supporting infrastructure:
+
+- `python-backend` for the FastAPI-based Python service.
+- `go-backend` for the Go service.
+- `nginx` as the local gateway.
+- `postgres` for relational storage.
+- `dragonfly` as the Redis-compatible cache.
+- `nats` for messaging.
+- `prometheus` and `grafana` for monitoring.
+- Exporters for nginx, postgres, and cache metrics.
+
+The repo also contains a production-like compose stack in `docker-compose.prod.yml` that adds:
+
+- `neo4j`
+- `minio`
+
+That file is closer to the full deployment surface, while `docker-compose.yml` is the standard local development stack.
+
+---
+
+## 2. CLI Commands
+
+The repository exposes the most common workflows through `package.json` scripts, which mostly forward to `make` targets.
+
+Note: the checked-in makefiles are split. The root [`Makefile`](../Makefile) currently only defines `lint-naming`, and [`Makefile.gateway`](../Makefile.gateway) carries the gateway-specific operational targets such as `test`, `config-test`, and `config-reload`. The `package.json` script names are still useful as the intended command surface, but some of them forward to make targets that are not defined in the root makefile in this checkout. In particular, there is no root `make quality` target in the current tree.
+
+### Root `package.json`
+
+| Command | Purpose |
+|---|---|
+| `bun run dev` | Start the full dev stack |
+| `bun run dev:tui` | Start the interactive TUI-based dev mode |
+| `bun run dev:down` | Stop the dev stack |
+| `bun run dev:logs` | Tail dev logs |
+| `bun run dev:status` | Show dev stack status |
+| `bun run quality` | Run the quality gate |
+| `bun run check` | Run repo checks |
+| `bun run lint` | Run frontend linting |
+| `bun run lint:all` | Run repo-wide linting |
+| `bun run type-check` | Run repo-wide type checking |
+| `bun run format` | Run formatting |
+| `bun run test` | Run repo-wide tests |
+| `bun run test:frontend` | Run frontend tests |
+| `bun run test:python` | Run Python tests |
+| `bun run test:go` | Run Go tests |
+| `bun run test:integration` | Run integration tests |
+| `bun run db:migrate` | Apply database migrations |
+| `bun run db:rollback` | Roll back the last migration |
+| `bun run db:reset` | Reset the database |
+| `bun run db:shell` | Open a database shell |
+
+### `Makefile`
+
+The checked-in root `Makefile` currently only defines the naming check:
+
+| Command | Purpose |
+|---|---|
+| `make lint-naming` | Run naming-consistency checks for Python, Go, and frontend code |
+
+### `Makefile.gateway`
+
+The gateway makefile is separate from the root build/test surface:
+
+| Command | Purpose |
+|---|---|
+| `make test` | Run the gateway test suite |
+| `make config-test` | Validate nginx configuration |
+| `make config-reload` | Reload nginx configuration |
+| `make cache-clear` | Clear the nginx cache and restart the gateway |
+| `make db-backup` | Run the gateway backup flow |
+
+### `Taskfile.yml`
+
+The bulk of the repo-wide automation lives in `Taskfile.yml`:
+
+| Task | Purpose |
+|---|---|
+| `task build` | Build detected Python, Go, and Bun workspaces |
+| `task build:python` | Build the Python package with `uv build` |
+| `task build:go` | Build Go modules |
+| `task build:bun` | Build the Bun workspace when present |
+| `task test` | Run all detected test suites |
+| `task test:python` | Run Python tests with `uv run pytest` |
+| `task test:go` | Run Go tests |
+| `task test:bun` | Run Bun workspace tests |
+| `task lint` | Run lint and format checks across Python, Go, and Bun |
+| `task lint:python` | Run Ruff lint and format checks |
+| `task lint:go` | Run `gofmt` verification and `go vet` |
+| `task lint:bun` | Run Bun lint and type checks |
+| `task clean` | Remove common build and test artifacts |
+
+### Practical command shortcuts
+
+Use these when you want the shortest path to a specific workflow:
+
+```bash
+bun run dev
+bun run test:python
+bun run test:frontend
+bun run quality
+task lint
+task test
+```
+
+---
+
+## 3. Docker Compose
+
+### Default dev stack: `docker-compose.yml`
+
+This is the normal local stack.
+
+| Service | Role |
+|---|---|
+| `nginx` | Local API gateway |
+| `nginx-exporter` | Nginx metrics exporter |
+| `go-backend` | Go backend service |
+| `python-backend` | Python backend service |
+| `postgres` | PostgreSQL database |
+| `postgres-exporter` | PostgreSQL metrics exporter |
+| `dragonfly` | Redis-compatible cache |
+| `redis-exporter` | Cache metrics exporter |
+| `nats` | Message broker |
+| `prometheus` | Metrics collection |
+| `grafana` | Dashboards and observability |
+
+### Production-like stack: `docker-compose.prod.yml`
+
+This file extends the stack with the broader infra surfaces used by the repo:
+
+| Service | Role |
+|---|---|
+| `postgres` | PostgreSQL 17 data store |
+| `dragonfly` | Redis-compatible cache |
+| `nats` | Messaging |
+| `go-backend` | Go backend |
+| `python-backend` | Python backend |
+| `nginx` | Gateway |
+| `neo4j` | Graph database |
+| `minio` | Object storage |
+| `grafana` | Dashboards |
+
+### Notes
+
+- The compose files use `dragonfly` rather than a native `redis` container for the cache layer.
+- If you are looking for the graph and object-storage dependencies mentioned in higher-level planning docs, they are present in `docker-compose.prod.yml`, not in the default dev compose file.
+
+---
+
+## 4. MCP Server
+
+TraceRTM does have an MCP package under `src/tracertm/mcp/`, but it is designed to run as part of the backend, not as a standalone process.
+
+Key points:
+
+- `src/tracertm/mcp/__main__.py` exits with an error if invoked directly.
+- The API mounts the MCP router under `/api/v1/mcp`.
+- `src/tracertm/mcp/server.py` is the main MCP server entrypoint referenced by the repo docs.
+- `docs/reference/MCP_TOOL_REFERENCE.md` is the detailed tool catalog and protocol reference.
+
+Operationally, the rule is:
+
+```bash
+# Do not run MCP by itself
+python -m tracertm.mcp
+
+# Run the backend/API instead, then use the mounted MCP endpoint
+```
+
+If you are extending MCP tooling, work inside `src/tracertm/mcp/` and validate through the backend that mounts it.
+
+---
+
+## 5. Dev Workflow
+
+The fastest iteration loop in this repo is:
+
+1. Make the change in the relevant surface:
+   - Python application code in `src/tracertm/`
+   - Frontend code in `frontend/`
+   - Compose or infra changes in the root compose files
+2. Run the narrowest useful check first:
+   - `bun run test:python`
+   - `bun run test:frontend`
+   - `task lint:python`
+   - `task lint:bun`
+3. Expand to the declared repo-level gate only after the local check passes:
+   - `bun run quality`
+   - `task test`
+   - `task lint`
+4. If you touched runtime wiring, restart the affected service rather than the whole stack when possible.
+5. Use the logs/status commands to confirm the service actually picked up the change:
+   - `bun run dev:status`
+   - `bun run dev:logs`
+
+For MCP work specifically, keep changes inside the package and validate through the backend route that exposes the MCP server.
+
+---
+
+## 6. Testing
+
+### Python
+
+```bash
+pytest
+pytest -m unit
+pytest -m integration
+```
+
+The repo also wires Python tests through:
+
+```bash
+bun run test:python
+task test:python
+task test
+```
+
+### Frontend
+
+```bash
+bun test
+bun run test:frontend
+```
+
+### Cross-stack
+
+```bash
+task test
+bun run test
+```
+
+### Recommended order
+
+When you are iterating locally:
+
+1. Run the nearest unit test target.
+2. Run the package-level test target.
+3. Finish with the repo-level test or quality gate before handing off.

--- a/frontend/apps/docs/package.json
+++ b/frontend/apps/docs/package.json
@@ -54,7 +54,7 @@
     "fuse.js": "^7.1.0",
     "get-nonce": "^1.0.1",
     "hast-util-to-html": "^9.0.5",
-    "js-yaml": "~> 6.0.0",
+    "js-yaml": "^4.1.1",
     "json-schema-traverse": "^1.0.0",
     "lucide-react": "^0.555.0",
     "micromark-factory-destination": "^2.0.1",

--- a/frontend/apps/web/src/__tests__/views/TraceabilityMatrixView.test.tsx
+++ b/frontend/apps/web/src/__tests__/views/TraceabilityMatrixView.test.tsx
@@ -10,13 +10,12 @@ import { useItems } from '../../hooks/useItems';
 import { useLinks } from '../../hooks/useLinks';
 import { TraceabilityMatrixView } from '../../views/TraceabilityMatrixView';
 
-// Mock TanStack Router
 vi.mock('@tanstack/react-router', async () => {
   const actual = await vi.importActual('@tanstack/react-router');
   return {
     ...actual,
-    Link: ({ children, to }: any) => (
-      <a href={typeof to === 'string' ? to : to.toString()}>{children}</a>
+    Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+      <a href={typeof to === 'string' ? to : String(to)}>{children}</a>
     ),
     useNavigate: () => vi.fn(),
     useSearch: () => ({}),
@@ -30,6 +29,26 @@ vi.mock('../../hooks/useItems', () => ({
 vi.mock('../../hooks/useLinks', () => ({
   useLinks: vi.fn(),
 }));
+
+function mockItems(overrides: Partial<ReturnType<typeof useItems>> = {}) {
+  vi.mocked(useItems).mockReturnValue({
+    data: { items: [], total: 0 },
+    error: null,
+    isError: false,
+    isLoading: false,
+    ...overrides,
+  } as ReturnType<typeof useItems>);
+}
+
+function mockLinks(overrides: Partial<ReturnType<typeof useLinks>> = {}) {
+  vi.mocked(useLinks).mockReturnValue({
+    data: { links: [] },
+    error: null,
+    isError: false,
+    isLoading: false,
+    ...overrides,
+  } as ReturnType<typeof useLinks>);
+}
 
 describe(TraceabilityMatrixView, () => {
   let queryClient: QueryClient;
@@ -45,19 +64,8 @@ describe(TraceabilityMatrixView, () => {
   });
 
   it('renders traceability matrix interface', () => {
-    vi.mocked(useItems).mockReturnValue({
-      data: [],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
-
-    vi.mocked(useLinks).mockReturnValue({
-      data: [],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
+    mockItems();
+    mockLinks();
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -66,23 +74,14 @@ describe(TraceabilityMatrixView, () => {
     );
 
     expect(screen.getByText('Traceability Matrix')).toBeInTheDocument();
-    expect(screen.getByText(/Requirements coverage overview/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Requirements coverage mapped to functional features/i),
+    ).toBeInTheDocument();
   });
 
   it('displays loading state', () => {
-    vi.mocked(useItems).mockReturnValue({
-      data: undefined,
-      error: null,
-      isError: false,
-      isLoading: true,
-    } as any);
-
-    vi.mocked(useLinks).mockReturnValue({
-      data: undefined,
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
+    mockItems({ data: undefined, isLoading: true });
+    mockLinks({ data: undefined, isLoading: false });
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -90,7 +89,7 @@ describe(TraceabilityMatrixView, () => {
       </QueryClientProvider>,
     );
 
-    // Should show skeleton/loading state
+    expect(screen.getByTestId('matrix-loading')).toBeInTheDocument();
   });
 
   it('displays matrix with requirements and features', () => {
@@ -104,24 +103,17 @@ describe(TraceabilityMatrixView, () => {
       { id: 'feat-2', title: 'Feature 2', type: 'feature' },
     ];
 
-    const links = [
-      { sourceId: 'req-1', targetId: 'feat-1' },
-      { sourceId: 'req-2', targetId: 'feat-2' },
-    ];
-
-    vi.mocked(useItems).mockReturnValue({
-      data: [...requirements, ...features],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
-
-    vi.mocked(useLinks).mockReturnValue({
-      data: links,
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
+    mockItems({
+      data: { items: [...requirements, ...features], total: 4 },
+    });
+    mockLinks({
+      data: {
+        links: [
+          { sourceId: 'req-1', targetId: 'feat-1' },
+          { sourceId: 'req-2', targetId: 'feat-2' },
+        ],
+      },
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -134,19 +126,8 @@ describe(TraceabilityMatrixView, () => {
   });
 
   it('shows export button', () => {
-    vi.mocked(useItems).mockReturnValue({
-      data: [],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
-
-    vi.mocked(useLinks).mockReturnValue({
-      data: [],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
+    mockItems();
+    mockLinks();
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -154,23 +135,12 @@ describe(TraceabilityMatrixView, () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByText('Export')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeInTheDocument();
   });
 
   it('handles empty state', () => {
-    vi.mocked(useItems).mockReturnValue({
-      data: [],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
-
-    vi.mocked(useLinks).mockReturnValue({
-      data: [],
-      error: null,
-      isError: false,
-      isLoading: false,
-    } as any);
+    mockItems();
+    mockLinks();
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -178,7 +148,25 @@ describe(TraceabilityMatrixView, () => {
       </QueryClientProvider>,
     );
 
-    // Should render empty matrix
     expect(screen.getByText('Traceability Matrix')).toBeInTheDocument();
+    expect(screen.getByTestId('matrix-empty-requirements')).toBeInTheDocument();
+  });
+
+  it('shows error state when items fail to load', () => {
+    mockItems({
+      data: undefined,
+      isError: true,
+      error: new Error('API unavailable'),
+    });
+    mockLinks();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TraceabilityMatrixView projectId='proj-test' />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('API unavailable')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/web/src/views/TraceabilityMatrixView.tsx
+++ b/frontend/apps/web/src/views/TraceabilityMatrixView.tsx
@@ -69,12 +69,28 @@ function CoverageBadge({ status, coveredCount, totalFeatures }: CoverageBadgePro
 }
 
 export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProps) {
-  const { data: itemsData, isLoading } = useItems({
+  const {
+    data: itemsData,
+    isLoading: itemsLoading,
+    isError: itemsError,
+    error: itemsErrorDetail,
+  } = useItems({
     projectId,
   });
-  const { data: linksData } = useLinks({
+  const {
+    data: linksData,
+    isLoading: linksLoading,
+    isError: linksError,
+    error: linksErrorDetail,
+  } = useLinks({
     projectId,
   });
+
+  const isLoading = itemsLoading || linksLoading;
+  const loadError =
+    itemsError || linksError
+      ? (itemsErrorDetail ?? linksErrorDetail ?? new Error('Failed to load traceability data'))
+      : null;
 
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -124,9 +140,24 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
     return { covered, partial, uncovered };
   }, [matrix]);
 
+  if (loadError) {
+    return (
+      <div
+        className='mx-auto flex max-w-lg flex-col items-center justify-center gap-3 px-6 py-24 text-center'
+        role='alert'
+      >
+        <Layers className='text-destructive h-10 w-10 opacity-60' />
+        <h2 className='font-mono text-sm font-bold tracking-tight'>Could not load matrix</h2>
+        <p className='text-muted-foreground text-sm'>
+          {loadError instanceof Error ? loadError.message : 'Try refreshing the page.'}
+        </p>
+      </div>
+    );
+  }
+
   if (isLoading) {
     return (
-      <div className='animate-pulse space-y-8 p-6'>
+      <div className='animate-pulse space-y-8 p-6' data-testid='matrix-loading'>
         <Skeleton className='h-10 w-48' />
         <div className='flex gap-4'>
           {[1, 2, 3].map((i) => (
@@ -361,10 +392,27 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
             </tbody>
           </table>
 
+          {matrix.features.length === 0 && matrix.requirements.length > 0 && (
+            <div
+              className='text-muted-foreground/50 flex flex-col items-center justify-center py-24'
+              data-testid='matrix-empty-features'
+            >
+              <Box className='mb-4 h-12 w-12 opacity-20' />
+              <p className='mono-label'>No features to map</p>
+              <p className='text-muted-foreground mt-1 max-w-sm text-xs'>
+                Add features to this project to build the traceability grid.
+              </p>
+            </div>
+          )}
           {matrix.requirements.length === 0 && (
-            <div className='text-muted-foreground/30 flex flex-col items-center justify-center py-24'>
+            <div
+              className='text-muted-foreground/30 flex flex-col items-center justify-center py-24'
+              data-testid='matrix-empty-requirements'
+            >
               <Layers className='mb-4 h-12 w-12 opacity-10' />
-              <p className='mono-label'>No requirements found</p>
+              <p className='mono-label'>
+                {searchQuery ? 'No requirements match your filter' : 'No requirements found'}
+              </p>
             </div>
           )}
         </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -152,6 +152,5 @@
     "vite": "^8.0.0-beta.11",
     "vitest": "^4.0.18",
     "zod": "4.3.6"
-  },
-  "packageManager": "bun@1.1.38"
+  }
 }

--- a/src/tracertm/api/deps.py
+++ b/src/tracertm/api/deps.py
@@ -79,7 +79,7 @@ async def get_event_bus() -> EventBus:
     return _event_bus
 
 
-async def get_db() -> AsyncGenerator[AsyncSession, None]:
+async def get_db() -> AsyncGenerator[AsyncSession]:
     """Get database session with shared connection pool.
 
     This now uses the MCP database adapter to share the connection pool

--- a/src/tracertm/api/handlers/chat.py
+++ b/src/tracertm/api/handlers/chat.py
@@ -1,13 +1,14 @@
 """Compatibility exports for chat handlers."""
-from typing import Any, Dict, Optional
+from typing import Any
+
 from fastapi import Request
 
 
 async def simple_chat(
     request: Request,
     message: str,
-    context: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Simple chat handler for compatibility."""
     return {
         "response": f"Echo: {message}",
@@ -18,7 +19,7 @@ async def simple_chat(
 async def stream_chat(
     request: Request,
     message: str,
-    context: Optional[Dict[str, Any]] = None,
+    context: dict[str, Any] | None = None,
 ):
     """Stream chat handler for compatibility."""
     yield f"Echo: {message}"

--- a/src/tracertm/api/handlers/chat_shared.py
+++ b/src/tracertm/api/handlers/chat_shared.py
@@ -68,7 +68,7 @@ def _get_working_directory(request_body: ChatRequest) -> str | None:
 
 async def _stream_with_agent_sandbox(
     ctx: SandboxStreamContext,
-) -> AsyncGenerator[str, None]:
+) -> AsyncGenerator[str]:
     async for chunk in ctx.agent_service.stream_chat_with_sandbox(
         messages=ctx.messages,
         session_id=ctx.session_id,
@@ -84,7 +84,7 @@ async def _stream_with_ai_service(
     request_body: ChatRequest,
     db_session: AsyncSession,
     working_directory: str | None,
-) -> AsyncGenerator[str, None]:
+) -> AsyncGenerator[str]:
     from tracertm.services.ai_service import get_ai_service
     from tracertm.services.ai_tools import set_allowed_paths
 

--- a/src/tracertm/api/handlers/chat_stream.py
+++ b/src/tracertm/api/handlers/chat_stream.py
@@ -34,7 +34,7 @@ async def _generate_sse_stream(
     db_session: AsyncSession,
     use_agent_sandbox: bool,
     request: Request | None = None,
-) -> AsyncGenerator[str, None]:
+) -> AsyncGenerator[str]:
     from tracertm.services.ai_service import AIServiceError
 
     try:

--- a/src/tracertm/api/main.py
+++ b/src/tracertm/api/main.py
@@ -97,7 +97,7 @@ async def _maybe_await(value: object) -> object:
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Startup then yield then shutdown (replaces deprecated on_event)."""
     # Startup - now using extracted module to reduce complexity
     await startup_initialization(app)

--- a/src/tracertm/api/routers/mcp.py
+++ b/src/tracertm/api/routers/mcp.py
@@ -407,7 +407,7 @@ async def mcp_sse(
     # Get optional task_id for task-specific streaming
     task_id = request.query_params.get("task_id")
 
-    async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
+    async def event_generator() -> AsyncGenerator[dict[str, Any]]:
         """Generate SSE events."""
         try:
             # Send initial connection event

--- a/src/tracertm/database/async_connection.py
+++ b/src/tracertm/database/async_connection.py
@@ -59,7 +59,7 @@ def get_session_factory() -> async_sessionmaker[AsyncSession]:
 
 
 @asynccontextmanager
-async def get_session() -> AsyncGenerator[AsyncSession, None]:
+async def get_session() -> AsyncGenerator[AsyncSession]:
     """Get database session context manager."""
     factory = get_session_factory()
     async with factory() as session:

--- a/src/tracertm/database/connection.py
+++ b/src/tracertm/database/connection.py
@@ -1,7 +1,7 @@
 """Database connection module for TracerTM."""
-from typing import Optional
+
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.orm import Session, sessionmaker
 
 
 class DatabaseConnection:
@@ -31,7 +31,7 @@ class DatabaseConnection:
         cls._session_factory = None
 
 
-def get_session() -> Optional[Session]:
+def get_session() -> Session | None:
     """Get a database session."""
     return DatabaseConnection.get_session()
 

--- a/src/tracertm/mcp/database_adapter.py
+++ b/src/tracertm/mcp/database_adapter.py
@@ -115,7 +115,7 @@ def _convert_to_async_url(database_url: str) -> str:
 
 
 @asynccontextmanager
-async def get_mcp_session() -> AsyncGenerator[AsyncSession, None]:
+async def get_mcp_session() -> AsyncGenerator[AsyncSession]:
     """Get an async database session with RLS context for MCP tools.
 
     This session:

--- a/src/tracertm/mcp/database_manager.py
+++ b/src/tracertm/mcp/database_manager.py
@@ -184,7 +184,7 @@ class DatabaseManager:
             self.metrics.record_query(str(statement), duration_ms, parameters if isinstance(parameters, dict) else None)
 
     @asynccontextmanager
-    async def session(self) -> AsyncGenerator[AsyncSession, None]:
+    async def session(self) -> AsyncGenerator[AsyncSession]:
         """Get a database session from the pool.
 
         Usage:

--- a/src/tracertm/mcp/http_transport.py
+++ b/src/tracertm/mcp/http_transport.py
@@ -126,8 +126,8 @@ def mount_mcp_to_fastapi(
 
 async def create_progress_stream(
     task_id: str,
-    generator_func: AsyncGenerator[dict[str, object], None],
-) -> AsyncGenerator[dict[str, object], None]:
+    generator_func: AsyncGenerator[dict[str, object]],
+) -> AsyncGenerator[dict[str, object]]:
     """Create an SSE stream for progress updates.
 
     This wraps a progress generator to format events for SSE streaming.

--- a/src/tracertm/mcp/tools/base_async.py
+++ b/src/tracertm/mcp/tools/base_async.py
@@ -36,7 +36,7 @@ def get_config_manager() -> ConfigManager:
 
 
 # Re-export get_mcp_session for convenience
-async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+async def get_async_session() -> AsyncGenerator[AsyncSession]:
     """Get an async database session with RLS context.
 
     This is an alias for get_mcp_session() for backward compatibility.

--- a/src/tracertm/mcp/tools/params/common.py
+++ b/src/tracertm/mcp/tools/params/common.py
@@ -55,8 +55,12 @@ except ImportError:
 project_tools = core
 item_tools = core
 link_tools = core
-trace_tools = core
 graph_tools = core
+
+try:
+    from tracertm.mcp.tools import traceability as trace_tools
+except ImportError:
+    trace_tools = core  # type: ignore[assignment]
 
 
 def _actor_from_context(ctx: object | None) -> dict[str, object] | None:

--- a/src/tracertm/mcp/tools/traceability.py
+++ b/src/tracertm/mcp/tools/traceability.py
@@ -102,10 +102,7 @@ async def get_trace_matrix(
             target_view=target_view.upper() if target_view else None,
         )
 
-        matrix_out = matrix
-        to_dict_fn = getattr(matrix, "to_dict", None)
-        if callable(to_dict_fn):
-            matrix_out = to_dict_fn()
+        matrix_out = matrix.to_dict() if hasattr(matrix, "to_dict") else matrix
         return wrap_success(  # type: ignore[return-value]
             {
                 "source_view": source_view,

--- a/src/tracertm/models/agent_session.py
+++ b/src/tracertm/models/agent_session.py
@@ -7,7 +7,7 @@ import uuid
 from sqlalchemy import ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from tracertm.models.base import Base, GUID, TimestampMixin
+from tracertm.models.base import GUID, Base, TimestampMixin
 
 
 def generate_agent_session_uuid() -> uuid.UUID:

--- a/src/tracertm/services/grpc_client.py
+++ b/src/tracertm/services/grpc_client.py
@@ -133,7 +133,7 @@ class GoBackendClient:
         await self.close()
 
     @asynccontextmanager
-    async def _retry_context(self, operation_name: str) -> AsyncGenerator[None, None]:
+    async def _retry_context(self, operation_name: str) -> AsyncGenerator[None]:
         """Context manager for retry logic with exponential backoff.
 
         Args:

--- a/src/tracertm/services/query_optimization_service.py
+++ b/src/tracertm/services/query_optimization_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -37,6 +38,11 @@ class QueryOptimizationService:
         self.query_cache: dict[str, Any] = {}
         self.query_stats: list[dict[str, Any]] = []
 
+    @staticmethod
+    def _query_cache_key(project_id: str, query_filters: dict[str, Any]) -> str:
+        """Stable cache key for analyze_query_performance deduplication."""
+        return f"{project_id}:{json.dumps(query_filters, sort_keys=True, default=str)}"
+
     async def analyze_query_performance(
         self,
         project_id: str,
@@ -44,12 +50,15 @@ class QueryOptimizationService:
     ) -> dict[str, Any]:
         """Analyze query performance."""
         start_time = datetime.now(UTC)
-
-        # Execute query
-        items = await self.items.query(project_id, query_filters)
-
-        end_time = datetime.now(UTC)
-        execution_time = (end_time - start_time).total_seconds()
+        cache_key = self._query_cache_key(project_id, query_filters)
+        cached_items = self.get_cached_query(cache_key)
+        if cached_items is not None:
+            items = cached_items
+            execution_time = 0.0
+        else:
+            items = await self.items.query(project_id, query_filters)
+            self.cache_query(cache_key, items)
+            execution_time = (datetime.now(UTC) - start_time).total_seconds()
 
         # Record stats
         stats = {

--- a/src/tracertm/services/traceability_matrix_service.py
+++ b/src/tracertm/services/traceability_matrix_service.py
@@ -65,15 +65,10 @@ class TraceabilityMatrixService:
 
         Complexity: O(n * m) where n = sources, m = targets
         """
-        # Get source items
-        source_items = await self.items.get_by_project(project_id)
-        if source_view:
-            source_items = [i for i in source_items if i.view == source_view]
-
-        # Get target items
-        target_items = await self.items.get_by_project(project_id)
-        if target_view:
-            target_items = [i for i in target_items if i.view == target_view]
+        # Single project fetch; filter in memory (avoids duplicate DB round-trip)
+        all_items = await self.items.get_by_project(project_id)
+        source_items = [i for i in all_items if not source_view or i.view == source_view]
+        target_items = [i for i in all_items if not target_view or i.view == target_view]
 
         # Get all links
         all_links = await self.links.get_by_project(project_id)

--- a/src/tracertm/services/traceability_matrix_service.py
+++ b/src/tracertm/services/traceability_matrix_service.py
@@ -1,6 +1,6 @@
 """Traceability matrix generation service for TraceRTM."""
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,6 +18,12 @@ class TraceabilityMatrix:
     matrix: list[list[str]]  # Link types or empty
     coverage: float  # Percentage of traced items
     total_links: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize matrix for MCP/API responses."""
+        data = asdict(self)
+        data["coverage"] = round(self.coverage, 2)
+        return data
 
 
 class TraceabilityMatrixService:

--- a/src/tracertm/services/traceability_service.py
+++ b/src/tracertm/services/traceability_service.py
@@ -89,28 +89,32 @@ class TraceabilityService:
     ) -> TraceabilityMatrix:
         """Generate traceability matrix between two views."""
         pid = str(project_id) if isinstance(project_id, uuid.UUID) else project_id
-        # Get all items in both views
         source_items = await self.items.get_by_view(pid, source_view)
-        await self.items.get_by_view(pid, target_view)
+        target_items = await self.items.get_by_view(pid, target_view)
+        source_by_id = {str(item.id): item for item in source_items}
+        target_by_id = {str(item.id): item for item in target_items}
+        source_ids = set(source_by_id)
+        target_ids = set(target_by_id)
 
-        # Get all links between these items
-        all_links = []
+        # One project link fetch instead of per-source queries and per-target lookups
+        all_links: list[dict[str, Any]] = []
         linked_source_ids: set[str] = set()
 
-        for source_item in source_items:
-            item_links = await self.links.get_by_source(str(source_item.id))
-            for link in item_links:
-                # Check if target is in target_view
-                target = await self.items.get_by_id(str(link.target_item_id))
-                if target and target.view == target_view:
-                    all_links.append({
-                        "source_id": str(source_item.id),
-                        "source_title": source_item.title,
-                        "target_id": str(target.id),
-                        "target_title": target.title,
-                        "link_type": link.link_type,
-                    })
-                    linked_source_ids.add(str(source_item.id))
+        for link in await self.links.get_by_project(pid):
+            source_id = str(link.source_item_id)
+            target_id = str(link.target_item_id)
+            if source_id not in source_ids or target_id not in target_ids:
+                continue
+            source = source_by_id[source_id]
+            target = target_by_id[target_id]
+            all_links.append({
+                "source_id": source_id,
+                "source_title": source.title,
+                "target_id": target_id,
+                "target_title": target.title,
+                "link_type": link.link_type,
+            })
+            linked_source_ids.add(source_id)
 
         # Calculate coverage
         coverage = len(linked_source_ids) / len(source_items) * 100 if source_items else 0

--- a/src/tracertm/storage/__init__.py
+++ b/src/tracertm/storage/__init__.py
@@ -1,8 +1,8 @@
 """Storage module for TracerTM."""
-from typing import Any, Dict, List, Optional
-from pathlib import Path
 import json
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 
 class LocalStorageManager:
@@ -15,17 +15,17 @@ class LocalStorageManager:
         self.items_dir.mkdir(parents=True, exist_ok=True)
         self.links_dir.mkdir(parents=True, exist_ok=True)
 
-    def save_item(self, item_id: str, data: Dict[str, Any]) -> None:
+    def save_item(self, item_id: str, data: dict[str, Any]) -> None:
         """Save an item to disk."""
         filepath = self.items_dir / f"{item_id}.json"
-        with open(filepath, 'w') as f:
+        with Path(filepath).open("w") as f:
             json.dump(data, f, default=str)
 
-    def load_item(self, item_id: str) -> Optional[Dict[str, Any]]:
+    def load_item(self, item_id: str) -> dict[str, Any] | None:
         """Load an item from disk."""
         filepath = self.items_dir / f"{item_id}.json"
         if filepath.exists():
-            with open(filepath, 'r') as f:
+            with Path(filepath).open() as f:
                 return json.load(f)
         return None
 
@@ -37,21 +37,21 @@ class LocalStorageManager:
             return True
         return False
 
-    def list_items(self) -> List[str]:
+    def list_items(self) -> list[str]:
         """List all item IDs."""
         return [f.stem for f in self.items_dir.glob("*.json")]
 
-    def save_link(self, link_id: str, data: Dict[str, Any]) -> None:
+    def save_link(self, link_id: str, data: dict[str, Any]) -> None:
         """Save a link to disk."""
         filepath = self.links_dir / f"{link_id}.json"
-        with open(filepath, 'w') as f:
+        with Path(filepath).open("w") as f:
             json.dump(data, f, default=str)
 
-    def load_link(self, link_id: str) -> Optional[Dict[str, Any]]:
+    def load_link(self, link_id: str) -> dict[str, Any] | None:
         """Load a link from disk."""
         filepath = self.links_dir / f"{link_id}.json"
         if filepath.exists():
-            with open(filepath, 'r') as f:
+            with Path(filepath).open() as f:
                 return json.load(f)
         return None
 
@@ -63,7 +63,7 @@ class LocalStorageManager:
             return True
         return False
 
-    def list_links(self) -> List[str]:
+    def list_links(self) -> list[str]:
         """List all link IDs."""
         return [f.stem for f in self.links_dir.glob("*.json")]
 
@@ -75,24 +75,21 @@ class ChangeDetector:
         self.storage = storage
         self._last_sync = datetime.now()
 
-    def detect_changes(self) -> List[Dict[str, Any]]:
+    def detect_changes(self) -> list[dict[str, Any]]:
         """Detect items changed since last sync."""
         # Simple implementation - returns empty list
         return []
 
     def mark_synced(self, item_id: str) -> None:
         """Mark an item as synced."""
-        pass
 
 
 class SyncQueue:
     """Queue for sync operations."""
-    pass
 
 
 class SyncEngine:
     """Sync engine for storage."""
-    pass
 
 
 class SyncState:
@@ -142,12 +139,10 @@ class Conflict:
 
 class ConflictBackup:
     """Backup for conflict resolution."""
-    pass
 
 
 class ConflictResolver:
     """Resolve conflicts between local and remote."""
-    pass
 
 
 class VectorClock:
@@ -159,7 +154,7 @@ class VectorClock:
         """Increment clock for a node."""
         self._clock[node] = self._clock.get(node, 0) + 1
 
-    def merge(self, other: 'VectorClock') -> None:
+    def merge(self, other: "VectorClock") -> None:
         """Merge with another clock."""
         for node, value in other._clock.items():
             self._clock[node] = max(self._clock.get(node, 0), value)
@@ -181,7 +176,6 @@ class OperationType:
 
 class QueuedChange:
     """Queued change for sync."""
-    pass
 
 
 class SyncResult:
@@ -193,32 +187,30 @@ class SyncResult:
 
 class SyncStateManager:
     """Manage sync state."""
-    pass
 
 
 class ResolvedEntity:
     """Resolved entity after conflict resolution."""
-    pass
 
 
 __all__ = [
-    "LocalStorageManager",
     "ChangeDetector",
-    "SyncQueue",
-    "SyncEngine",
-    "SyncState",
-    "SyncStatus",
-    "SyncResult",
-    "SyncStateManager",
-    "ConflictStrategy",
-    "ConflictStatus",
-    "EntityType",
-    "OperationType",
-    "QueuedChange",
     "Conflict",
     "ConflictBackup",
     "ConflictResolver",
-    "VectorClock",
+    "ConflictStatus",
+    "ConflictStrategy",
+    "EntityType",
     "EntityVersion",
+    "LocalStorageManager",
+    "OperationType",
+    "QueuedChange",
     "ResolvedEntity",
+    "SyncEngine",
+    "SyncQueue",
+    "SyncResult",
+    "SyncState",
+    "SyncStateManager",
+    "SyncStatus",
+    "VectorClock",
 ]

--- a/src/tracertm/tui/__init__.py
+++ b/src/tracertm/tui/__init__.py
@@ -1,10 +1,30 @@
 """Textual TUI (Terminal User Interface) for TraceRTM."""
 
-from tracertm.tui.apps.browser import BrowserApp
-from tracertm.tui.apps.dashboard_compat import EnhancedDashboardApp
-from tracertm.tui.apps.dashboard_compat import (
-    EnhancedDashboardApp as DashboardApp,
-)
-from tracertm.tui.apps.graph import GraphApp
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tracertm.tui.apps.browser import BrowserApp
+    from tracertm.tui.apps.dashboard_compat import EnhancedDashboardApp
+    from tracertm.tui.apps.graph import GraphApp
 
 __all__ = ["BrowserApp", "DashboardApp", "EnhancedDashboardApp", "GraphApp"]
+
+
+def __getattr__(name: str) -> object:
+    """Lazy-load apps so optional Textual is not required for widget utilities."""
+    if name in {"BrowserApp"}:
+        from tracertm.tui.apps.browser import BrowserApp
+
+        return BrowserApp
+    if name in {"DashboardApp", "EnhancedDashboardApp"}:
+        from tracertm.tui.apps.dashboard_compat import EnhancedDashboardApp
+
+        return EnhancedDashboardApp
+    if name == "GraphApp":
+        from tracertm.tui.apps.graph import GraphApp
+
+        return GraphApp
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/tracertm/tui/widgets/__init__.py
+++ b/src/tracertm/tui/widgets/__init__.py
@@ -4,10 +4,7 @@ from tracertm.tui.widgets.conflict_panel import ConflictPanel
 from tracertm.tui.widgets.graph_view import GraphViewWidget
 from tracertm.tui.widgets.item_list import ItemListWidget
 from tracertm.tui.widgets.state_display import StateDisplayWidget
-from tracertm.tui.widgets.sync_status import (
-    CompactSyncStatus,
-    SyncStatusWidget,
-)
+from tracertm.tui.widgets.sync_status import CompactSyncStatus, SyncStatusWidget
 from tracertm.tui.widgets.view_switcher import ViewSwitcherWidget
 
 try:  # noqa: RUF067

--- a/src/tracertm/tui/widgets/step_status_table.py
+++ b/src/tracertm/tui/widgets/step_status_table.py
@@ -3,7 +3,10 @@
 Displays DAG steps with status (pending/running/passed/failed/skipped) and duration.
 """
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 try:
     from textual.widgets import DataTable
@@ -38,8 +41,8 @@ def load_step_status() -> tuple[list[str], list[tuple[str, str, str]]]:  # noqa:
             data = json.loads(LAST_RUN_JSON.read_text())
             results = data.get("steps", {})
             step_details = data.get("step_details", {})
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Ignoring unreadable last-run.json at %s: %s", LAST_RUN_JSON, exc)
 
     def _fmt_duration(sec: float) -> str:
         if sec <= 0:

--- a/src/tracertm/tui/widgets/sync_status.py
+++ b/src/tracertm/tui/widgets/sync_status.py
@@ -332,3 +332,7 @@ if textual_available:
         def set_conflicts(self, count: int) -> None:
             """Set conflicts count."""
             self.conflicts_count = count
+
+else:
+    SyncStatusWidget = None  # type: ignore[misc, assignment]
+    CompactSyncStatus = None  # type: ignore[misc, assignment]

--- a/tests/unit/services/test_perf_optimizations.py
+++ b/tests/unit/services/test_perf_optimizations.py
@@ -1,0 +1,117 @@
+"""Targeted tests for performance optimizations on hot paths."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tracertm.testing_factories import ItemFactoryConfig, create_item, create_link
+
+
+@pytest.mark.asyncio
+async def test_matrix_generate_fetches_items_once() -> None:
+    """TraceabilityMatrixService should load project items in a single query."""
+    from tracertm.services.traceability_matrix_service import TraceabilityMatrixService
+
+    mock_session = MagicMock()
+    service = TraceabilityMatrixService(mock_session)
+
+    req = create_item(
+        config=ItemFactoryConfig(title="Req 1", view="requirements", item_type="requirements"),
+    )
+    test_item = create_item(
+        config=ItemFactoryConfig(title="Test 1", view="tests", item_type="tests"),
+    )
+    link = create_link(
+        source_item_id=str(req.id),
+        target_item_id=str(test_item.id),
+        link_type="traces_to",
+        project_id=str(req.project_id),
+    )
+
+    service.items.get_by_project = AsyncMock(return_value=[req, test_item])
+    service.links.get_by_project = AsyncMock(return_value=[link])
+
+    matrix = await service.generate_matrix(
+        str(req.project_id),
+        source_view="requirements",
+        target_view="tests",
+    )
+
+    service.items.get_by_project.assert_awaited_once()
+    assert len(matrix.rows) == 1
+    assert len(matrix.columns) == 1
+    assert matrix.matrix[0][0] == "traces_to"
+    assert matrix.total_links == 1
+
+
+@pytest.mark.asyncio
+async def test_traceability_generate_matrix_uses_project_links() -> None:
+    """TraceabilityService.generate_matrix should batch links via get_by_project."""
+    from tracertm.services.traceability_service import TraceabilityService
+
+    mock_session = MagicMock()
+    service = TraceabilityService(mock_session)
+
+    source = create_item(
+        config=ItemFactoryConfig(title="Feature A", view="feature", item_type="feature"),
+    )
+    target = create_item(
+        config=ItemFactoryConfig(title="Test A", view="test", item_type="test"),
+    )
+    link = create_link(
+        source_item_id=str(source.id),
+        target_item_id=str(target.id),
+        link_type="tests",
+        project_id=str(source.project_id),
+    )
+
+    service.items.get_by_view = AsyncMock(side_effect=[[source], [target]])
+    service.links.get_by_project = AsyncMock(return_value=[link])
+    service.links.get_by_source = AsyncMock()
+    service.items.get_by_id = AsyncMock()
+
+    matrix = await service.generate_matrix(
+        str(source.project_id),
+        source_view="feature",
+        target_view="test",
+    )
+
+    service.links.get_by_project.assert_awaited_once()
+    service.links.get_by_source.assert_not_awaited()
+    service.items.get_by_id.assert_not_awaited()
+    assert len(matrix.links) == 1
+    assert matrix.links[0]["source_title"] == "Feature A"
+    assert matrix.links[0]["target_title"] == "Test A"
+    assert matrix.coverage_percentage == 100.0
+
+
+@pytest.mark.asyncio
+async def test_analyze_query_performance_uses_cache() -> None:
+    """Repeated analyze_query_performance calls should not re-query the database."""
+    from tracertm.services.query_optimization_service import QueryOptimizationService
+
+    mock_session = MagicMock()
+    service = QueryOptimizationService(mock_session)
+
+    mock_items = [MagicMock(), MagicMock()]
+    service.items.query = AsyncMock(return_value=mock_items)
+
+    filters = {"status": "todo"}
+    first = await service.analyze_query_performance("project-123", filters)
+    second = await service.analyze_query_performance("project-123", filters)
+
+    service.items.query.assert_awaited_once()
+    assert first["items_returned"] == second["items_returned"] == 2
+    assert first["execution_time_seconds"] >= 0
+    assert second["execution_time_seconds"] == 0.0
+
+
+def test_query_cache_key_is_stable() -> None:
+    """Cache keys must be stable regardless of filter dict insertion order."""
+    from tracertm.services.query_optimization_service import QueryOptimizationService
+
+    key_a = QueryOptimizationService._query_cache_key("p1", {"status": "todo", "view": "feature"})
+    key_b = QueryOptimizationService._query_cache_key("p1", {"view": "feature", "status": "todo"})
+    assert key_a == key_b


### PR DESCRIPTION
## **User description**
Adds docs/tooling.md as a repo-local tooling reference covering the Python-first stack, declared CLI scripts, default and production-like docker compose services, MCP entrypoints, dev workflow, and testing commands. Also calls out that the checked-in makefiles are split and that the root tree does not currently define a root make quality target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Traceability matrix and MCP dispatch changes alter hot reporting paths; behavior is covered by new unit tests but still affects API/MCP consumers.
> 
> **Overview**
> Adds **`docs/tooling.md`** as the local dev quick reference (compose stacks, `Taskfile`/`package.json`, MCP mount rules, testing order) and **trims `CLAUDE.md`** toward build/test/branch workflow. **`docs/services/traceability_matrix_service.md`** gains a complete-polish status table for matrix/MCP work.
> 
> **Traceability backend:** `TraceabilityMatrix` gets **`to_dict()`**; matrix generation **loads project items once** and **`TraceabilityService.generate_matrix`** uses a **single `get_by_project` link pass** instead of per-source/per-target lookups. **`QueryOptimizationService.analyze_query_performance`** dedupes via a stable JSON cache key. MCP **`params/common.py`** routes **`trace_analyze`** to **`mcp.tools.traceability`** when importable.
> 
> **Frontend:** **`TraceabilityMatrixView`** surfaces **load errors** (`role="alert"`), **loading/empty test IDs**, and a **no-features** empty state; tests align with paginated hook shapes and add an error case. Docs app bumps **`js-yaml`**; root **`frontend/package.json`** drops **`packageManager`**.
> 
> **Housekeeping:** Modern **`AsyncGenerator[T]`** typing across API/MCP DB helpers, **lazy TUI app imports**, query perf **unit tests**, and minor storage/TUI widget fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62430ec0224618326362b76703b5e225e44b40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Speed up traceability views and make empty/error states clearer**

### What Changed
- The traceability matrix now loads faster by avoiding repeated data fetches and reusing cached query results for repeated lookups
- Traceability matrix and related traceability tools now return cleaner exported data, with rounded coverage values and more reliable matrix output
- The traceability matrix page now shows clearer loading, empty, and error states, including a direct message when data cannot be loaded and a separate empty state when there are no features to map
- Documentation was added and updated to describe the repo’s main tooling, commands, compose stacks, and agent workflow

### Impact
`✅ Faster traceability matrix loading`
`✅ Fewer repeated database queries`
`✅ Clearer traceability errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
