### PR TITLE
fix(frontend): move dev server from port 5173 to 5180

### DIFF
--- a/frontend/apps/web/vite.config.mjs
+++ b/frontend/apps/web/vite.config.mjs
@@ -378,14 +378,14 @@ export default defineConfig({
     extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
   },
   server: {
-    port: 5173,
-    strictPort: true,
-    // Bind to loopback only; Caddy (4000) is the single dev entrypoint. Do not open 5173 in the browser.
+    port: 5180,
+    strictPort: false,
+    // Bind to loopback; changed from 5173 (occupied by Civis) to 5180.
     host: '127.0.0.1',
     // Open: true or use vite --open to warm up entry and improve first load (Vite Performance Guide)
-    // Optimize HMR for faster updates; client connects via gateway so HMR works when using http://localhost:4000
+    // Optimize HMR for faster updates; client connects directly on the dev port.
     hmr: {
-      clientPort: 4000,
+      clientPort: 5180,
       overlay: true,
     },
     // Optimize watch settings


### PR DESCRIPTION
## **User description**
## Summary
- Port 5173 is occupied by Civis; Tracera dashboard now runs on port 5180
- Relaxed `strictPort` to `false` so a fallback port is used if 5180 is also busy
- Updated HMR `clientPort` from 4000 (Caddy gateway) to 5180 for direct dev usage

## Test plan
- [ ] `pnpm dev` starts without port conflict
- [ ] `curl http://localhost:5180` returns 200
- [ ] HMR updates work on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 29f227bbe9e57886ed56a2e326409c4b1b9ad596. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Move the web dev server to a free port and keep hot reload working directly on it**

### What Changed
- The web app now starts on port 5180 instead of 5173, avoiding the Civis port conflict
- If 5180 is already in use, the dev server can fall back to another port instead of failing
- Hot reload now connects to the same dev port for local development, so updates continue to work without the Caddy gateway

### Impact
`✅ Fewer local startup failures`
`✅ Fewer port conflict interruptions`
`✅ Reliable hot reload during local development`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
