### PR TITLE
fix: post-453 export guards, MCP test, DB URL messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,7 @@ services:
 
   # NATS Message Broker
   nats:
-    image: nats:latest
+    image: nats:2.10.15-alpine
     container_name: tracertm-nats
     ports:
       - "4222:4222" # Client connections

--- a/frontend/apps/web/src/__tests__/views/TraceabilityMatrixView.test.tsx
+++ b/frontend/apps/web/src/__tests__/views/TraceabilityMatrixView.test.tsx
@@ -153,7 +153,7 @@ describe(TraceabilityMatrixView, () => {
     expect(screen.getByRole('button', { name: /export csv/i })).toBeInTheDocument();
   });
 
-  it('blocks export when matrix has no rows or columns', () => {
+  it('disables export when matrix has no rows or columns', () => {
     mockItems();
     mockLinks();
 
@@ -163,10 +163,44 @@ describe(TraceabilityMatrixView, () => {
       </QueryClientProvider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
-    expect(toast.error).toHaveBeenCalledWith(
-      'Nothing to export — add requirements and features first',
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('disables export when only requirements exist', () => {
+    mockItems({
+      data: {
+        items: [{ id: 'req-1', title: 'Requirement 1', type: 'requirement' }],
+        total: 1,
+      },
+    });
+    mockLinks();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TraceabilityMatrixView projectId='proj-test' />
+      </QueryClientProvider>,
     );
+
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
+  });
+
+  it('disables export when only features exist', () => {
+    mockItems({
+      data: {
+        items: [{ id: 'feat-1', title: 'Feature 1', type: 'feature' }],
+        total: 1,
+      },
+    });
+    mockLinks();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TraceabilityMatrixView projectId='proj-test' />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
   });
 
   it('handles empty state', () => {

--- a/frontend/apps/web/src/views/TraceabilityMatrixView.tsx
+++ b/frontend/apps/web/src/views/TraceabilityMatrixView.tsx
@@ -124,31 +124,55 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
     return Math.round((covered / matrix.requirements.length) * 100);
   }, [matrix]);
 
+  const canExport =
+    matrix.requirements.length > 0 && matrix.features.length > 0;
+
   const handleExportCsv = useCallback(async () => {
     if (matrix.requirements.length === 0 && matrix.features.length === 0) {
       toast.error('Nothing to export — add requirements and features first');
       return;
     }
+    if (matrix.requirements.length === 0) {
+      toast.error('Nothing to export — add requirements first');
+      return;
+    }
+    if (matrix.features.length === 0) {
+      toast.error('Nothing to export — add features first');
+      return;
+    }
 
-    const firstReq = matrix.requirements[0] as { view?: string; type?: string };
-    const firstFeat = matrix.features[0] as { view?: string; type?: string };
-    const exportOptions = {
-      sourceView: firstReq.type ?? firstReq.view,
-      targetView: firstFeat.type ?? firstFeat.view,
-    };
+    const firstReq = matrix.requirements[0] as
+      | { view?: string; type?: string }
+      | undefined;
+    const firstFeat = matrix.features[0] as
+      | { view?: string; type?: string }
+      | undefined;
+    const sourceView = firstReq?.type ?? firstReq?.view;
+    const targetView = firstFeat?.type ?? firstFeat?.view;
+    if (!sourceView || !targetView) {
+      toast.error('Nothing to export — matrix views are not configured');
+      return;
+    }
+
+    const exportOptions = { sourceView, targetView };
 
     setIsExporting(true);
     try {
       await downloadTraceMatrixFromApi(projectId, exportOptions);
       toast.success('Matrix exported to CSV');
     } catch {
-      const csv = buildTraceabilityMatrixCsv(
-        matrix.requirements.map((r) => ({ id: r.id, title: r.title })),
-        matrix.features.map((f) => ({ id: f.id, title: f.title })),
-        matrix.coverage,
-      );
-      downloadTraceabilityMatrixCsv(csv, projectId);
-      toast.success('Matrix exported to CSV (from current view)');
+      try {
+        const csv = buildTraceabilityMatrixCsv(
+          matrix.requirements.map((r) => ({ id: r.id, title: r.title })),
+          matrix.features.map((f) => ({ id: f.id, title: f.title })),
+          matrix.coverage,
+        );
+        downloadTraceabilityMatrixCsv(csv, projectId);
+        toast.success('Matrix exported to CSV (from current view)');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Export failed';
+        toast.error(`Could not export matrix: ${message}`);
+      }
     } finally {
       setIsExporting(false);
     }
@@ -211,7 +235,7 @@ export function TraceabilityMatrixView({ projectId }: TraceabilityMatrixViewProp
           variant='outline'
           size='sm'
           className='gap-2 rounded-lg font-mono text-xs tracking-wider uppercase'
-          disabled={isExporting}
+          disabled={isExporting || !canExport}
           onClick={() => {
             void handleExportCsv();
           }}

--- a/frontend/apps/web/vite.config.mjs
+++ b/frontend/apps/web/vite.config.mjs
@@ -411,7 +411,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         changeOrigin: true,
-        target: 'http://localhost:8080',
+        target: 'http://localhost:8000',
       },
     },
     // Warm up frequently used files

--- a/src/tracertm/config/schema.py
+++ b/src/tracertm/config/schema.py
@@ -92,7 +92,8 @@ class Config(BaseModel):
         if not v.startswith(allowed_prefixes):
             msg = (
                 "Database URL must start with 'postgresql://', "
-                "'postgresql+asyncpg://', or 'sqlite:///'"
+                "'postgresql+asyncpg://', 'postgresql+psycopg://', "
+                "'postgresql+psycopg2://', or 'sqlite:///'"
             )
             raise ValueError(msg)
 

--- a/src/tracertm/config/settings.py
+++ b/src/tracertm/config/settings.py
@@ -43,7 +43,8 @@ class DatabaseSettings(BaseSettings):
         if not v.startswith(allowed_prefixes):
             msg = (
                 "Database URL must start with 'postgresql://', "
-                "'postgresql+asyncpg://', or 'sqlite:///'"
+                "'postgresql+asyncpg://', 'postgresql+psycopg://', "
+                "'postgresql+psycopg2://', or 'sqlite:///'"
             )
             raise ValueError(msg)
         return v

--- a/tests/unit/mcp/test_async_database.py
+++ b/tests/unit/mcp/test_async_database.py
@@ -84,10 +84,11 @@ async def test_get_mcp_session_sets_rls_context(mocker: Any) -> None:
 @pytest.mark.asyncio
 async def test_get_mcp_session_commits_on_success() -> None:
     """Test that session commits changes on successful execution."""
+    project_id = str(uuid4())
     async with get_mcp_session() as session:
         # Create a test project
         project = Project(
-            id=str(uuid4()),
+            id=project_id,
             name="Test Project",
             description="Test",
         )
@@ -96,7 +97,7 @@ async def test_get_mcp_session_commits_on_success() -> None:
 
     # Verify project was committed
     async with get_mcp_session() as session:
-        result = await session.execute(select(Project).filter(Project.id == "test-project-1"))
+        result = await session.execute(select(Project).filter(Project.id == project_id))
         saved_project = result.scalar_one_or_none()
         assert saved_project is not None
         assert saved_project.name == "Test Project"


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #453 (deferred review + main CI).

- TraceabilityMatrixView: disable export unless both axes exist; guard view types; safe local CSV fallback
- test_async_database.py: query the inserted project id on commit verification
- schema/settings: complete database URL scheme list in validation errors

## Test plan

- Vitest TraceabilityMatrixView (9 tests) — pass locally
- Ruff on changed Python — pass


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI export guards, dev/proxy/docker pinning, validation copy, and a unit test fix; no auth, data migration, or production API behavior changes beyond export edge cases.
> 
> **Overview**
> **Traceability matrix CSV export** is tightened: the button stays **disabled** unless both requirements and features exist (`canExport`), so users no longer click export and get a toast on empty or one-sided matrices. Export still validates **source/target views** before calling the API, uses clearer toasts when an axis or views are missing, and wraps the **local CSV fallback** in an inner try/catch so a failed fallback surfaces an error instead of failing silently. Vitest expectations move from “click → error toast” to **disabled button**, with new cases for requirements-only and features-only.
> 
> **Local dev** aligns the Vite `/api` proxy with the backend on **port 8000** (was 8080). **Docker Compose** pins NATS to **`nats:2.10.15-alpine`** instead of `latest`.
> 
> **Database URL validation** error text in `schema.py` and `settings.py` now lists **`postgresql+psycopg://`** and **`postgresql+psycopg2://`** alongside the schemes already accepted.
> 
> **MCP async DB test** `test_get_mcp_session_commits_on_success` reuses the inserted project’s UUID when verifying commit instead of a hard-coded id that never matched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aeb037a2cf3d2b8706b6a90eb57dd828fe2bce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Tighten traceability matrix export checks and clarify database URL errors**

### What Changed
- The CSV export button is now disabled unless the matrix has both requirements and features, and it no longer triggers an error after clicking in incomplete states
- Export now gives a clearer message when requirements are missing, features are missing, or the matrix cannot be exported because its views are not set up
- If the API export fails, the page falls back to a local CSV export; if that also fails, it now shows the error instead of silently stopping
- Test coverage was updated to verify export is disabled when only requirements or only features are present
- Database URL validation messages now list all accepted PostgreSQL and SQLite formats

### Impact
`✅ Fewer failed export attempts`
`✅ Clearer export error messages`
`✅ Less confusion with incomplete traceability matrices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
