### PR TITLE
feat(impact-api): Cypher forward/reverse impact analysis endpoints

### DIFF
--- a/src/tracertm/api/handlers/impact.py
+++ b/src/tracertm/api/handlers/impact.py
@@ -1,0 +1,159 @@
+"""Cypher-based impact analysis handlers for TraceRTM.
+
+Implements forward and reverse impact traversal over the Neo4j trace-link
+graph using the canonical :class:`tracertm.models.trace_link.TraceLink`
+relationship model.
+
+Functional Requirements: FR-TRACE-003 (Neo4j projection query layer)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from neo4j import AsyncDriver
+
+__all__ = [
+    "get_neo4j_driver",
+    "query_forward_impact",
+    "query_reverse_impact",
+]
+
+
+def _neo4j_driver() -> AsyncDriver:
+    """Create an async Neo4j driver from environment variables.
+
+    Environment variables read:
+    * ``NEO4J_URI``  — bolt/neo4j URI (default: ``neo4j://localhost:7687``)
+    * ``NEO4J_USER`` — username (default: ``neo4j``)
+    * ``NEO4J_PASSWORD`` — password (default: ``neo4j``)
+
+    Returns:
+        An open :class:`neo4j.AsyncDriver`.
+    """
+    from neo4j import AsyncGraphDatabase
+
+    uri = os.environ.get("NEO4J_URI", "neo4j://localhost:7687")
+    user = os.environ.get("NEO4J_USER", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "neo4j")
+    return AsyncGraphDatabase.driver(uri, auth=(user, password))
+
+
+async def get_neo4j_driver() -> AsyncDriver:
+    """FastAPI dependency that yields a fresh async Neo4j driver per request.
+
+    The driver is closed after the request completes.  For production usage,
+    replace this with a module-level singleton; the interface is intentionally
+    identical so callers need no changes.
+
+    Yields:
+        An open :class:`neo4j.AsyncDriver`.
+    """
+    driver = _neo4j_driver()
+    try:
+        yield driver
+    finally:
+        await driver.close()
+
+
+# ---------------------------------------------------------------------------
+# Cypher queries
+# ---------------------------------------------------------------------------
+
+# Forward impact: starting from ``artifact_id``, follow all outgoing trace
+# relationships any number of hops and collect the downstream artifacts.
+_FORWARD_CYPHER = """
+MATCH (src:Artifact {id: $artifact_id})
+MATCH (src)-[l*1..]->(affected:Artifact)
+WHERE affected.id <> src.id
+WITH DISTINCT affected, [rel IN l | type(rel)] AS link_types
+RETURN
+    affected.id          AS id,
+    affected.project_id  AS project_id,
+    affected.kind        AS kind,
+    affected.title       AS title,
+    affected.external_id AS external_id,
+    link_types
+ORDER BY affected.kind, affected.id
+"""
+
+# Reverse impact: starting from ``artifact_id``, follow all *incoming* trace
+# relationships any number of hops and collect the upstream artifacts.
+_REVERSE_CYPHER = """
+MATCH (tgt:Artifact {id: $artifact_id})
+MATCH (upstream:Artifact)-[l*1..]->(tgt)
+WHERE upstream.id <> tgt.id
+WITH DISTINCT upstream, [rel IN l | type(rel)] AS link_types
+RETURN
+    upstream.id          AS id,
+    upstream.project_id  AS project_id,
+    upstream.kind        AS kind,
+    upstream.title       AS title,
+    upstream.external_id AS external_id,
+    link_types
+ORDER BY upstream.kind, upstream.id
+"""
+
+
+def _row_to_artifact(record: Any) -> dict[str, Any]:
+    """Convert a Neo4j result record to a JSON-serialisable artifact dict."""
+    return {
+        "id": record["id"],
+        "project_id": record["project_id"],
+        "kind": record["kind"],
+        "title": record["title"],
+        "external_id": record["external_id"],
+        "via_link_types": list(record["link_types"]),
+    }
+
+
+async def query_forward_impact(
+    driver: AsyncDriver,
+    artifact_id: str,
+) -> list[dict[str, Any]]:
+    """Run the forward impact Cypher query and return affected artifacts.
+
+    Traverses all *outgoing* :class:`~tracertm.models.trace_link.TraceLink`
+    relationships from ``artifact_id`` (unbounded depth) to collect every
+    downstream artifact that is transitively affected when the source artifact
+    changes.
+
+    Args:
+        driver: An open :class:`neo4j.AsyncDriver`.
+        artifact_id: UUID string of the source artifact.
+
+    Returns:
+        List of artifact dicts, each containing ``id``, ``project_id``,
+        ``kind``, ``title``, ``external_id``, and ``via_link_types``.
+    """
+    async with driver.session() as session:
+        result = await session.run(_FORWARD_CYPHER, artifact_id=artifact_id)
+        records = await result.data()
+    return [_row_to_artifact(r) for r in records]
+
+
+async def query_reverse_impact(
+    driver: AsyncDriver,
+    artifact_id: str,
+) -> list[dict[str, Any]]:
+    """Run the reverse impact Cypher query and return upstream artifacts.
+
+    Traverses all *incoming* :class:`~tracertm.models.trace_link.TraceLink`
+    relationships to ``artifact_id`` (unbounded depth) to collect every
+    upstream artifact that needs re-validation when the target artifact
+    changes.
+
+    Args:
+        driver: An open :class:`neo4j.AsyncDriver`.
+        artifact_id: UUID string of the target artifact.
+
+    Returns:
+        List of artifact dicts, each containing ``id``, ``project_id``,
+        ``kind``, ``title``, ``external_id``, and ``via_link_types``.
+    """
+    async with driver.session() as session:
+        result = await session.run(_REVERSE_CYPHER, artifact_id=artifact_id)
+        records = await result.data()
+    return [_row_to_artifact(r) for r in records]

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -23,6 +23,7 @@ from tracertm.api.routers import (
     github,
     graphs,
     health,
+    impact,
     items,
     items_summary,
     linear,
@@ -89,6 +90,9 @@ def register_api_routers(app: FastAPI) -> None:
 
     # Agent sessions and workflow
     app.include_router(agent.router, prefix="/api/v1")
+
+    # Impact analysis (Cypher forward/reverse traversal)
+    app.include_router(impact.router, prefix="/api/v1")
 
     # MCP router (Model Context Protocol over HTTP)
     app.include_router(mcp.router, prefix="/api/v1")

--- a/src/tracertm/api/routers/impact.py
+++ b/src/tracertm/api/routers/impact.py
@@ -1,0 +1,86 @@
+"""Impact analysis API routes for TraceRTM.
+
+Exposes Cypher-backed forward and reverse impact traversal over the Neo4j
+trace-link graph.
+
+Endpoints
+---------
+GET /api/v1/impact/forward/{artifact_id}
+    Return all artifacts *downstream* of the given artifact (forward impact).
+
+GET /api/v1/impact/reverse/{artifact_id}
+    Return all artifacts *upstream* of the given artifact (reverse impact).
+
+Functional Requirements: FR-TRACE-003
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+
+from tracertm.api.deps import auth_guard
+from tracertm.api.handlers.impact import (
+    get_neo4j_driver,
+    query_forward_impact,
+    query_reverse_impact,
+)
+
+router = APIRouter(prefix="/impact", tags=["impact"])
+
+
+@router.get("/forward/{artifact_id}", summary="Forward impact of an artifact")
+async def forward_impact(
+    artifact_id: str,
+    claims: Annotated[dict[str, Any], Depends(auth_guard)],
+    driver: Annotated[Any, Depends(get_neo4j_driver)],
+) -> dict[str, Any]:
+    """Return artifacts that are *affected by* changes to ``artifact_id``.
+
+    Follows all outgoing trace-link relationships from the given artifact
+    (unbounded depth, all relationship types) and returns every distinct
+    downstream artifact.
+
+    Args:
+        artifact_id: UUID of the source artifact.
+
+    Returns:
+        JSON body with ``artifact_id``, ``direction``, ``total``, and
+        ``affected`` list.
+    """
+    affected = await query_forward_impact(driver, artifact_id)
+    return {
+        "artifact_id": artifact_id,
+        "direction": "forward",
+        "total": len(affected),
+        "affected": affected,
+    }
+
+
+@router.get("/reverse/{artifact_id}", summary="Reverse impact on an artifact")
+async def reverse_impact(
+    artifact_id: str,
+    claims: Annotated[dict[str, Any], Depends(auth_guard)],
+    driver: Annotated[Any, Depends(get_neo4j_driver)],
+) -> dict[str, Any]:
+    """Return artifacts that *affect* the given ``artifact_id``.
+
+    Follows all incoming trace-link relationships to the given artifact
+    (unbounded depth, all relationship types) and returns every distinct
+    upstream artifact that needs re-validation when the target changes.
+
+    Args:
+        artifact_id: UUID of the target artifact.
+
+    Returns:
+        JSON body with ``artifact_id``, ``direction``, ``total``, and
+        ``upstream`` list.
+    """
+    upstream = await query_reverse_impact(driver, artifact_id)
+    return {
+        "artifact_id": artifact_id,
+        "direction": "reverse",
+        "total": len(upstream),
+        "upstream": upstream,
+    }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -268,7 +268,7 @@ async def db_session(async_test_db_engine: Any) -> None:
 
 
 @pytest.fixture(autouse=True)
-def isolated_cli_environment(tmp_path: Any, _monkeypatch: Any) -> None:
+def isolated_cli_environment(tmp_path: Any) -> None:
     """Isolate CLI tests from the repository's .trace/ directory.
 
     Changes the working directory to a temporary directory so that

--- a/tests/integration/graph/test_cypher_impact_api.py
+++ b/tests/integration/graph/test_cypher_impact_api.py
@@ -1,0 +1,204 @@
+"""Integration tests for Cypher-based impact analysis API.
+
+Tests both handler-level Cypher execution and the HTTP layer for the two
+impact endpoints.
+
+Markers
+-------
+* ``integration`` — requires a live Neo4j instance (set NEO4J_URI env var)
+* ``slow``        — full end-to-end graph traversal; excluded from fast CI
+
+Functional Requirements: FR-TRACE-003
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def artifact_ids() -> dict[str, str]:
+    """Return a small set of stable UUIDs for graph fixtures."""
+    return {
+        "req": str(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")),
+        "design": str(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000002")),
+        "code": str(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000003")),
+        "test": str(uuid.UUID("aaaaaaaa-0000-0000-0000-000000000004")),
+    }
+
+
+def _make_record(artifact_id: str, kind: str, title: str, link_types: list[str]) -> dict[str, Any]:
+    """Build a fake Neo4j record dict matching ``_row_to_artifact`` expectations."""
+    return {
+        "id": artifact_id,
+        "project_id": str(uuid.UUID("bbbbbbbb-0000-0000-0000-000000000001")),
+        "kind": kind,
+        "title": title,
+        "external_id": None,
+        "link_types": link_types,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit-style: handler functions (mocked driver)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_forward_impact_returns_affected_artifacts(
+    artifact_ids: dict[str, str],
+) -> None:
+    """Forward impact query returns downstream artifacts from Neo4j records.
+
+    Uses a mocked AsyncDriver so no live Neo4j is required for this assertion.
+    """
+    from tracertm.api.handlers.impact import query_forward_impact
+
+    design_record = _make_record(
+        artifact_ids["design"],
+        "design",
+        "System Design Doc",
+        ["SATISFIES"],
+    )
+    code_record = _make_record(
+        artifact_ids["code"],
+        "code",
+        "auth.py",
+        ["SATISFIES", "IMPLEMENTS"],
+    )
+
+    # Build a mock session whose .run().data() returns two records
+    mock_result = AsyncMock()
+    mock_result.data = AsyncMock(return_value=[design_record, code_record])
+    mock_session = AsyncMock()
+    mock_session.run = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    mock_driver = MagicMock()
+    mock_driver.session = MagicMock(return_value=mock_session)
+
+    result = await query_forward_impact(mock_driver, artifact_ids["req"])
+
+    assert len(result) == 2
+    ids = {r["id"] for r in result}
+    assert artifact_ids["design"] in ids
+    assert artifact_ids["code"] in ids
+    # Check shape of one item
+    design_item = next(r for r in result if r["id"] == artifact_ids["design"])
+    assert design_item["kind"] == "design"
+    assert "SATISFIES" in design_item["via_link_types"]
+
+
+@pytest.mark.asyncio
+async def test_query_reverse_impact_returns_upstream_artifacts(
+    artifact_ids: dict[str, str],
+) -> None:
+    """Reverse impact query returns upstream artifacts from Neo4j records.
+
+    Uses a mocked AsyncDriver — no live Neo4j required.
+    """
+    from tracertm.api.handlers.impact import query_reverse_impact
+
+    req_record = _make_record(
+        artifact_ids["req"],
+        "requirement",
+        "FR-001 Auth",
+        ["SATISFIES"],
+    )
+
+    mock_result = AsyncMock()
+    mock_result.data = AsyncMock(return_value=[req_record])
+    mock_session = AsyncMock()
+    mock_session.run = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    mock_driver = MagicMock()
+    mock_driver.session = MagicMock(return_value=mock_session)
+
+    result = await query_reverse_impact(mock_driver, artifact_ids["code"])
+
+    assert len(result) == 1
+    assert result[0]["id"] == artifact_ids["req"]
+    assert result[0]["kind"] == "requirement"
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer: FastAPI TestClient (mocked Neo4j + auth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_client() -> TestClient:
+    """Return a TestClient with auth and Neo4j driver mocked out."""
+    from fastapi import FastAPI
+
+    # Import the exact function objects used inside the router's Depends() calls
+    from tracertm.api.deps import auth_guard
+    from tracertm.api.handlers.impact import get_neo4j_driver
+    from tracertm.api.routers.impact import router
+
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/api/v1")
+
+    # Override the exact function objects referenced by Depends() in the router
+    test_app.dependency_overrides[auth_guard] = lambda: {"sub": "test-user"}
+
+    # Stub Neo4j driver — returns empty lists by default
+    async def _stub_driver():
+        mock_result = AsyncMock()
+        mock_result.data = AsyncMock(return_value=[])
+        mock_session = AsyncMock()
+        mock_session.run = AsyncMock(return_value=mock_result)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        mock_driver = MagicMock()
+        mock_driver.session = MagicMock(return_value=mock_session)
+        yield mock_driver
+
+    test_app.dependency_overrides[get_neo4j_driver] = _stub_driver
+
+    return TestClient(test_app)
+
+
+def test_forward_impact_endpoint_returns_200(
+    app_client: TestClient,
+    artifact_ids: dict[str, str],
+) -> None:
+    """GET /api/v1/impact/forward/{id} returns 200 with expected JSON shape."""
+    resp = app_client.get(f"/api/v1/impact/forward/{artifact_ids['req']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["artifact_id"] == artifact_ids["req"]
+    assert body["direction"] == "forward"
+    assert isinstance(body["total"], int)
+    assert isinstance(body["affected"], list)
+
+
+def test_reverse_impact_endpoint_returns_200(
+    app_client: TestClient,
+    artifact_ids: dict[str, str],
+) -> None:
+    """GET /api/v1/impact/reverse/{id} returns 200 with expected JSON shape."""
+    resp = app_client.get(f"/api/v1/impact/reverse/{artifact_ids['code']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["artifact_id"] == artifact_ids["code"]
+    assert body["direction"] == "reverse"
+    assert isinstance(body["total"], int)
+    assert isinstance(body["upstream"], list)


### PR DESCRIPTION
## **User description**
## Summary

- Adds `GET /api/v1/impact/forward/{artifact_id}` — follows all outgoing trace-link relationships (unbounded depth) and returns every downstream artifact affected by a change to the source
- Adds `GET /api/v1/impact/reverse/{artifact_id}` — follows all incoming trace-link relationships (unbounded depth) and returns every upstream artifact that needs re-validation when the target changes
- Wires the new `impact` router into `router_registry.py` under `/api/v1`

## Design

- Handler logic in `src/tracertm/api/handlers/impact.py`: two Cypher queries, a `get_neo4j_driver()` FastAPI dependency that reads `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` from env
- Router in `src/tracertm/api/routers/impact.py`: thin FastAPI layer, auth-guarded via existing `auth_guard` dep
- Relationships traverse all `TraceLinkType` labels (SATISFIES, VERIFIES, IMPLEMENTS, DERIVES_FROM, REFINES, CONFLICTS_WITH, DUPLICATES)

## Test plan

- [x] `test_query_forward_impact_returns_affected_artifacts` — mocked driver, asserts shape + content
- [x] `test_query_reverse_impact_returns_upstream_artifacts` — mocked driver, asserts shape + content
- [x] `test_forward_impact_endpoint_returns_200` — FastAPI TestClient, asserts HTTP 200 + JSON schema
- [x] `test_reverse_impact_endpoint_returns_200` — FastAPI TestClient, asserts HTTP 200 + JSON schema
- All 4 tests pass

Also fixes pre-existing `_monkeypatch` typo in `tests/integration/conftest.py` that broke the `isolated_cli_environment` autouse fixture for the entire integration suite.

Functional Requirements: FR-TRACE-003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated graph endpoints use unbounded Cypher traversals (performance/load risk) and query by artifact id only without obvious project authorization in the handler layer.
> 
> **Overview**
> Adds **Neo4j-backed impact analysis** under `/api/v1/impact`: `GET .../forward/{artifact_id}` walks outgoing trace links (unbounded depth) and returns downstream artifacts; `GET .../reverse/{artifact_id}` walks incoming links and returns upstream artifacts. Handler code runs parameterized Cypher, maps rows to JSON (including `via_link_types`), and exposes a per-request `get_neo4j_driver` dependency from `NEO4J_*` env vars. Routes use the existing **`auth_guard`** and are registered in **`router_registry`**.
> 
> Adds integration tests with **mocked Neo4j** for handler mapping and HTTP response shape. Also fixes the **`isolated_cli_environment`** autouse fixture by removing an invalid `_monkeypatch` parameter in `tests/integration/conftest.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2591423421e2d4160a02a7e3201d031be9ba5f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add forward and reverse impact analysis endpoints**

### What Changed
- Added API endpoints that show which artifacts are affected by a change, and which artifacts must be rechecked when one changes
- Forward results list downstream artifacts; reverse results list upstream artifacts, each with the path types that connect them
- The new impact routes are now available under the main API versioned router
- Fixed a test fixture typo that was preventing the integration test environment from setting up correctly

### Impact
`✅ Faster impact checks for change reviews`
`✅ Clearer re-validation lists when artifacts change`
`✅ Fewer broken integration test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
