### PR TITLE
fix(mcp): implement auth/config/db contract tests (#232)

### DIFF
--- a/src/tracertm/mcp/tools/auth_config_db.py
+++ b/src/tracertm/mcp/tools/auth_config_db.py
@@ -468,7 +468,7 @@ async def config_list(ctx: object) -> dict[str, object]:
             raw = config_manager.get_all()
         else:
             raw = config_manager.load().model_dump()
-        config_dict: dict[str, object] = cast("dict[str, object]", raw) if isinstance(raw, dict[str, object]) else {}  # type: ignore[misc]
+        config_dict: dict[str, object] = cast("dict[str, object]", raw) if isinstance(raw, dict) else {}  # type: ignore[misc]
 
         # Mask sensitive values
         display_config: dict[str, object] = {}

--- a/tests/mcp/test_auth_config_db.py
+++ b/tests/mcp/test_auth_config_db.py
@@ -1,50 +1,250 @@
-"""Tests for auth, config, and database MCP tools."""
+"""Tests for auth, config, and database MCP tools.
+
+Closes: https://github.com/KooshaPari/trace/issues/232
+
+Strategy: patch out the FastMCP server singleton (tracertm.mcp.core) before
+importing the tool module so the heavy MCP boot sequence is never triggered in
+unit-test context.
+"""
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-
-class TestAuthTools:
-    """Tests for authentication-related MCP tools."""
-
-    @pytest.mark.asyncio
-    async def test_auth_status_returns_mode(self) -> None:
-        """Test that auth status returns the current auth mode."""
-        # tracked: https://github.com/KooshaPari/trace/issues/231
-
-    @pytest.mark.asyncio
-    async def test_auth_validate_token(self) -> None:
-        """Test token validation."""
+# ---------------------------------------------------------------------------
+# Stub out tracertm.mcp.core BEFORE the tool module is imported so that the
+# @mcp.tool() decorator calls are no-ops during test collection.
+# ---------------------------------------------------------------------------
 
 
-class TestConfigTools:
-    """Tests for configuration MCP tools."""
+def _stub_mcp_core() -> None:
+    """Insert a lightweight stub for tracertm.mcp.core into sys.modules."""
+    if "tracertm.mcp.core" in sys.modules:
+        return  # already stubbed by a previous test run in the same process
 
-    @pytest.mark.asyncio
-    async def test_config_get_key(self) -> None:
-        """Test getting a config value by key."""
+    stub = ModuleType("tracertm.mcp.core")
+    mock_mcp = MagicMock()
 
-    @pytest.mark.asyncio
-    async def test_config_set_key(self) -> None:
-        """Test setting a config value."""
+    # Make @mcp.tool() a pass-through decorator (returns the function unchanged)
+    def _passthrough_decorator(*_args: object, **_kwargs: object):  # type: ignore[return]
+        def _wrap(fn):  # type: ignore[return]
+            return fn
 
-    @pytest.mark.asyncio
-    async def test_config_list_all(self) -> None:
-        """Test listing all config values."""
+        return _wrap
+
+    mock_mcp.tool = _passthrough_decorator
+    stub.mcp = mock_mcp
+    sys.modules["tracertm.mcp.core"] = stub
+
+    # Ensure tracertm.mcp package is the real package (not overridden)
+    import tracertm.mcp  # noqa: PLC0415 – intentional deferred import
+
+    tracertm.mcp.core = stub  # type: ignore[attr-defined]
 
 
-class TestDatabaseTools:
-    """Tests for database MCP tools."""
+_stub_mcp_core()
 
-    @pytest.mark.asyncio
-    async def test_db_status(self) -> None:
-        """Test database status check."""
+# Now it is safe to import the tool functions directly
+from tracertm.mcp.tools.auth_config_db import (  # noqa: E402
+    auth_logout,
+    auth_status,
+    config_get,
+    config_list,
+    config_set,
+    config_unset,
+    db_init,
+    db_migrate,
+    db_reset,
+    db_status,
+)
 
-    @pytest.mark.asyncio
-    async def test_db_migrate(self) -> None:
-        """Test database migration."""
 
-    @pytest.mark.asyncio
-    async def test_db_reset_requires_confirm(self) -> None:
-        """Test that db reset requires confirmation."""
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_ctx() -> MagicMock:
+    """Minimal MCP context mock – actor extraction is patched away."""
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Auth Tools
+# ---------------------------------------------------------------------------
+
+
+def test_auth_status_no_token(mock_ctx: MagicMock) -> None:
+    """auth_status returns authenticated=False when no token is stored."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.get.return_value = None
+        mgr.config_path = Path("/tmp/config.yaml")
+
+        result = auth_status(mock_ctx)
+
+    assert result["ok"] is True
+    assert result["action"] == "auth_status"
+    data = result["data"]
+    assert data["authenticated"] is False
+    assert data["has_token"] is False
+
+
+def test_auth_status_with_token(mock_ctx: MagicMock) -> None:
+    """auth_status returns authenticated=True when a token exists."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.get.return_value = "tok_abc123"
+        mgr.config_path = Path("/tmp/config.yaml")
+
+        result = auth_status(mock_ctx)
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert data["authenticated"] is True
+    assert data["has_token"] is True
+
+
+def test_auth_logout_clears_token(mock_ctx: MagicMock) -> None:
+    """auth_logout sets api_token to None and returns a confirmation message."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.config_path = Path("/tmp/config.yaml")
+
+        result = auth_logout(mock_ctx)
+
+    assert result["ok"] is True
+    assert result["action"] == "auth_logout"
+    mgr.set.assert_called_once_with("api_token", None)
+    assert "message" in result["data"]
+
+
+# ---------------------------------------------------------------------------
+# Config Tools
+# ---------------------------------------------------------------------------
+
+
+def test_config_get_returns_value(mock_ctx: MagicMock) -> None:
+    """config_get returns the stored value for a key."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.get.return_value = "proj-001"
+
+        result = config_get(mock_ctx, key="current_project_id")
+
+    assert result["ok"] is True
+    assert result["action"] == "config_get"
+    assert result["data"]["key"] == "current_project_id"
+    assert result["data"]["value"] == "proj-001"
+
+
+def test_config_set_persists_value(mock_ctx: MagicMock) -> None:
+    """config_set calls set on the manager and echoes key/value."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+
+        result = config_set(mock_ctx, key="current_project_id", value="proj-999")
+
+    assert result["ok"] is True
+    assert result["action"] == "config_set"
+    mgr.set.assert_called_once_with("current_project_id", "proj-999")
+    assert result["data"]["key"] == "current_project_id"
+    assert result["data"]["value"] == "proj-999"
+
+
+def test_config_unset_clears_key(mock_ctx: MagicMock) -> None:
+    """config_unset sets the key to None in the manager."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+
+        result = config_unset(mock_ctx, key="current_project_id")
+
+    assert result["ok"] is True
+    assert result["action"] == "config_unset"
+    mgr.set.assert_called_once_with("current_project_id", None)
+
+
+@pytest.mark.asyncio
+async def test_config_list_returns_all_keys(mock_ctx: MagicMock) -> None:
+    """config_list returns every config key including a count."""
+    fake_config = {
+        "database_url": None,
+        "current_project_id": "proj-1",
+        "output_format": "table",
+        "api_token": None,
+    }
+
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.get_all.return_value = fake_config
+
+        result = await config_list(mock_ctx)
+
+    assert result["ok"] is True
+    assert result["action"] == "config_list"
+    assert result["data"]["count"] == len(fake_config)
+    assert result["data"]["config"]["api_token"] is None
+
+
+# ---------------------------------------------------------------------------
+# Database Tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_status_no_url_returns_error(mock_ctx: MagicMock) -> None:
+    """db_status returns NO_DATABASE_URL when no database_url is configured."""
+    from tracertm.config.schema import Config
+
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.load.return_value = Config(database_url=None)
+
+        result = await db_status(mock_ctx)
+
+    assert result["ok"] is False
+    assert result["error_code"] == "NO_DATABASE_URL"
+
+
+@pytest.mark.asyncio
+async def test_db_migrate_no_url_returns_error(mock_ctx: MagicMock) -> None:
+    """db_migrate returns NO_DATABASE_URL when no database_url is configured."""
+    from tracertm.config.schema import Config
+
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.load.return_value = Config(database_url=None)
+
+        result = await db_migrate(mock_ctx)
+
+    assert result["ok"] is False
+    assert result["error_code"] == "NO_DATABASE_URL"
+
+
+@pytest.mark.asyncio
+async def test_db_reset_requires_confirm(mock_ctx: MagicMock) -> None:
+    """db_reset returns CONFIRMATION_REQUIRED when confirm=False (default)."""
+    result = await db_reset(mock_ctx, confirm=False)
+
+    assert result["ok"] is False
+    assert result["error_code"] == "CONFIRMATION_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_db_init_sets_url_and_succeeds(mock_ctx: MagicMock) -> None:
+    """db_init stores the database_url and returns a success response."""
+    with patch("tracertm.mcp.tools.auth_config_db.ConfigManager") as MockCM:
+        mgr = MockCM.return_value
+        mgr.config_path = Path("/tmp/test/config.yaml")
+
+        result = await db_init(mock_ctx, database_url="sqlite:///test.db")
+
+    assert result["ok"] is True
+    assert result["action"] == "db_init"
+    mgr.set.assert_called_once_with("database_url", "sqlite:///test.db")


### PR DESCRIPTION
## **User description**
## Summary
- Implements 11 real assertions in `tests/mcp/test_auth_config_db.py` covering `auth_status`, `auth_logout`, `config_get/set/unset/list`, `db_status/migrate/reset/init`
- Stubs `tracertm.mcp.core` at import time so tests don't require the full MCP runtime environment
- Fixes a latent `TypeError` in `config_list`: `isinstance(raw, dict[str, object])` is invalid in Python 3.9+ — replaced with `isinstance(raw, dict)`

Closes #232

## Test plan
- [ ] `python -m pytest tests/mcp/test_auth_config_db.py -x` → 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus a one-line defensive fix in config listing; no changes to auth flows or live database behavior beyond the isinstance bugfix.
> 
> **Overview**
> Adds **11 unit tests** for auth, config, and database MCP tools, replacing placeholder test classes. Tests stub `tracertm.mcp.core` before import so `@mcp.tool()` is a no-op and the full MCP runtime is not required; `ConfigManager` is patched for isolated assertions on responses and side effects.
> 
> Fixes a **runtime bug in `config_list`**: `isinstance(raw, dict[str, object])` is invalid at runtime (PEP 585 generics are not valid for `isinstance`); it now uses `isinstance(raw, dict)` so listing config no longer raises `TypeError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e635cd7c156d6833e5a6b67b96d973a7c176ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix MCP auth, config, and database behavior and cover it with real tests**

### What Changed
- Added working tests for auth, config, and database tools so their key success and error paths are verified end to end.
- Prevented the MCP server startup during test collection, so these tests run without needing the full runtime environment.
- Fixed config listing so it correctly handles normal configuration data and no longer fails on valid Python dictionaries.

### Impact
`✅ Fewer MCP test startup failures`
`✅ Clearer config listing behavior`
`✅ More reliable auth and database tool checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
