### PR TITLE
fix: remove go-backend, fix nats image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,7 +49,7 @@ services:
     cpus: '0.5'
 
   nats:
-    image: nats:2.10-alpine
+    image: nats:latest
     container_name: tracertm-nats
     command: nats-server -c /etc/nats/nats.conf -js
     ports:
@@ -250,55 +250,6 @@ services:
   #############################################################################
   # Application Services
   #############################################################################
-
-  go-backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    container_name: tracertm-go-backend
-    depends_on:
-      postgres:
-        condition: service_healthy
-      dragonfly:
-        condition: service_healthy
-      nats:
-        condition: service_healthy
-      temporal:
-        condition: service_healthy
-      tempo:
-        condition: service_healthy
-    environment:
-      PORT: 8080
-      GRPC_PORT: 9090
-      ENV: production
-      GIN_MODE: release
-      DATABASE_URL: postgres://tracertm:${DB_PASSWORD}@postgres:5432/tracertm?sslmode=disable
-      REDIS_URL: redis://dragonfly:6379
-      NATS_URL: nats://nats:4222
-      TEMPORAL_HOST: temporal:7233
-      PYTHON_BACKEND_URL: http://python-backend:8000
-      JWT_SECRET: ${JWT_SECRET}
-      CSRF_SECRET: ${CSRF_SECRET}
-      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID:-}
-      WORKOS_API_KEY: ${WORKOS_API_KEY:-}
-      WORKOS_AUTHKIT_DOMAIN: ${WORKOS_AUTHKIT_DOMAIN:-}
-      CORS_ALLOWED_ORIGINS: http://localhost,http://localhost:3000,http://localhost:5173
-      TRACING_ENABLED: "true"
-      TRACING_ENVIRONMENT: production
-      PHENO_OBSERVABILITY_OTLP_GRPC_ENDPOINT: tempo:4317
-    ports:
-      - "8080:8080"
-      - "9090:9090"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - tracertm
-    restart: unless-stopped
-    mem_limit: 512m
-    cpus: '2'
 
   python-backend:
     build:


### PR DESCRIPTION
## **User description**
Remove the Go backend service from the production compose file and update NATS to latest.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping `go-backend` breaks API routing unless callers are repointed, and `nats:latest` adds version drift versus the previous pinned image.
> 
> **Overview**
> **Production compose** no longer defines the **`go-backend`** service (build, ports **8080/9090**, healthcheck, and its env wiring to Postgres, Dragonfly, NATS, Temporal, Tempo, WorkOS, JWT, etc.). **`python-backend`** becomes the first application service in that section.
> 
> **NATS** image tag changes from **`nats:2.10-alpine`** to **`nats:latest`**, so prod-like local runs track the moving **`latest`** tag instead of a pinned minor release.
> 
> This PR does **not** update **`GO_BACKEND_URL`** on **`python-backend`** or **`VITE_API_URL`** on **`frontend`**, which still reference **`http://go-backend:8080`** and **`http://localhost:8080`** respectively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79cf3ca2f30ec22ca2923e4ae3bf916a50843635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Remove the Go backend from production and update NATS to the latest image**

### What Changed
- Production compose now starts the Python backend without the Go backend service
- NATS now uses the latest image instead of a pinned older version

### Impact
`✅ Simpler production startup`
`✅ Fewer unused services running in production`
`✅ Updated NATS runtime`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NATS message broker service to the latest version in production deployment
  * Removed Go backend service from production Docker Compose configuration, including associated dependencies and health checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KooshaPari/Tracera/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->