### PR TITLE
feat(trace-link): canonical TraceLink/Requirement/Artifact domain + Neo4j schema (P0)

### DIFF
--- a/alembic/versions/062_add_trace_link_fields.py
+++ b/alembic/versions/062_add_trace_link_fields.py
@@ -1,0 +1,56 @@
+"""Add confidence and rationale columns to the links table.
+
+These two fields are the SOTA-research P0 first-class fields on a trace
+link: ``confidence`` (miner posterior in [0, 1], defaulting to 1.0 for
+human-curated links) and ``rationale`` (short natural-language
+justification). They live as proper columns rather than inside
+``link_metadata`` so they can be indexed and filtered cheaply by the
+RAG / explainability layer.
+
+Revision ID: 062_add_trace_link_fields
+Revises: 061_add_agent_tasks
+Create Date: 2026-05-28
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "062_add_trace_link_fields"
+down_revision = "061_add_agent_tasks"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add confidence + rationale columns to links and a confidence index."""
+    op.execute("""
+        ALTER TABLE links
+        ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION
+            NOT NULL DEFAULT 1.0
+    """)
+    op.execute("""
+        ALTER TABLE links
+        ADD CONSTRAINT links_confidence_range
+        CHECK (confidence >= 0.0 AND confidence <= 1.0)
+    """)
+    op.execute("""
+        ALTER TABLE links
+        ADD COLUMN IF NOT EXISTS rationale TEXT
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_links_confidence
+        ON links(confidence)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_links_project_type_confidence
+        ON links(project_id, link_type, confidence DESC)
+    """)
+
+
+def downgrade() -> None:
+    """Drop the confidence / rationale columns and their indexes."""
+    op.execute("DROP INDEX IF EXISTS idx_links_project_type_confidence")
+    op.execute("DROP INDEX IF EXISTS idx_links_confidence")
+    op.execute("ALTER TABLE links DROP COLUMN IF EXISTS rationale")
+    op.execute("ALTER TABLE links DROP CONSTRAINT IF EXISTS links_confidence_range")
+    op.execute("ALTER TABLE links DROP COLUMN IF EXISTS confidence")

--- a/src/tracertm/models/_exports.py
+++ b/src/tracertm/models/_exports.py
@@ -22,6 +22,18 @@ from tracertm.models.item import Item
 from tracertm.models.item_view import ItemView
 from tracertm.models.link import Link
 from tracertm.models.link_type import LinkType
+from tracertm.models.trace_link import (
+    NEO4J_NODE_LABELS,
+    NEO4J_RELATIONSHIP_TYPES,
+    Artifact,
+    ArtifactKind,
+    Neo4jSchema,
+    Requirement,
+    RequirementStatus,
+    TraceLink,
+    TraceLinkType,
+    VerificationMethod,
+)
 from tracertm.models.node_kind import NodeKind
 from tracertm.models.node_kind_rule import NodeKindRule
 from tracertm.models.problem import Problem, ProblemActivity
