### PR TITLE
fix(tests): add underscore-prefixed aliases for chaos proxy fixtures

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -169,6 +169,18 @@ async def python_backend_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenera
 
 
 @pytest.fixture
+async def _postgres_proxy(postgres_proxy: str) -> str:
+    """Alias for postgres_proxy with underscore prefix (pytest convention for unused fixtures)."""
+    return postgres_proxy
+
+
+@pytest.fixture
+async def _redis_proxy(redis_proxy: str) -> str:
+    """Alias for redis_proxy with underscore prefix (pytest convention for unused fixtures)."""
+    return redis_proxy
+
+
+@pytest.fixture
 async def db_session(postgres_proxy: str) -> AsyncGenerator[AsyncSession, None]:
     """Provides a database session through the Toxiproxy proxy."""
     engine = create_async_engine(postgres_proxy, echo=False)


### PR DESCRIPTION
## **User description**
## Summary

- `conftest.py` defined `postgres_proxy` and `redis_proxy` fixtures (no underscore)
- All three chaos test files (`test_connection_failures.py`, `test_end_to_end_resilience.py`, `test_network_latency.py`) plus `test_resource_exhaustion.py` requested `_postgres_proxy` and `_redis_proxy` (with leading underscore — pytest convention for fixtures injected purely for side effects, not used as a value)
- Added `_postgres_proxy` and `_redis_proxy` as thin aliases in `conftest.py` that delegate to the original fixtures, so both the underscore and non-underscore names resolve correctly

This unblocks CI on PR #451 (Dependabot npm/yarn bump), which was failing on pre-existing stale fixture name mismatches rather than any regression from the dependency update.

## Test plan

- [ ] CI chaos test suite runs without fixture-not-found errors for `_postgres_proxy` / `_redis_proxy`
- [ ] Existing fixtures `postgres_proxy`, `redis_proxy`, `db_session`, `redis_client` are unaffected
- [ ] PR #451 CI passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only conftest wiring with no production or runtime behavior changes.
> 
> **Overview**
> Adds **`_postgres_proxy`** and **`_redis_proxy`** fixtures in `tests/chaos/conftest.py` as thin async aliases that return the same connection strings as the existing **`postgres_proxy`** and **`redis_proxy`** Toxiproxy fixtures.
> 
> Chaos tests already depend on the underscore names (pytest convention when the fixture is only needed to spin up the proxy, not as a test argument value). Without these aliases, collection fails with missing-fixture errors while **`db_session`** / **`redis_client`** keep using the non-underscore fixtures unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ac09e83293ba1f66d6f0da1c37f358315d8738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix chaos tests that could not find proxy fixtures**

### What Changed
- Added underscore-prefixed aliases for the PostgreSQL and Redis chaos proxy fixtures so tests that request side-effect-only fixtures now run without errors
- Kept the existing non-underscored proxy fixtures intact for the database session and Redis client setup

### Impact
`✅ Fewer chaos test fixture errors`
`✅ CI runs through proxy-based test setup`
`✅ No change to existing database and Redis test behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
