### PR TITLE
feat(quality): FR-TRC-012 duplicate/conflict detector + POST /api/v1/quality/duplicates,conflicts

### DIFF
--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -203,6 +203,27 @@
 
 ---
 
+### FR-TRC-012 — Automated Duplicate / Conflict Detection via TraceLink Miner
+
+**Title:** Detect near-duplicate requirements and mutually-exclusive TraceLinks
+
+**Description:** The system shall provide a `dup_conflict_detector` service that, given an in-memory collection of `Artifact`/`Requirement` objects and `TraceLink` objects, identifies (a) near-duplicate requirements using token-Jaccard similarity (stdlib `difflib`-compatible, no external NLP dependency) above a configurable threshold (default 0.75), and (b) conflicting TraceLinks where the same ordered (source, target) artifact pair carries mutually-exclusive link types (e.g. `CONFLICTS_WITH` co-existing with `SATISFIES`, `VERIFIES`, `IMPLEMENTS`, `DERIVES_FROM`, or `REFINES`). Both detectors are pure functions over in-memory collections (no live DB access required). The API shall expose two read-only POST endpoints: `POST /api/v1/quality/duplicates` and `POST /api/v1/quality/conflicts`.
+
+**Acceptance Criteria:**
+- `detect_duplicate_requirements(artifacts, threshold)` returns `DuplicateFinding` list sorted descending by similarity.
+- `detect_conflicting_links(links)` returns `ConflictFinding` list for all (source, target) pairs with cooperative + `CONFLICTS_WITH` link types.
+- Threshold outside `(0.0, 1.0]` raises `ValueError`.
+- `POST /api/v1/quality/duplicates` and `POST /api/v1/quality/conflicts` accept JSON bodies and return findings with confidence.
+- 22 unit tests pass with no live DB or graph required.
+
+**Traceability:**
+- Branch: `feat/dup-conflict-detector`
+- Source: `src/tracertm/services/dup_conflict_detector.py`, `src/tracertm/api/routers/dup_conflict.py`
+- Tests: `src/tracertm/services/test_dup_conflict_detector.py` (22 tests)
+- Closes: FR-TRC-012
+
+---
+
 ## Non-Functional Requirements
 
 ### NFR-TRC-001 — Spatial Index Query Performance
@@ -296,7 +317,7 @@
 | ID | Title | Status | Notes |
 |----|-------|--------|-------|
 | FR-TRC-011 | RAG-layer traceability query (LLM-assisted link suggestion) | PLANNED | Referenced in `trace_link.py` docstring as "later PRs"; miner posterior = `confidence` field |
-| FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | PLANNED | `DUPLICATES` and `CONFLICTS_WITH` link types defined but no miner service wired |
+| FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | SHIPPED | Token-Jaccard duplicate detector + structural conflict detector; `dup_conflict_detector.py`; endpoints POST /api/v1/quality/duplicates + /conflicts; PR: feat/dup-conflict-detector |
 | FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | PLANNED | `github_import_service.py`, `jira_import_service.py` exist but TraceLink confidence mapping TBD |
 | FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | PLANNED | `traceability_matrix_service.py` and `frontend/apps/web/e2e/traceability-matrix.spec.ts` exist; FR/NFR ingestion path not wired |
 | FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | PLANNED | `impact_analysis_service.py`, `critical_path_service.py` exist; no confidence-weighted scoring yet |
@@ -321,4 +342,5 @@
 | FR-TRC-008 | #466 | `test_auth_config_db.py` |
 | FR-TRC-009 | #469 | alembic `063` |
 | FR-TRC-010 | #470 | `test_project_lifecycle.py` |
+| FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -19,6 +19,7 @@ from tracertm.api.routers import (
     comments,
     contracts,
     coverage,
+    dup_conflict,
     execution,
     executions,
     features,
@@ -97,6 +98,9 @@ def register_api_routers(app: FastAPI) -> None:
 
     # Impact analysis (Cypher forward/reverse traversal)
     app.include_router(impact.router, prefix="/api/v1")
+
+    # Duplicate / conflict detection (FR-TRC-012)
+    app.include_router(dup_conflict.router, prefix="/api/v1")
 
     # MCP router (Model Context Protocol over HTTP)
     app.include_router(mcp.router, prefix="/api/v1")

--- a/src/tracertm/api/routers/dup_conflict.py
+++ b/src/tracertm/api/routers/dup_conflict.py
@@ -1,0 +1,214 @@
+"""Duplicate and conflict detection API routes.
+
+Exposes read-only quality-gate endpoints over an in-memory graph payload.
+
+Endpoints
+---------
+POST /api/v1/quality/duplicates
+    Detect near-duplicate requirements from a submitted list.
+
+POST /api/v1/quality/conflicts
+    Detect conflicting TraceLink pairs from a submitted list.
+
+Functional Requirements: FR-TRC-012
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from tracertm.api.deps import auth_guard
+from tracertm.models.trace_link import Artifact, ArtifactKind, TraceLink, TraceLinkType
+from tracertm.services.dup_conflict_detector import (
+    ConflictFinding,
+    DuplicateFinding,
+    detect_conflicting_links,
+    detect_duplicate_requirements,
+)
+
+router = APIRouter(prefix="/quality", tags=["quality"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class ArtifactPayload(BaseModel):
+    """Wire format for an artifact submitted to the duplicates endpoint."""
+
+    id: str
+    project_id: str
+    kind: ArtifactKind = ArtifactKind.REQUIREMENT
+    title: str
+    description: str | None = None
+    external_id: str | None = None
+
+
+class TraceLinkPayload(BaseModel):
+    """Wire format for a TraceLink submitted to the conflicts endpoint."""
+
+    id: str
+    project_id: str
+    source_artifact_id: str
+    target_artifact_id: str
+    link_type: TraceLinkType
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    rationale: str | None = None
+
+
+class DuplicatesRequest(BaseModel):
+    """Request body for the duplicates endpoint."""
+
+    artifacts: list[ArtifactPayload]
+    threshold: float = Field(default=0.75, gt=0.0, le=1.0)
+
+
+class ConflictsRequest(BaseModel):
+    """Request body for the conflicts endpoint."""
+
+    links: list[TraceLinkPayload]
+
+
+class DuplicateFindingOut(BaseModel):
+    """Serialisable duplicate finding."""
+
+    artifact_a_id: str
+    artifact_a_title: str
+    artifact_b_id: str
+    artifact_b_title: str
+    similarity: float
+
+
+class ConflictFindingOut(BaseModel):
+    """Serialisable conflict finding."""
+
+    link_a_id: str
+    link_b_id: str
+    source_artifact_id: str
+    target_artifact_id: str
+    link_type_a: str
+    link_type_b: str
+    confidence: float
+
+
+class DuplicatesResponse(BaseModel):
+    """Response for the duplicates endpoint."""
+
+    threshold: float
+    total: int
+    findings: list[DuplicateFindingOut]
+
+
+class ConflictsResponse(BaseModel):
+    """Response for the conflicts endpoint."""
+
+    total: int
+    findings: list[ConflictFindingOut]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _finding_to_out(f: DuplicateFinding) -> DuplicateFindingOut:
+    return DuplicateFindingOut(
+        artifact_a_id=str(f.artifact_a_id),
+        artifact_a_title=f.artifact_a_title,
+        artifact_b_id=str(f.artifact_b_id),
+        artifact_b_title=f.artifact_b_title,
+        similarity=f.similarity,
+    )
+
+
+def _conflict_to_out(c: ConflictFinding) -> ConflictFindingOut:
+    return ConflictFindingOut(
+        link_a_id=str(c.link_a_id),
+        link_b_id=str(c.link_b_id),
+        source_artifact_id=str(c.source_artifact_id),
+        target_artifact_id=str(c.target_artifact_id),
+        link_type_a=c.link_type_a.value,
+        link_type_b=c.link_type_b.value,
+        confidence=c.confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/duplicates",
+    response_model=DuplicatesResponse,
+    summary="Detect near-duplicate requirements",
+    description=(
+        "Accepts a list of Artifact/Requirement objects and returns pairs "
+        "whose token-Jaccard similarity meets or exceeds *threshold*. "
+        "FR-TRC-012."
+    ),
+)
+async def detect_duplicates(
+    body: DuplicatesRequest,
+    _claims: Annotated[dict[str, Any], Depends(auth_guard)],
+) -> DuplicatesResponse:
+    """Detect near-duplicate requirements via token-Jaccard similarity."""
+    import uuid
+
+    artifacts = [
+        Artifact(
+            id=uuid.UUID(a.id),
+            project_id=uuid.UUID(a.project_id),
+            kind=a.kind,
+            title=a.title,
+            description=a.description,
+            external_id=a.external_id,
+        )
+        for a in body.artifacts
+    ]
+    findings = detect_duplicate_requirements(artifacts, threshold=body.threshold)
+    return DuplicatesResponse(
+        threshold=body.threshold,
+        total=len(findings),
+        findings=[_finding_to_out(f) for f in findings],
+    )
+
+
+@router.post(
+    "/conflicts",
+    response_model=ConflictsResponse,
+    summary="Detect conflicting TraceLinks",
+    description=(
+        "Accepts a list of TraceLink objects and returns pairs that are "
+        "mutually exclusive on the same (source, target) artifact pair. "
+        "FR-TRC-012."
+    ),
+)
+async def detect_conflicts(
+    body: ConflictsRequest,
+    _claims: Annotated[dict[str, Any], Depends(auth_guard)],
+) -> ConflictsResponse:
+    """Detect mutually-exclusive TraceLink pairs."""
+    import uuid
+
+    links = [
+        TraceLink(
+            id=uuid.UUID(lp.id),
+            project_id=uuid.UUID(lp.project_id),
+            source_artifact_id=uuid.UUID(lp.source_artifact_id),
+            target_artifact_id=uuid.UUID(lp.target_artifact_id),
+            link_type=lp.link_type,
+            confidence=lp.confidence,
+            rationale=lp.rationale,
+        )
+        for lp in body.links
+    ]
+    findings = detect_conflicting_links(links)
+    return ConflictsResponse(
+        total=len(findings),
+        findings=[_conflict_to_out(c) for c in findings],
+    )

--- a/src/tracertm/services/dup_conflict_detector.py
+++ b/src/tracertm/services/dup_conflict_detector.py
@@ -1,0 +1,249 @@
+"""Duplicate and conflict detector for Tracera requirements + TraceLinks.
+
+Implements FR-TRC-012: Automated duplicate / conflict detection via TraceLink
+miner.
+
+Two detection modes
+-------------------
+1. **Duplicate requirements** — pairs of :class:`~tracertm.models.trace_link.Requirement`
+   (or generic :class:`~tracertm.models.trace_link.Artifact`) whose normalised
+   text (title + description) share a token-Jaccard similarity above a
+   configurable threshold (default 0.75). Uses Python stdlib ``difflib`` only —
+   no external NLP dependency.
+
+2. **Conflicting TraceLinks** — pairs of :class:`~tracertm.models.trace_link.TraceLink`
+   where the same ordered (source, target) artifact pair is simultaneously
+   tagged with mutually-exclusive link types.  Current conflict rules:
+
+   * A link typed ``CONFLICTS_WITH`` co-exists with any of the cooperative link
+     types (``SATISFIES``, ``VERIFIES``, ``IMPLEMENTS``, ``DERIVES_FROM``,
+     ``REFINES``) on the **same (source, target) pair**.
+   * The same (source, target) pair carries both ``SATISFIES`` and
+     ``CONFLICTS_WITH``, or both ``IMPLEMENTS`` and ``CONFLICTS_WITH``.
+
+Both detectors are **pure functions** (no DB access) so they can be composed
+over any in-memory collection or graph projection.  The API layer feeds them
+the materialised artifact/link lists from the repository.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from tracertm.models.trace_link import Artifact, TraceLink, TraceLinkType
+
+__all__ = [
+    "ConflictFinding",
+    "DuplicateFinding",
+    "detect_conflicting_links",
+    "detect_duplicate_requirements",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Link types that are inherently cooperative / positive relationships.
+_COOPERATIVE_TYPES: frozenset[TraceLinkType] = frozenset({
+    TraceLinkType.SATISFIES,
+    TraceLinkType.VERIFIES,
+    TraceLinkType.IMPLEMENTS,
+    TraceLinkType.DERIVES_FROM,
+    TraceLinkType.REFINES,
+})
+
+#: A link typed CONFLICTS_WITH alongside any cooperative type is a conflict.
+_CONFLICT_PAIRS: frozenset[frozenset[TraceLinkType]] = frozenset({
+    frozenset({TraceLinkType.CONFLICTS_WITH, t}) for t in _COOPERATIVE_TYPES
+})
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicateFinding:
+    """A near-duplicate pair of requirements/artifacts."""
+
+    artifact_a_id: uuid.UUID
+    artifact_a_title: str
+    artifact_b_id: uuid.UUID
+    artifact_b_title: str
+    #: Jaccard similarity score in [0.0, 1.0].
+    similarity: float
+
+
+@dataclass(frozen=True, slots=True)
+class ConflictFinding:
+    """A pair of TraceLinks that are mutually exclusive."""
+
+    link_a_id: uuid.UUID
+    link_b_id: uuid.UUID
+    source_artifact_id: uuid.UUID
+    target_artifact_id: uuid.UUID
+    link_type_a: TraceLinkType
+    link_type_b: TraceLinkType
+    #: Confidence is 1.0 — structural contradiction, no probability involved.
+    confidence: float = field(default=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Text normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise(text: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _token_set(text: str) -> set[str]:
+    """Return the set of non-empty tokens after normalisation."""
+    return set(_normalise(text).split())
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    """Token Jaccard similarity: |A ∩ B| / |A ∪ B|.
+
+    Returns 0.0 when both sets are empty (avoids division by zero).
+    """
+    if not a and not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _artifact_tokens(artifact: Artifact) -> set[str]:
+    """Combine title + description into one token set."""
+    text = artifact.title
+    if artifact.description:
+        text = f"{text} {artifact.description}"
+    return _token_set(text)
+
+
+# ---------------------------------------------------------------------------
+# Public detector functions
+# ---------------------------------------------------------------------------
+
+
+def detect_duplicate_requirements(
+    artifacts: Sequence[Artifact],
+    threshold: float = 0.75,
+) -> list[DuplicateFinding]:
+    """Detect near-duplicate requirements by token-Jaccard similarity.
+
+    Compares every distinct pair in *O(n²)* — suitable for project-scoped
+    batches (hundreds to low thousands of requirements).  Use a higher
+    ``threshold`` (e.g. 0.90) if you want only near-exact duplicates.
+
+    Args:
+        artifacts: Iterable of :class:`~tracertm.models.trace_link.Artifact`
+            (or :class:`~tracertm.models.trace_link.Requirement`) objects.
+        threshold: Minimum Jaccard similarity to classify as a duplicate.
+            Must be in (0.0, 1.0].  Default is 0.75.
+
+    Returns:
+        List of :class:`DuplicateFinding` for pairs whose similarity is
+        at or above *threshold*, sorted descending by similarity.
+
+    Raises:
+        ValueError: If *threshold* is outside (0.0, 1.0].
+    """
+    if not 0.0 < threshold <= 1.0:
+        msg = f"threshold must be in (0.0, 1.0], got {threshold!r}"
+        raise ValueError(msg)
+
+    items = list(artifacts)
+    findings: list[DuplicateFinding] = []
+
+    for i in range(len(items)):
+        tokens_i = _artifact_tokens(items[i])
+        for j in range(i + 1, len(items)):
+            tokens_j = _artifact_tokens(items[j])
+            score = _jaccard(tokens_i, tokens_j)
+            if score >= threshold:
+                findings.append(
+                    DuplicateFinding(
+                        artifact_a_id=items[i].id,
+                        artifact_a_title=items[i].title,
+                        artifact_b_id=items[j].id,
+                        artifact_b_title=items[j].title,
+                        similarity=round(score, 4),
+                    )
+                )
+
+    findings.sort(key=lambda f: f.similarity, reverse=True)
+    return findings
+
+
+def detect_conflicting_links(
+    links: Sequence[TraceLink],
+) -> list[ConflictFinding]:
+    """Detect mutually-exclusive TraceLink pairs on the same (source, target).
+
+    A conflict is raised when the **same ordered (source_artifact_id,
+    target_artifact_id) pair** carries two link types that are logically
+    incompatible:
+
+    * ``CONFLICTS_WITH`` paired with any cooperative type
+      (``SATISFIES``, ``VERIFIES``, ``IMPLEMENTS``, ``DERIVES_FROM``,
+      ``REFINES``).
+
+    Args:
+        links: Collection of :class:`~tracertm.models.trace_link.TraceLink`
+            objects to inspect.
+
+    Returns:
+        List of :class:`ConflictFinding`, one per conflicting pair, sorted
+        by (source_artifact_id, target_artifact_id, link_type_a).
+    """
+    # Group links by (source, target) pair.
+    from collections import defaultdict
+
+    pair_map: dict[
+        tuple[uuid.UUID, uuid.UUID], list[TraceLink]
+    ] = defaultdict(list)
+    for link in links:
+        pair_map[(link.source_artifact_id, link.target_artifact_id)].append(link)
+
+    findings: list[ConflictFinding] = []
+    seen: set[frozenset[uuid.UUID]] = set()
+
+    for (src, tgt), group in pair_map.items():
+        # Check every distinct link pair within this (source, target) group.
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                a, b = group[i], group[j]
+                type_pair: frozenset[TraceLinkType] = frozenset({a.link_type, b.link_type})
+                id_pair: frozenset[uuid.UUID] = frozenset({a.id, b.id})
+
+                # Skip already-recorded pairs (can't happen with i<j, but safe).
+                if id_pair in seen:
+                    continue
+
+                if type_pair in _CONFLICT_PAIRS:
+                    seen.add(id_pair)
+                    # Stable ordering: put CONFLICTS_WITH second for readability.
+                    if a.link_type == TraceLinkType.CONFLICTS_WITH:
+                        a, b = b, a
+                    findings.append(
+                        ConflictFinding(
+                            link_a_id=a.id,
+                            link_b_id=b.id,
+                            source_artifact_id=src,
+                            target_artifact_id=tgt,
+                            link_type_a=a.link_type,
+                            link_type_b=b.link_type,
+                        )
+                    )
+
+    findings.sort(
+        key=lambda f: (str(f.source_artifact_id), str(f.target_artifact_id), f.link_type_a.value)
+    )
+    return findings

--- a/src/tracertm/services/test_dup_conflict_detector.py
+++ b/src/tracertm/services/test_dup_conflict_detector.py
@@ -1,0 +1,273 @@
+"""Unit tests for the duplicate / conflict detector service.
+
+Functional Requirements: FR-TRC-012
+
+Coverage
+--------
+* Near-duplicate pair detected above threshold.
+* Distinct requirements NOT flagged as duplicates.
+* A conflicting link pair detected.
+* Clean link set returns empty findings.
+* Edge cases: threshold validation, empty inputs.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tracertm.models.trace_link import Artifact, ArtifactKind, TraceLink, TraceLinkType
+from tracertm.services.dup_conflict_detector import (
+    detect_conflicting_links,
+    detect_duplicate_requirements,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROJECT = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_PROJ_B = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000001")
+
+
+def _req(title: str, description: str | None = None) -> Artifact:
+    return Artifact(
+        id=uuid.uuid4(),
+        project_id=_PROJECT,
+        kind=ArtifactKind.REQUIREMENT,
+        title=title,
+        description=description,
+    )
+
+
+def _link(
+    src: uuid.UUID,
+    tgt: uuid.UUID,
+    link_type: TraceLinkType,
+) -> TraceLink:
+    return TraceLink(
+        id=uuid.uuid4(),
+        project_id=_PROJ_B,
+        source_artifact_id=src,
+        target_artifact_id=tgt,
+        link_type=link_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection
+# ---------------------------------------------------------------------------
+
+
+def test_near_duplicate_pair_detected() -> None:
+    """Two requirements with near-identical text are flagged as duplicates."""
+    a = _req(
+        "The system shall validate user input before processing",
+        "Input validation is required",
+    )
+    b = _req(
+        "The system shall validate user input before processing",
+        "Input validation is required for all forms",
+    )
+    findings = detect_duplicate_requirements([a, b], threshold=0.70)
+    assert len(findings) == 1
+    finding = findings[0]
+    assert {finding.artifact_a_id, finding.artifact_b_id} == {a.id, b.id}
+    assert finding.similarity >= 0.70
+
+
+def test_exact_duplicates_score_1_0() -> None:
+    """Identical title+description yields similarity 1.0."""
+    title = "The system shall authenticate users via OAuth2"
+    a = _req(title, "OAuth2 PKCE flow required")
+    b = _req(title, "OAuth2 PKCE flow required")
+    findings = detect_duplicate_requirements([a, b])
+    assert len(findings) == 1
+    assert findings[0].similarity == 1.0
+
+
+def test_distinct_requirements_not_flagged() -> None:
+    """Requirements with clearly different text produce no findings."""
+    a = _req("The system shall export reports to PDF", "PDF export via wkhtmltopdf")
+    b = _req("The system shall authenticate users via SSO", "SAML 2.0 IdP required")
+    c = _req("Database backups must run daily at midnight", "Automated pg_dump scheduled task")
+    assert detect_duplicate_requirements([a, b, c]) == []
+
+
+def test_empty_artifacts_returns_empty() -> None:
+    """Empty artifact list yields no findings."""
+    assert detect_duplicate_requirements([]) == []
+
+
+def test_single_artifact_no_findings() -> None:
+    """A single artifact has no peer to compare against."""
+    assert detect_duplicate_requirements([_req("Only one requirement")]) == []
+
+
+def test_findings_sorted_descending_by_similarity() -> None:
+    """Multiple findings are returned highest similarity first."""
+    base = "The system shall log all user actions to the audit trail"
+    a = _req(base)
+    b = _req(base)
+    c = _req("The system shall log user actions to audit")
+    findings = detect_duplicate_requirements([a, b, c], threshold=0.5)
+    assert len(findings) >= 2
+    sims = [f.similarity for f in findings]
+    assert sims == sorted(sims, reverse=True)
+
+
+def test_threshold_zero_raises() -> None:
+    """Threshold of 0.0 is invalid."""
+    with pytest.raises(ValueError, match="threshold"):
+        detect_duplicate_requirements([_req("x")], threshold=0.0)
+
+
+def test_threshold_negative_raises() -> None:
+    """Negative threshold raises ValueError."""
+    with pytest.raises(ValueError, match="threshold"):
+        detect_duplicate_requirements([_req("x")], threshold=-0.1)
+
+
+def test_threshold_1_flags_only_exact() -> None:
+    """Threshold 1.0 flags only token-identical pairs."""
+    a = _req("System shall validate input")
+    b = _req("System shall validate input")
+    c = _req("System shall validate all user input")
+    findings = detect_duplicate_requirements([a, b, c], threshold=1.0)
+    assert len(findings) == 1
+    assert {findings[0].artifact_a_id, findings[0].artifact_b_id} == {a.id, b.id}
+
+
+def test_description_contributes_to_similarity() -> None:
+    """Description text is folded into the token set."""
+    a = _req("Auth requirement", "Users must log in with their corporate SSO credentials")
+    b = _req("Auth requirement", "Users must log in with their corporate SSO credentials")
+    findings = detect_duplicate_requirements([a, b], threshold=0.9)
+    assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Conflict detection
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_and_conflicts_with_flagged() -> None:
+    """SATISFIES + CONFLICTS_WITH on the same (src, tgt) pair is a conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.SATISFIES),
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+    ])
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.source_artifact_id == src
+    assert f.target_artifact_id == tgt
+    assert TraceLinkType.CONFLICTS_WITH.value in {f.link_type_a, f.link_type_b}
+    assert f.confidence == 1.0
+
+
+def test_implements_and_conflicts_with_flagged() -> None:
+    """IMPLEMENTS + CONFLICTS_WITH on same pair is a conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.IMPLEMENTS),
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+    ])
+    assert len(findings) == 1
+
+
+def test_verifies_and_conflicts_with_flagged() -> None:
+    """VERIFIES + CONFLICTS_WITH on same pair is a conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.VERIFIES),
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+    ])
+    assert len(findings) == 1
+
+
+def test_derives_from_and_conflicts_with_flagged() -> None:
+    """DERIVES_FROM + CONFLICTS_WITH on same pair is a conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.DERIVES_FROM),
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+    ])
+    assert len(findings) == 1
+
+
+def test_refines_and_conflicts_with_flagged() -> None:
+    """REFINES + CONFLICTS_WITH on same pair is a conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.REFINES),
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+    ])
+    assert len(findings) == 1
+
+
+def test_different_pairs_no_cross_conflict() -> None:
+    """CONFLICTS_WITH on one (src, tgt) pair does not affect a different pair."""
+    src1, tgt1 = uuid.uuid4(), uuid.uuid4()
+    src2, tgt2 = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src1, tgt1, TraceLinkType.SATISFIES),
+        _link(src1, tgt1, TraceLinkType.CONFLICTS_WITH),
+        _link(src2, tgt2, TraceLinkType.SATISFIES),
+    ])
+    assert len(findings) == 1
+    assert findings[0].source_artifact_id == src1
+
+
+def test_clean_links_returns_empty() -> None:
+    """Links with no mutual exclusion return empty findings."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.SATISFIES),
+        _link(src, tgt, TraceLinkType.VERIFIES),
+    ])
+    assert findings == []
+
+
+def test_two_cooperative_types_no_conflict() -> None:
+    """SATISFIES + IMPLEMENTS on same pair is NOT a conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    assert detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.SATISFIES),
+        _link(src, tgt, TraceLinkType.IMPLEMENTS),
+    ]) == []
+
+
+def test_empty_links_returns_empty() -> None:
+    """Empty link list yields empty findings."""
+    assert detect_conflicting_links([]) == []
+
+
+def test_single_link_no_conflict() -> None:
+    """A single link cannot conflict with itself."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    assert detect_conflicting_links([_link(src, tgt, TraceLinkType.SATISFIES)]) == []
+
+
+def test_conflicts_with_only_not_a_conflict() -> None:
+    """Two CONFLICTS_WITH links on same pair are not a structural conflict."""
+    src, tgt = uuid.uuid4(), uuid.uuid4()
+    findings = detect_conflicting_links([
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+        _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+    ])
+    assert findings == []
+
+
+def test_multiple_conflict_pairs_all_found() -> None:
+    """Multiple conflicting pairs on distinct (src, tgt) are all reported."""
+    pairs = [(uuid.uuid4(), uuid.uuid4()) for _ in range(3)]
+    links = []
+    for src, tgt in pairs:
+        links.append(_link(src, tgt, TraceLinkType.SATISFIES))
+        links.append(_link(src, tgt, TraceLinkType.CONFLICTS_WITH))
+    findings = detect_conflicting_links(links)
+    assert len(findings) == 3


### PR DESCRIPTION
## **User description**
## Summary

Implements **FR-TRC-012** (Automated duplicate / conflict detection via TraceLink miner).

- **`dup_conflict_detector.py`** — two pure detector functions, no live DB required:
  - `detect_duplicate_requirements(artifacts, threshold=0.75)` — token-Jaccard similarity using Python stdlib (no external NLP dep); returns `DuplicateFinding` list sorted descending by score
  - `detect_conflicting_links(links)` — structural conflict: same (source, target) pair tagged with `CONFLICTS_WITH` + any cooperative type (`SATISFIES`, `VERIFIES`, `IMPLEMENTS`, `DERIVES_FROM`, `REFINES`)
- **`dup_conflict.py` router** — `POST /api/v1/quality/duplicates` and `POST /api/v1/quality/conflicts`; accepts artifact/link JSON payloads, returns findings with confidence
- **router_registry.py** — registers new router under `/api/v1`
- **docs/requirements/tracera-frnfr.md** — FR-TRC-012 PLANNED → SHIPPED with full FR spec entry

## Test plan

- [x] 22 unit tests in `src/tracertm/services/test_dup_conflict_detector.py` — all green, no DB/network needed
- [x] Near-duplicate pair detected above threshold
- [x] Distinct requirements not flagged
- [x] Conflicting link pair (SATISFIES + CONFLICTS_WITH) detected
- [x] Clean link set returns empty
- [x] All 5 cooperative types tested against CONFLICTS_WITH
- [x] Threshold validation (0.0, negative raise ValueError)
- [x] Edge cases: empty inputs, single item, exact duplicates → similarity 1.0

Closes FR-TRC-012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only, auth-protected endpoints over client-supplied payloads; no persistence or DB/graph writes. O(n²) duplicate scans may need size limits if exposed to very large batches later.
> 
> **Overview**
> Ships **FR-TRC-012** by adding in-memory quality checks for requirements and trace links, plus authenticated API entry points and requirements doc updates.
> 
> A new **`dup_conflict_detector`** service exposes pure functions: **`detect_duplicate_requirements`** (token-Jaccard on normalized title+description, default threshold 0.75, invalid thresholds raise **`ValueError`**) and **`detect_conflicting_links`** (same ordered source/target with **`CONFLICTS_WITH`** plus a cooperative type). The **`dup_conflict`** router registers **`POST /api/v1/quality/duplicates`** and **`POST /api/v1/quality/conflicts`**, mapping JSON payloads to domain models and returning findings (conflicts use structural confidence 1.0). **`router_registry`** wires the router; **`tracera-frnfr.md`** documents FR-TRC-012 and marks it **SHIPPED** in the gap table and traceability map. **22** unit tests cover duplicates, conflicts, and edge cases with no DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9341eff789797b38ec4275090ed90a3465959cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add duplicate and conflict checks for requirements and TraceLinks**

### What Changed
- Added two quality checks that run on submitted data: one flags near-duplicate requirements, and the other flags conflicting TraceLinks on the same source-target pair
- Exposed new read-only endpoints for these checks: `/api/v1/quality/duplicates` and `/api/v1/quality/conflicts`
- Returned clear results with matched item IDs, titles, similarity or confidence, and kept the checks independent of the live database
- Marked FR-TRC-012 as shipped in the requirements docs and added unit tests covering duplicates, conflicts, thresholds, and empty inputs

### Impact
`✅ Faster review of duplicate requirements`
`✅ Earlier detection of contradictory trace links`
`✅ Clearer quality-gate results for traceability checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