@@ -234,6 +246,8 @@ __all__ = [
     "AgentEvent",
     "AgentLock",
     "AgentSession",
+    "Artifact",
+    "ArtifactKind",
     "Base",
     "Baseline",
     "BaselineItem",
@@ -271,6 +285,9 @@ __all__ = [
     "Link",
     "LinkType",
     "MerkleProofCache",
+    "NEO4J_NODE_LABELS",
+    "NEO4J_RELATIONSHIP_TYPES",
+    "Neo4jSchema",
     "NodeKind",
     "NodeKindRule",
     "Problem",
@@ -278,8 +295,10 @@ __all__ = [
     "Process",
     "ProcessExecution",
     "Project",
+    "Requirement",
     "RequirementQuality",
     "RequirementSpec",
+    "RequirementStatus",
     "RequirementType",
     "RiskLevel",
     "Scenario",
@@ -299,8 +318,11 @@ __all__ = [
     "TestSuiteActivity",
     "TestSuiteTestCase",
     "TestType",
+    "TraceLink",
+    "TraceLinkType",
     "User",
     "UserStorySpec",
+    "VerificationMethod",
     "VerificationStatus",
     "VersionBlock",
     "VersionChainIndex",

--- a/src/tracertm/models/link.py
+++ b/src/tracertm/models/link.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKey, Index, String
+from sqlalchemy import CheckConstraint, Float, ForeignKey, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from tracertm.models.base import GUID, Base, TimestampMixin
@@ -31,6 +31,9 @@ class Link(Base, TimestampMixin):
         Index("idx_links_source_target", "source_item_id", "target_item_id"),
         Index("idx_links_project_type", "project_id", "link_type"),
         Index("idx_links_project_graph", "project_id", "graph_id"),
+        Index("idx_links_confidence", "confidence"),
+        Index("idx_links_project_type_confidence", "project_id", "link_type", "confidence"),
+        CheckConstraint("confidence >= 0.0 AND confidence <= 1.0", name="links_confidence_range"),
         {"extend_existing": True},
     )
 
@@ -65,6 +68,12 @@ class Link(Base, TimestampMixin):
 
     link_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     link_metadata: Mapped[dict[str, object]] = mapped_column(JSONType, nullable=False, default=dict)
+
+    # SOTA-research P0 trace-link fields. ``confidence`` is the miner's
+    # posterior in [0, 1] (1.0 = human-curated); ``rationale`` is a short
+    # natural-language justification used by the explainability / RAG layer.
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     source_item: Mapped[Item] = relationship(

--- a/src/tracertm/models/trace_link.py
+++ b/src/tracertm/models/trace_link.py
@@ -1,0 +1,302 @@
+"""Trace-link domain model for SOTA research P0.
+
+This module is the *canonical* domain layer for the requirements-traceability
+spine. It sits on top of the existing generic ``Item``/``Link`` SQL models
+(``tracertm.models.item.Item`` and ``tracertm.models.link.Link``) and adds:
+
+* A canonical :class:`TraceLinkType` enum (SATISFIES, VERIFIES, IMPLEMENTS,
+  DERIVES_FROM, REFINES, CONFLICTS_WITH, DUPLICATES) used by both the SQL
+  ``links.link_type`` column and the Neo4j relationship label.
+* A canonical :class:`ArtifactKind` enum partitioning Items into the
+  traceability roles relevant for ISO 29148 / DO-178C / IEC 62304 style
+  traces (REQUIREMENT, DESIGN, CODE, TEST, EVIDENCE, RISK, RATIONALE).
+* Lightweight Pydantic value objects (:class:`TraceLink`,
+  :class:`Requirement`, :class:`Artifact`) used at API and RAG boundaries.
+  These are *not* ORM models — the SQL persistence already lives in
+  :mod:`tracertm.models.link` and :mod:`tracertm.models.item`. The
+  dataclasses here are the wire-format / pipeline-format the upcoming
+  RAG, miner and query layers (later PRs) will operate on.
+* :class:`Neo4jSchema`: declarative Cypher schema (constraints, indexes,
+  relationship labels) for the graph projection.
+
+Persistence note: the existing ``links`` table already covers source/target
+ids and a free-form ``link_metadata`` JSONB. The two new SOTA-research
+fields — ``confidence`` (float 0..1) and ``rationale`` (text) — are added
+as first-class columns by alembic revision ``062_add_trace_link_fields`` so
+they can be indexed and filtered without JSON-path queries.
+
+Functional Requirements: FR-TRACE-001 (canonical link types),
+FR-TRACE-002 (confidence-scored trace links), FR-TRACE-003 (Neo4j
+projection of the traceability graph).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Final
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+__all__ = [
+    "ArtifactKind",
+    "TraceLinkType",
+    "RequirementStatus",
+    "VerificationMethod",
+    "Artifact",
+    "Requirement",
+    "TraceLink",
+    "Neo4jSchema",
+    "NEO4J_RELATIONSHIP_TYPES",
+    "NEO4J_NODE_LABELS",
+]
+
+
+# ---------------------------------------------------------------------------
+# Enums (canonical vocabulary shared by SQL, Neo4j and API layers)
+# ---------------------------------------------------------------------------
+
+
+class TraceLinkType(StrEnum):
+    """Canonical trace-link relationship vocabulary.
+
+    Values are the *exact* strings used as both the SQL ``links.link_type``
+    column value and the Neo4j relationship label. Keep them SCREAMING_SNAKE
+    so they round-trip cleanly through Cypher.
+
+    Semantic mapping (ISO 29148 § 5.2.6 + DO-178C Table A-3):
+
+    * ``SATISFIES``     — implementation/design artifact satisfies a requirement
+    * ``VERIFIES``      — test/evidence verifies a requirement (forward V-model)
+    * ``IMPLEMENTS``    — code artifact implements a design/spec element
+    * ``DERIVES_FROM``  — derived requirement (parent → child decomposition)
+    * ``REFINES``       — peer refinement at the same abstraction level
+    * ``CONFLICTS_WITH``— mutually exclusive / contradictory requirements
+    * ``DUPLICATES``    — semantic-equivalence link found by the miner
+    """
+
+    SATISFIES = "SATISFIES"
+    VERIFIES = "VERIFIES"
+    IMPLEMENTS = "IMPLEMENTS"
+    DERIVES_FROM = "DERIVES_FROM"
+    REFINES = "REFINES"
+    CONFLICTS_WITH = "CONFLICTS_WITH"
+    DUPLICATES = "DUPLICATES"
+
+
+#: Core P0 subset called out in the SOTA research brief.
+#: The miner / RAG layer (next PR) only needs to score these four.
+CORE_TRACE_LINK_TYPES: Final[frozenset[TraceLinkType]] = frozenset({
+    TraceLinkType.SATISFIES,
+    TraceLinkType.VERIFIES,
+    TraceLinkType.IMPLEMENTS,
+    TraceLinkType.DERIVES_FROM,
+})
+
+
+class ArtifactKind(StrEnum):
+    """Role of an :class:`Artifact` inside the traceability graph.
+
+    Maps to the ``items.type`` discriminator on the SQL side and to the
+    Neo4j node label (``:Requirement``, ``:Test``, …) on the graph side.
+    """
+
+    REQUIREMENT = "requirement"
+    DESIGN = "design"
+    CODE = "code"
+    TEST = "test"
+    EVIDENCE = "evidence"
+    RISK = "risk"
+    RATIONALE = "rationale"
+
+
+class RequirementStatus(StrEnum):
+    """Lifecycle states for a :class:`Requirement` (ISO 29148 § 5.2.8)."""
+
+    DRAFT = "draft"
+    PROPOSED = "proposed"
+    APPROVED = "approved"
+    IMPLEMENTED = "implemented"
+    VERIFIED = "verified"
+    DEPRECATED = "deprecated"
+    REJECTED = "rejected"
+
+
+class VerificationMethod(StrEnum):
+    """DO-178C / IEEE 1012 verification methods used on VERIFIES links."""
+
+    TEST = "test"
+    ANALYSIS = "analysis"
+    INSPECTION = "inspection"
+    DEMONSTRATION = "demonstration"
+    REVIEW = "review"
+
+
+# ---------------------------------------------------------------------------
+# Value objects (Pydantic, used at API / RAG / mining boundaries)
+# ---------------------------------------------------------------------------
+
+
+class Artifact(BaseModel):
+    """Any node in the traceability graph (super-type of Requirement).
+
+    Mirrors :class:`tracertm.models.item.Item` for the subset of fields the
+    trace-link layer needs. ``id`` is the same UUID as ``items.id``.
+    """
+
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    kind: ArtifactKind
+    title: str = Field(min_length=1, max_length=500)
+    description: str | None = None
+    external_id: str | None = Field(default=None, max_length=255)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class Requirement(Artifact):
+    """A traceable requirement.
+
+    Specialisation of :class:`Artifact` with ``kind`` pinned to
+    :attr:`ArtifactKind.REQUIREMENT` and the ISO 29148 lifecycle fields the
+    quality analyser (:mod:`tracertm.models.requirement_quality`) reads.
+    """
+
+    kind: ArtifactKind = ArtifactKind.REQUIREMENT
+    status: RequirementStatus = RequirementStatus.DRAFT
+    priority: int | None = Field(default=None, ge=0, le=5)
+    rationale: str | None = None
+    acceptance_criteria: list[str] = Field(default_factory=list)
+    verification_method: VerificationMethod | None = None
+
+    @field_validator("kind")
+    @classmethod
+    def _kind_must_be_requirement(cls, v: ArtifactKind) -> ArtifactKind:
+        if v is not ArtifactKind.REQUIREMENT:
+            msg = f"Requirement.kind must be REQUIREMENT, got {v!r}"
+            raise ValueError(msg)
+        return v
+
+
+class TraceLink(BaseModel):
+    """A confidence-scored directed edge in the traceability graph.
+
+    Direction is ``source_artifact_id ──link_type──▶ target_artifact_id``.
+    For example, a SATISFIES link runs *from* the implementing artifact
+    *to* the requirement it satisfies::
+
+        CodeFile ──SATISFIES──▶ Requirement
+        TestCase ──VERIFIES──▶ Requirement
+        ChildReq ──DERIVES_FROM──▶ ParentReq
+
+    ``confidence`` is the miner's posterior probability that the link is
+    correct (``1.0`` for human-curated links). ``rationale`` is a short
+    natural-language justification, used both for explainability and as
+    grounding context for the RAG layer.
+    """
+
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    project_id: uuid.UUID
+    source_artifact_id: uuid.UUID
+    target_artifact_id: uuid.UUID
+    link_type: TraceLinkType
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    rationale: str | None = Field(default=None, max_length=4000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def _no_self_loops(self) -> TraceLink:
+        if self.source_artifact_id == self.target_artifact_id:
+            msg = "TraceLink source_artifact_id and target_artifact_id must differ"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def is_core(self) -> bool:
+        """True if this link uses one of the P0 SOTA link types."""
+        return self.link_type in CORE_TRACE_LINK_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Neo4j schema
+# ---------------------------------------------------------------------------
+
+
+#: Neo4j relationship labels. Kept in sync with :class:`TraceLinkType` so
+#: the projection layer can do ``rel_type = link.link_type.value``.
+NEO4J_RELATIONSHIP_TYPES: Final[tuple[str, ...]] = tuple(t.value for t in TraceLinkType)
+
+#: Neo4j node labels (one per ArtifactKind, plus the umbrella ``Artifact``).
+NEO4J_NODE_LABELS: Final[tuple[str, ...]] = (
+    "Artifact",
+    "Requirement",
+    "Design",
+    "Code",
+    "Test",
+    "Evidence",
+    "Risk",
+    "Rationale",
+    "Project",
+)
+
+
+class Neo4jSchema:
+    """Declarative Cypher schema for the trace-link graph projection.
+
+    Apply once at startup (idempotent — all statements use IF NOT EXISTS).
+    The schema deliberately uses *node-key* constraints on
+    ``(project_id, id)`` so the same UUID can theoretically be reused
+    across tenants without collisions.
+    """
+
+    #: Uniqueness / existence constraints.
+    CONSTRAINTS: Final[tuple[str, ...]] = (
+        # Every Artifact must have an id and project_id, unique per project.
+        "CREATE CONSTRAINT artifact_node_key IF NOT EXISTS "
+        "FOR (a:Artifact) REQUIRE (a.project_id, a.id) IS NODE KEY",
+        "CREATE CONSTRAINT requirement_id_unique IF NOT EXISTS "
+        "FOR (r:Requirement) REQUIRE r.id IS UNIQUE",
+        "CREATE CONSTRAINT project_id_unique IF NOT EXISTS "
+        "FOR (p:Project) REQUIRE p.id IS UNIQUE",
+        # Every trace edge must carry a confidence in [0,1].
+        "CREATE CONSTRAINT trace_link_confidence_exists IF NOT EXISTS "
+        "FOR ()-[l:SATISFIES|VERIFIES|IMPLEMENTS|DERIVES_FROM|"
+        "REFINES|CONFLICTS_WITH|DUPLICATES]-() "
+        "REQUIRE l.confidence IS NOT NULL",
+    )
+
+    #: Lookup / range indexes for the common RAG-side queries.
+    INDEXES: Final[tuple[str, ...]] = (
+        "CREATE INDEX artifact_project_kind IF NOT EXISTS "
+        "FOR (a:Artifact) ON (a.project_id, a.kind)",
+        "CREATE INDEX artifact_external_id IF NOT EXISTS "
+        "FOR (a:Artifact) ON (a.external_id)",
+        "CREATE INDEX requirement_status IF NOT EXISTS "
+        "FOR (r:Requirement) ON (r.status)",
+        "CREATE FULLTEXT INDEX artifact_text IF NOT EXISTS "
+        "FOR (a:Artifact) ON EACH [a.title, a.description]",
+    )
+
+    @classmethod
+    def all_statements(cls) -> tuple[str, ...]:
+        """All DDL statements in apply order (constraints before indexes)."""
+        return cls.CONSTRAINTS + cls.INDEXES
+
+    @classmethod
+    def relationship_label_for(cls, link_type: TraceLinkType) -> str:
+        """Return the Neo4j relationship label for a given TraceLinkType."""
+        return link_type.value
+
+    @classmethod
+    def node_label_for(cls, kind: ArtifactKind) -> str:
+        """Return the primary Neo4j node label for a given ArtifactKind."""
+        # Title-case mapping matches NEO4J_NODE_LABELS above.
+        return kind.value.capitalize()

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -169,6 +169,18 @@ async def python_backend_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenera
 
 
 @pytest.fixture
+async def _postgres_proxy(postgres_proxy: str) -> str:
+    """Alias for postgres_proxy with underscore prefix (pytest convention for unused fixtures)."""
+    return postgres_proxy
+
+
+@pytest.fixture
+async def _redis_proxy(redis_proxy: str) -> str:
+    """Alias for redis_proxy with underscore prefix (pytest convention for unused fixtures)."""
+    return redis_proxy
+
+
+@pytest.fixture
 async def db_session(postgres_proxy: str) -> AsyncGenerator[AsyncSession, None]:
     """Provides a database session through the Toxiproxy proxy."""
     engine = create_async_engine(postgres_proxy, echo=False)


### PR DESCRIPTION
## **User description**
## Summary

Locks in the SOTA-research **P0** traceability schema on top of the existing generic `Item` / `Link` SQL models. RAG, mining, and query implementations land in follow-up PRs — this PR is schema-only so the rest of the work can fan out in parallel.

- New module `src/tracertm/models/trace_link.py`:
  - `TraceLinkType` enum — canonical vocabulary (`SATISFIES`, `VERIFIES`, `IMPLEMENTS`, `DERIVES_FROM`, `REFINES`, `CONFLICTS_WITH`, `DUPLICATES`) shared by SQL `links.link_type`, Neo4j relationship label, and API layer. `CORE_TRACE_LINK_TYPES` exposes the 4-link P0 subset the miner needs.
  - `ArtifactKind` enum partitioning Items by traceability role (`REQUIREMENT`/`DESIGN`/`CODE`/`TEST`/`EVIDENCE`/`RISK`/`RATIONALE`).
  - Pydantic value objects `Artifact`, `Requirement` (ISO 29148 `status` + `verification_method` + `acceptance_criteria`), and `TraceLink` with `confidence` in `[0, 1]`, `rationale`, model-level self-loop rejection, and `is_core` helper.
  - `Neo4jSchema` — idempotent Cypher DDL: node-key on `(project_id, id)`, uniqueness on `Requirement.id` / `Project.id`, REQUIRE-confidence on every trace relationship, range indexes on `kind` / `external_id` / `status`, fulltext on `title` + `description`. Helpers `relationship_label_for(...)` and `node_label_for(...)` keep SQL ↔ graph projections in sync.
- Alembic `062_add_trace_link_fields`: adds `confidence DOUBLE PRECISION NOT NULL DEFAULT 1.0` (with `CHECK 0..1`), `rationale TEXT`, and the `(project_id, link_type, confidence DESC)` index the RAG layer will need.
- `Link` ORM model picks up the new columns + matching `CheckConstraint` + indexes.
- Wired into `tracertm.models` package exports.

## Rationale

`confidence` and `rationale` are first-class columns rather than `link_metadata` JSON keys so they can be indexed and filtered cheaply during retrieval and explainability — they will be on the hot path for the upcoming miner posterior + RAG grounding layers.

## Test plan

- [x] Module imports cleanly (`PYTHONPATH=src python -c "from tracertm.models import TraceLink, ..."`).
- [x] `TraceLink` rejects self-loops (source == target).
- [x] `TraceLink` rejects `confidence` outside `[0, 1]`.
- [x] `Requirement.kind` pinned to `REQUIREMENT`.
- [x] `Neo4jSchema.all_statements()` returns 8 DDL statements.
- [ ] Apply alembic `062` against staging Postgres; confirm CHECK + indexes.
- [ ] Apply `Neo4jSchema.all_statements()` to a fresh Neo4j 5; confirm idempotent re-apply.
- [ ] Follow-up: miner writes posterior confidence into `links.confidence` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a non-null DB column with safe defaults on `links`, but migration rollout and future reliance on confidence for retrieval make schema correctness important; API/miner wiring is still follow-up.
> 
> **Overview**
> Introduces the **P0 trace-link schema** on top of existing `Item` / `Link` persistence: miner-facing **`confidence`** (0–1, default 1.0) and **`rationale`** as first-class `links` columns (Alembic `062` + matching ORM indexes/check constraint) instead of JSON metadata, so RAG and explainability can filter and rank edges cheaply.
> 
> Adds **`tracertm.models.trace_link`**: shared enums (`TraceLinkType`, `ArtifactKind`, requirement lifecycle/verification), frozen Pydantic **`Artifact` / `Requirement` / `TraceLink`** wire types (with self-loop and confidence validation), and **`Neo4jSchema`** idempotent Cypher DDL plus label helpers for graph projection. Public model exports are extended accordingly.
> 
> Chaos tests gain underscore-prefixed **aliases** for postgres/redis Toxiproxy fixtures only; no runtime behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31592dae891c03e0daf0da7cf536dfbeadec0b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add a shared traceability model with confidence-scored links

### What Changed
- Added a common traceability vocabulary for requirements, design, code, tests, evidence, risks, and rationale so links and graph data use the same terms
- Trace links can now store a confidence score and a short rationale, and they reject links that point to the same item on both ends
- Requirements now carry lifecycle details such as status, verification method, and acceptance criteria
- Added graph schema rules and indexes so traceability data can be stored and searched consistently in Neo4j
- Added fixture aliases used by chaos tests so CI can load the expected proxies without fixture lookup failures

### Impact
`✅ Clearer traceability review`
`✅ Confidence scores on linked requirements`
`✅ Fewer CI test fixture failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
