### PR TITLE
feat(neo4j): idempotent TraceLink projection writer (P0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ test = [
     "hypothesis>=6.151.4",
     "faker>=40.1.2",
     "factory-boy>=3.3.3",
+    "testcontainers[neo4j]>=4.10.0",
 ]
 phase2 = [
     "poethepoet>=0.40.0",

--- a/src/tracertm/storage/neo4j_trace_link_writer.py
+++ b/src/tracertm/storage/neo4j_trace_link_writer.py
@@ -1,0 +1,259 @@
+"""Neo4j projection writer for the canonical TraceLink domain.
+
+This module is the *write-side* of FR-TRACE-003: it projects the
+SQL-resident :mod:`tracertm.models.trace_link` value objects
+(:class:`Artifact`, :class:`Requirement`, :class:`TraceLink`) into the
+Neo4j graph using the declarative DDL defined by
+:class:`tracertm.models.trace_link.Neo4jSchema`.
+
+Design notes
+------------
+* All write operations use idempotent ``MERGE`` clauses so the projection
+  is safe to replay from the SQL system of record (or from an event log).
+  ``MERGE`` matches on the *node-key* ``(project_id, id)`` for artifacts
+  and on the full triple ``(source, target, link_type)`` for trace edges.
+* The writer accepts a ``neo4j.Driver`` (sync) — async callers should
+  ``run_in_executor`` or use the async equivalent. We keep the surface
+  sync because:
+
+  1. The schema apply path runs at startup, not in a request loop.
+  2. The first miner / RAG consumer (PR follow-up) batches writes via
+     UNWIND, so per-call async overhead is not on the hot path.
+
+* All MERGEs set ``updated_at = datetime()`` on both create and match so
+  the projection retains a last-touched timestamp without requiring the
+  caller to thread one through.
+
+Functional Requirements: FR-TRACE-003 (Neo4j projection of the
+traceability graph).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from tracertm.models.trace_link import (
+    Artifact,
+    Neo4jSchema,
+    Requirement,
+    TraceLink,
+)
+
+if TYPE_CHECKING:
+    from neo4j import Driver
+
+__all__ = [
+    "apply_schema",
+    "write_artifact",
+    "write_requirement",
+    "write_link",
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _artifact_properties(artifact: Artifact) -> dict[str, Any]:
+    """Flatten an :class:`Artifact` into a Cypher-friendly property map.
+
+    UUIDs are stringified (Neo4j has no native UUID type) and ``metadata``
+    is left as a dict — the driver serialises it to a Neo4j map property.
+    Datetimes are passed through; the driver converts them to
+    ``DateTime`` values.
+    """
+    props: dict[str, Any] = {
+        "id": str(artifact.id),
+        "project_id": str(artifact.project_id),
+        "kind": artifact.kind.value,
+        "title": artifact.title,
+        "description": artifact.description,
+        "external_id": artifact.external_id,
+        # Neo4j map properties must be primitive — JSON-encode nested dicts.
+        "metadata_json": _safe_json(artifact.metadata),
+    }
+    if artifact.created_at is not None:
+        props["created_at"] = artifact.created_at
+    if artifact.updated_at is not None:
+        props["updated_at"] = artifact.updated_at
+    return props
+
+
+def _requirement_properties(req: Requirement) -> dict[str, Any]:
+    """Extend the base artifact property map with Requirement-only fields."""
+    props = _artifact_properties(req)
+    props.update(
+        {
+            "status": req.status.value,
+            "priority": req.priority,
+            "rationale": req.rationale,
+            "acceptance_criteria": list(req.acceptance_criteria),
+            "verification_method": (
+                req.verification_method.value
+                if req.verification_method is not None
+                else None
+            ),
+        }
+    )
+    return props
+
+
+def _safe_json(value: dict[str, Any]) -> str:
+    """JSON-encode ``value`` so it can be stored as a Neo4j string property.
+
+    We keep nested metadata as an opaque JSON blob rather than a Neo4j
+    map so that the SQL system-of-record stays canonical and we don't
+    have to round-trip arbitrarily nested structures through Cypher.
+    """
+    import json
+
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def apply_schema(driver: Driver) -> None:
+    """Apply :class:`Neo4jSchema` DDL to the target database.
+
+    Runs every constraint and index statement from
+    :meth:`Neo4jSchema.all_statements`. All statements use
+    ``IF NOT EXISTS`` so this method is idempotent and safe to call at
+    every application startup.
+
+    Args:
+        driver: An open ``neo4j.Driver`` connected to the target instance.
+    """
+    with driver.session() as session:
+        for stmt in Neo4jSchema.all_statements():
+            session.run(stmt)
+
+
+def write_artifact(driver: Driver, artifact: Artifact) -> None:
+    """Project an :class:`Artifact` node into Neo4j.
+
+    Idempotent: matches on the ``(project_id, id)`` node key. The node
+    receives both the umbrella ``:Artifact`` label and the kind-specific
+    label (e.g. ``:Test``, ``:Code``) so kind-specific queries can use
+    the narrower label without a property filter.
+
+    Args:
+        driver: An open ``neo4j.Driver``.
+        artifact: The artifact value object to project.
+    """
+    kind_label = Neo4jSchema.node_label_for(artifact.kind)
+    # Property names are static; ``kind_label`` is derived from a
+    # validated enum value so it cannot inject arbitrary Cypher.
+    cypher = (
+        "MERGE (a:Artifact {project_id: $project_id, id: $id}) "
+        f"SET a:{kind_label}, "
+        "    a.title = $title, "
+        "    a.description = $description, "
+        "    a.external_id = $external_id, "
+        "    a.kind = $kind, "
+        "    a.metadata_json = $metadata_json, "
+        "    a.updated_at = coalesce($updated_at, datetime()) "
+        "ON CREATE SET a.created_at = coalesce($created_at, datetime())"
+    )
+    with driver.session() as session:
+        session.run(cypher, **_artifact_properties(artifact))
+
+
+def write_requirement(driver: Driver, requirement: Requirement) -> None:
+    """Project a :class:`Requirement` node into Neo4j.
+
+    Idempotent on ``(project_id, id)``. Sets both ``:Artifact`` and
+    ``:Requirement`` labels and persists the ISO 29148 lifecycle fields
+    (``status``, ``priority``, ``rationale``, ``acceptance_criteria``,
+    ``verification_method``).
+
+    Args:
+        driver: An open ``neo4j.Driver``.
+        requirement: The requirement value object to project.
+    """
+    cypher = (
+        "MERGE (r:Artifact {project_id: $project_id, id: $id}) "
+        "SET r:Requirement, "
+        "    r.title = $title, "
+        "    r.description = $description, "
+        "    r.external_id = $external_id, "
+        "    r.kind = $kind, "
+        "    r.metadata_json = $metadata_json, "
+        "    r.status = $status, "
+        "    r.priority = $priority, "
+        "    r.rationale = $rationale, "
+        "    r.acceptance_criteria = $acceptance_criteria, "
+        "    r.verification_method = $verification_method, "
+        "    r.updated_at = coalesce($updated_at, datetime()) "
+        "ON CREATE SET r.created_at = coalesce($created_at, datetime())"
+    )
+    with driver.session() as session:
+        session.run(cypher, **_requirement_properties(requirement))
+
+
+def write_link(driver: Driver, link: TraceLink) -> None:
+    """Project a :class:`TraceLink` edge into Neo4j.
+
+    Idempotent: matches on the (source, target, link_type) triple inside
+    a single project. Updates ``confidence``, ``rationale``, ``metadata``
+    and ``updated_at`` on every call.
+
+    The relationship label is taken from
+    :meth:`Neo4jSchema.relationship_label_for`, which returns the enum's
+    value (already SCREAMING_SNAKE).
+
+    Both endpoint nodes are ``MERGE``d on the ``:Artifact`` super-label so
+    a link can be written even if the source/target artifact projection
+    has not run yet — the endpoints will be created as bare Artifact
+    nodes and back-filled by a later ``write_artifact`` / ``write_requirement``.
+
+    Args:
+        driver: An open ``neo4j.Driver``.
+        link: The trace link value object to project.
+
+    Raises:
+        ValueError: If the link is a self-loop (already rejected by the
+            :class:`TraceLink` model validator, but re-checked here for
+            defence-in-depth at the persistence boundary).
+    """
+    if link.source_artifact_id == link.target_artifact_id:
+        msg = "TraceLink source and target must differ"
+        raise ValueError(msg)
+
+    rel_label = Neo4jSchema.relationship_label_for(link.link_type)
+    # ``rel_label`` comes from a validated enum value, so f-string
+    # interpolation cannot inject arbitrary Cypher.
+    cypher = (
+        "MERGE (src:Artifact {project_id: $project_id, id: $source_id}) "
+        "MERGE (tgt:Artifact {project_id: $project_id, id: $target_id}) "
+        f"MERGE (src)-[l:{rel_label} {{id: $link_id}}]->(tgt) "
+        "SET l.project_id = $project_id, "
+        "    l.confidence = $confidence, "
+        "    l.rationale = $rationale, "
+        "    l.metadata_json = $metadata_json, "
+        "    l.updated_at = coalesce($updated_at, datetime()) "
+        "ON CREATE SET l.created_at = coalesce($created_at, datetime())"
+    )
+    params: dict[str, Any] = {
+        "project_id": str(link.project_id),
+        "source_id": str(link.source_artifact_id),
+        "target_id": str(link.target_artifact_id),
+        "link_id": str(link.id),
+        "confidence": float(link.confidence),
+        "rationale": link.rationale,
+        "metadata_json": _safe_json(link.metadata),
+    }
+    if link.created_at is not None:
+        params["created_at"] = link.created_at
+    else:
+        params["created_at"] = None
+    if link.updated_at is not None:
+        params["updated_at"] = link.updated_at
+    else:
+        params["updated_at"] = None
+
+    with driver.session() as session:
+        session.run(cypher, **params)

--- a/tests/integration/storage/test_neo4j_trace_link_writer.py
+++ b/tests/integration/storage/test_neo4j_trace_link_writer.py
@@ -1,0 +1,221 @@
+"""Integration tests for :mod:`tracertm.storage.neo4j_trace_link_writer`.
+
+These tests spin up a real Neo4j 5 instance via ``testcontainers-neo4j``
+and exercise the writer end-to-end. They are gated behind the
+``integration`` pytest marker and skipped when Docker (and therefore
+testcontainers) is not available on the host — matching the policy used
+by the rest of the integration suite.
+
+Functional Requirements: FR-TRACE-003 (Neo4j projection of the
+traceability graph).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from neo4j import Driver
+
+# testcontainers + neo4j are optional at test-collection time; skip the
+# whole module if either is missing so the unit-only CI tier keeps green.
+testcontainers_neo4j = pytest.importorskip(
+    "testcontainers.neo4j",
+    reason="testcontainers-neo4j is required for Neo4j projection tests",
+)
+neo4j_pkg = pytest.importorskip(
+    "neo4j",
+    reason="neo4j driver is required for Neo4j projection tests",
+)
+
+from tracertm.models.trace_link import (  # noqa: E402  (after importorskip)
+    Artifact,
+    ArtifactKind,
+    Requirement,
+    RequirementStatus,
+    TraceLink,
+    TraceLinkType,
+    VerificationMethod,
+)
+from tracertm.storage.neo4j_trace_link_writer import (  # noqa: E402
+    apply_schema,
+    write_artifact,
+    write_link,
+    write_requirement,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+@pytest.fixture(scope="module")
+def neo4j_driver() -> Iterator[Driver]:
+    """Start a Neo4j 5 testcontainer and yield an open driver.
+
+    Scoped per-module so the (relatively expensive) container start cost
+    is amortised across all three tests. Each test uses a unique
+    ``project_id`` so they don't see each other's data despite sharing
+    the database.
+    """
+    Neo4jContainer = testcontainers_neo4j.Neo4jContainer  # noqa: N806
+    GraphDatabase = neo4j_pkg.GraphDatabase  # noqa: N806
+
+    container = Neo4jContainer("neo4j:5-community")
+    container.start()
+    try:
+        driver = GraphDatabase.driver(
+            container.get_connection_url(),
+            auth=("neo4j", container.password),  # type: ignore[attr-defined]
+        )
+        try:
+            apply_schema(driver)
+            yield driver
+        finally:
+            driver.close()
+    finally:
+        container.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_apply_schema_is_idempotent(neo4j_driver: Driver) -> None:
+    """Re-applying the schema must not raise (all DDL uses IF NOT EXISTS).
+
+    Also verifies that the artifact node-key constraint and the artifact
+    fulltext index are both visible to ``SHOW CONSTRAINTS`` /
+    ``SHOW INDEXES`` after the first apply.
+    """
+    # Second apply — first apply happened in the fixture.
+    apply_schema(neo4j_driver)
+
+    with neo4j_driver.session() as session:
+        constraint_names = {
+            record["name"] for record in session.run("SHOW CONSTRAINTS YIELD name")
+        }
+        index_names = {
+            record["name"] for record in session.run("SHOW INDEXES YIELD name")
+        }
+
+    assert "artifact_node_key" in constraint_names
+    assert "requirement_id_unique" in constraint_names
+    assert "artifact_text" in index_names
+
+
+def test_write_requirement_and_artifact_are_idempotent(
+    neo4j_driver: Driver,
+) -> None:
+    """write_requirement + write_artifact MERGE on (project_id, id).
+
+    Calling each writer twice for the same value object must produce
+    exactly one node with the latest property values.
+    """
+    project_id = uuid.uuid4()
+    req = Requirement(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        title="REQ-1: System shall authenticate users",
+        description="Initial wording",
+        status=RequirementStatus.DRAFT,
+        priority=3,
+        acceptance_criteria=["Given valid creds, when login, then 200"],
+        verification_method=VerificationMethod.TEST,
+    )
+    artifact = Artifact(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        kind=ArtifactKind.TEST,
+        title="test_login_happy_path",
+        external_id="tests/auth/test_login.py::test_happy_path",
+    )
+
+    # First write.
+    write_requirement(neo4j_driver, req)
+    write_artifact(neo4j_driver, artifact)
+
+    # Second write — same ids, mutated title on the requirement.
+    updated_req = req.model_copy(update={"title": "REQ-1: SSO required"})
+    write_requirement(neo4j_driver, updated_req)
+    write_artifact(neo4j_driver, artifact)
+
+    with neo4j_driver.session() as session:
+        req_count = session.run(
+            "MATCH (r:Requirement {project_id: $pid, id: $id}) RETURN count(r) AS c",
+            pid=str(project_id),
+            id=str(req.id),
+        ).single()["c"]
+        req_title = session.run(
+            "MATCH (r:Requirement {project_id: $pid, id: $id}) RETURN r.title AS t",
+            pid=str(project_id),
+            id=str(req.id),
+        ).single()["t"]
+        artifact_labels = session.run(
+            "MATCH (a:Artifact {project_id: $pid, id: $id}) RETURN labels(a) AS l",
+            pid=str(project_id),
+            id=str(artifact.id),
+        ).single()["l"]
+
+    assert req_count == 1, "Requirement MERGE must be idempotent"
+    assert req_title == "REQ-1: SSO required", "second write should update title"
+    assert "Artifact" in artifact_labels
+    assert "Test" in artifact_labels, "kind-specific label must be set"
+
+
+def test_write_link_creates_typed_relationship_and_is_idempotent(
+    neo4j_driver: Driver,
+) -> None:
+    """write_link creates exactly one typed edge per (src,tgt,link_type).
+
+    Calling write_link twice for the same TraceLink id must result in a
+    single SATISFIES relationship whose confidence reflects the most
+    recent write.
+    """
+    project_id = uuid.uuid4()
+    req = Requirement(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        title="REQ-2: Encrypted at rest",
+    )
+    code = Artifact(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        kind=ArtifactKind.CODE,
+        title="storage/encryption.py",
+    )
+    write_requirement(neo4j_driver, req)
+    write_artifact(neo4j_driver, code)
+
+    link = TraceLink(
+        project_id=project_id,
+        source_artifact_id=code.id,
+        target_artifact_id=req.id,
+        link_type=TraceLinkType.SATISFIES,
+        confidence=0.72,
+        rationale="cosine(code, req) = 0.81",
+    )
+
+    write_link(neo4j_driver, link)
+    # Second write of the SAME link id, but with a higher confidence —
+    # idempotent MERGE must update in place, not insert a duplicate edge.
+    write_link(
+        neo4j_driver,
+        link.model_copy(update={"confidence": 0.95}),
+    )
+
+    with neo4j_driver.session() as session:
+        result = session.run(
+            "MATCH (c:Artifact {id: $cid})-[l:SATISFIES]->(r:Artifact {id: $rid}) "
+            "RETURN count(l) AS c, collect(l.confidence) AS confs, "
+            "collect(l.rationale) AS rationales",
+            cid=str(code.id),
+            rid=str(req.id),
+        ).single()
+
+    assert result["c"] == 1, "SATISFIES edge MERGE must be idempotent"
+    assert result["confs"] == [pytest.approx(0.95)]
+    assert result["rationales"] == ["cosine(code, req) = 0.81"]


### PR DESCRIPTION
## **User description**
## Summary

Implements FR-TRACE-003 (write side): projects the canonical TraceLink / Requirement / Artifact value objects (PR #458) and the SQL link rows (PR #460) into the Neo4j graph using idempotent `MERGE`.

- `apply_schema(driver)` runs every `Neo4jSchema` constraint + index statement (all `IF NOT EXISTS`), safe to call at every startup.
- `write_artifact` / `write_requirement` MERGE on the `(project_id, id)` node key, set the `:Artifact` super-label plus the kind-specific label derived from the validated `ArtifactKind` enum, and persist the ISO 29148 lifecycle fields on requirements.
- `write_link` MERGEs both endpoints (so links can land before their endpoints are back-filled) and MERGEs the typed relationship on `link.id` under the label returned by `Neo4jSchema.relationship_label_for`; confidence + rationale + metadata + `updated_at` refresh on every call.
- Nested metadata is stored as a JSON string property — keeps SQL canonical and lets arbitrarily nested structures round-trip cleanly.

## Test plan

Three integration tests in `tests/integration/storage/test_neo4j_trace_link_writer.py`, gated behind `pytest.mark.integration` + `pytest.mark.slow` and `importorskip`ed on `testcontainers.neo4j` so the unit-only CI tier stays green.

- [ ] `test_apply_schema_is_idempotent` — re-apply DDL, assert `artifact_node_key`, `requirement_id_unique`, `artifact_text` show up in `SHOW CONSTRAINTS` / `SHOW INDEXES`.
- [ ] `test_write_requirement_and_artifact_are_idempotent` — write same nodes twice with a mutated title; assert single node remains, title reflects latest write, and the Test artifact carries both `:Artifact` and `:Test` labels.
- [ ] `test_write_link_creates_typed_relationship_and_is_idempotent` — write SATISFIES link twice with different confidences; assert single edge remains with the second confidence value.

`pyproject.toml` adds `testcontainers[neo4j]>=4.10.0` to the `test` extra. The miner / RAG read-side consumer lands in a follow-up PR.

Builds on #458 (TraceLink domain + `Neo4jSchema`) and #460 (LinkRepository confidence/rationale).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New graph persistence path with dynamic Cypher labels (enum-validated) and link writes that can create stub artifact nodes; replay/idempotency is intentional but wrong ordering or partial replays could leave incomplete graph state until back-fill.
> 
> **Overview**
> Adds the **write-side Neo4j projection** for FR-TRACE-003: a new `tracertm.storage.neo4j_trace_link_writer` module that pushes canonical `Artifact`, `Requirement`, and `TraceLink` value objects into the graph using `Neo4jSchema` DDL and idempotent `MERGE` Cypher.
> 
> **`apply_schema`** runs all constraint/index statements at startup. **`write_artifact`** / **`write_requirement`** upsert nodes on `(project_id, id)`, apply `:Artifact` plus kind- or `:Requirement`-specific labels, and refresh timestamps and fields (including ISO 29148 fields on requirements). **`write_link`** MERGEs endpoint `:Artifact` stubs if needed, then upserts a typed relationship keyed by `link.id`, updating confidence, rationale, and metadata; nested metadata is stored as **`metadata_json`** strings. Self-loops are rejected at the writer boundary.
> 
> The **`test`** extra gains **`testcontainers[neo4j]`**. Three **`integration`/`slow`** tests spin up Neo4j 5 via testcontainers (skipped without Docker/importorskip) and assert schema re-apply idempotency, node MERGE behavior, and typed edge idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cef51875dcbfd2966b4b2d3a6adaed04c9f8079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Project trace links into Neo4j with idempotent writes**

### What Changed
- Added a Neo4j writer that saves artifacts, requirements, and trace links without creating duplicates when the same data is written again
- Requirements now keep their lifecycle details, and artifacts keep their type-specific labels for clearer graph queries
- Trace links can be written even before both endpoints exist in Neo4j, and repeated writes update the latest confidence, rationale, and timestamp
- Added integration tests that verify schema setup, idempotent node writes, and idempotent relationship writes against a real Neo4j instance

### Impact
`✅ Fewer duplicate graph records`
`✅ Safer traceability sync`
`✅ Clearer Neo4j projections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Neo4j write functionality for trace links, artifacts, and requirements with idempotent schema application and timestamp tracking.

* **Tests**
  * Added integration tests for Neo4j trace link operations with testcontainer support.

* **Chores**
  * Added testcontainers dependency for Neo4j testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KooshaPari/Tracera/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->