### PR TITLE
chore(seed): extend FR/NFR ingestion to all 6 catalogs

### DIFF
--- a/scripts/seed_requirements.py
+++ b/scripts/seed_requirements.py
@@ -1,6 +1,6 @@
 """Seed FR/NFR catalogs into the Tracera traceability graph.
 
-Reads four cross-repo Markdown catalogs and builds:
+Reads six cross-repo Markdown catalogs and builds:
 
 * A :class:`~tracertm.models.trace_link.Requirement` per FR/NFR entry.
 * An :class:`~tracertm.models.trace_link.Artifact` per cited PR/test.
@@ -62,6 +62,16 @@ CATALOGS: list[tuple[str, Path]] = [
     (
         "AUTHV",
         Path("C:/Users/koosh/Dev/Authvault/docs/requirements/authvault-frnfr.md"),
+    ),
+    (
+        "PMCP",
+        Path("C:/Users/koosh/Dev/PhenoMCP/docs/requirements/phenomcp-frnfr.md"),
+    ),
+    (
+        "OBS",
+        Path(
+            "C:/Users/koosh/Dev/PhenoObservability/docs/requirements/phenoobservability-frnfr.md"
+        ),
     ),
 ]
 

--- a/tests/unit/storage/test_seed_requirements.py
+++ b/tests/unit/storage/test_seed_requirements.py
@@ -309,9 +309,9 @@ def test_real_catalog_parses_nonzero(project_key: str, catalog_path: Path) -> No
 
 
 def test_total_counts_across_all_catalogs() -> None:
-    """All four catalogs together should yield ≥50 requirements."""
+    """All six catalogs together should yield ≥100 requirements."""
     total = 0
     for project_key, catalog_path in sr.CATALOGS:
         if catalog_path.exists():
             total += len(sr.parse_catalog(project_key, catalog_path))
-    assert total >= 50, f"Expected ≥50 requirements across all catalogs, got {total}"
+    assert total >= 100, f"Expected ≥100 requirements across all catalogs, got {total}"


### PR DESCRIPTION
## Summary

- Extended `CATALOGS` list in `scripts/seed_requirements.py` from 4 to 6 entries, adding **PhenoMCP** (`PMCP`) and **PhenoObservability** (`OBS`)
- Created `PhenoObservability/docs/requirements/phenoobservability-frnfr.md` (49 FRs) in correct `### FR-OBS-NNN — Title` format
- Added `PR #35` traceability ref to `FR-AUTHV-013` in Authvault catalog
- Updated seed test threshold from ≥50 to ≥100 requirements across all 6 catalogs

**Seed totals:** 141 requirements / 126 unique artifacts / 245 links  
**Tests:** 36/36 green (all 6 catalogs smoke-tested)

## Test plan

- [x] `pytest tests/unit/storage/test_seed_requirements.py` — 36 passed
- [x] All 6 catalogs parse non-zero (parametrized smoke test)
- [x] Total count ≥ 100 threshold passes (141 actual)
- [ ] Live Neo4j write — re-run `uv run python scripts/seed_requirements.py` once docker daemon recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and test-threshold only; no parser or Neo4j write logic changes, and missing catalog paths are already skipped gracefully.
> 
> **Overview**
> Extends traceability seeding so **six** cross-repo FR/NFR Markdown catalogs are ingested instead of four, by registering **PhenoMCP** (`PMCP`) and **PhenoObservability** (`OBS`) in `CATALOGS` with the same absolute-path pattern as the other external repos. The seed script docstring now says six catalogs.
> 
> The aggregate seed test is tightened to expect **≥100** requirements across all configured catalogs (was ≥50). The parametrized per-catalog smoke test still iterates `CATALOGS`, so the two new entries are covered automatically when those files exist locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca4ba76ab169745cd994fd3bbd096e97a91d96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->