### PR TITLE
fix(ci): remove npm cache from setup-node on Bun workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -42,7 +42,6 @@ jobs:
       uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
       with:
         node-version: '22'
-        cache: npm
     - name: Install Bun
       uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
       with:
@@ -51,7 +50,7 @@ jobs:
       uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
       with:
         path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: '${{ runner.os }}-bun-
 
           '

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,6 +18,7 @@ on:
     - frontend/apps/web/src/components/**
     - frontend/apps/web/.storybook/**
     - frontend/apps/web/package.json
+    - .github/workflows/chromatic.yml
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/test-validation.yml
+++ b/.github/workflows/test-validation.yml
@@ -25,6 +25,7 @@ on:
     - package.json
     - bun.lock
     - uv.lock
+    - .github/workflows/test-validation.yml
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test-validation.yml
+++ b/.github/workflows/test-validation.yml
@@ -35,7 +35,6 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
       with:
-        cache: npm
         node-version: '20'
     - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
       with:
@@ -56,12 +55,18 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
       with:
-        cache: npm
         node-version: '20'
     - name: Install bun
       uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
       with:
         bun-version: latest
+    - name: Cache Bun dependencies
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
     - name: Install dependencies
       run: 'cd frontend/apps/web
 
@@ -96,12 +101,18 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
       with:
-        cache: npm
         node-version: '20'
     - name: Install bun
       uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
       with:
         bun-version: latest
+    - name: Cache Bun dependencies
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
     - name: Install dependencies
       run: 'cd frontend/apps/web
 


### PR DESCRIPTION
## **User description**
## Summary
- Remove \cache: npm\ from \ctions/setup-node\ in Chromatic and Comprehensive Test Validation workflows.
- \setup-node\ npm cache requires \package-lock.json\; this repo uses \un.lock\ and Bun install (existing Bun cache steps remain in Chromatic).

## Test plan
- [ ] Chromatic Visual Regression Testing — Visual Regression Tests job passes setup step
- [ ] Comprehensive Test Validation — Setup test users and credentials job passes setup step


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application or security logic; main risk is misconfigured cache keys causing slower installs, not production impact.
> 
> **Overview**
> Fixes CI setup for **Bun-based** jobs by removing **`cache: npm`** from `actions/setup-node` in **Chromatic** and **Comprehensive Test Validation**, since npm caching expects `package-lock.json` while the repo uses **`bun.lock`**.
> 
> **Chromatic** now keys the Bun install cache on **`**/bun.lock`** (replacing `bun.lockb`) and includes the workflow file in **pull_request** path filters so workflow-only edits trigger the job.
> 
> **Test validation** adds the same **Bun dependency cache** step to **Frontend E2E** and **Frontend API** jobs (after removing npm cache from all `setup-node` steps that had it), and adds **`.github/workflows/test-validation.yml`** to PR path filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360e61bd7769f057de5c1b7826e18ab1318f034b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Remove failing npm cache setup from Bun-based CI workflows**

### What Changed
- Removed npm caching from the Chromatic and test validation workflows so their setup no longer depends on an npm lockfile
- Left the Bun install and caching steps in place for the workflows that use Bun
- This helps CI setup complete cleanly for visual regression, test-user setup, frontend E2E, and frontend API jobs

### Impact
`✅ Fewer CI setup failures`
`✅ More reliable visual regression runs`
`✅ More reliable test validation runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
