### PR TITLE
feat(coverage-matrix): FR-TRC-014 coverage matrix export (CSV/JSON)

### DIFF
--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -345,7 +345,7 @@
 | FR-TRC-011 | RAG-layer traceability query / requirement miner | SHIPPED | Heuristic miner (modal verbs, FR/NFR tags, spec markers) + confidence scoring; `requirement_miner.py`; endpoint POST /api/v1/mine/requirements; PR: feat/requirement-miner |
 | FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | SHIPPED | Token-Jaccard duplicate detector + structural conflict detector; `dup_conflict_detector.py`; endpoints POST /api/v1/quality/duplicates + /conflicts; PR: feat/dup-conflict-detector |
 | FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | PLANNED | `github_import_service.py`, `jira_import_service.py` exist but TraceLink confidence mapping TBD |
-| FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | PLANNED | `traceability_matrix_service.py` and `frontend/apps/web/e2e/traceability-matrix.spec.ts` exist; FR/NFR ingestion path not wired |
+| FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | SHIPPED | Pure-function `coverage_matrix_service.py`; rows=requirements, cols=impl/test + ArtifactKind buckets; endpoint GET /api/v1/coverage/matrix?format=csv\|json; CSV RFC 4180 + pipe-separated multi-artifact cells; PDF deferred (heavy dep); 25 unit tests; PR: feat/coverage-matrix-export |
 | FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | PLANNED | `impact_analysis_service.py`, `critical_path_service.py` exist; no confidence-weighted scoring yet |
 | FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | PLANNED | Dog-food use case; AgilePlus at `C:/Users/koosh/Dev/AgilePlus`; API contract TBD |
 | FR-TRC-017 | Traceability coverage / health scoring over Requirement-Artifact-TraceLink graph | SHIPPED | Pure-function `traceability_score_service.py`; metrics: impl_coverage, test_coverage, orphan_req_pct, orphan_art_pct, avg_confidence, composite 0-100; endpoint GET /api/v1/quality/score; 19 unit tests; PR: feat/quality-scoring |
@@ -370,5 +370,6 @@
 | FR-TRC-010 | #470 | `test_project_lifecycle.py` |
 | FR-TRC-011 | feat/requirement-miner | `test_requirement_miner.py` (26 tests) |
 | FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
+| FR-TRC-014 | feat/coverage-matrix-export | `test_coverage_matrix_service.py` (25 tests) |
 | FR-TRC-017 | feat/quality-scoring | `test_traceability_score_service.py` (19 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -19,6 +19,7 @@ from tracertm.api.routers import (
     comments,
     contracts,
     coverage,
+    coverage_matrix,
     dup_conflict,
     execution,
     executions,
@@ -109,6 +110,9 @@ def register_api_routers(app: FastAPI) -> None:
 
     # Traceability quality scoring (FR-TRC-017)
     app.include_router(traceability_score.router, prefix="/api/v1")
+
+    # Coverage matrix export (FR-TRC-014)
+    app.include_router(coverage_matrix.router, prefix="/api/v1")
 
     # MCP router (Model Context Protocol over HTTP)
     app.include_router(mcp.router, prefix="/api/v1")

--- a/src/tracertm/api/routers/coverage_matrix.py
+++ b/src/tracertm/api/routers/coverage_matrix.py
@@ -1,0 +1,147 @@
+"""Coverage matrix export API route.
+
+Exposes a read-only GET endpoint that builds and exports a requirement
+coverage matrix from an in-memory graph snapshot.
+
+Endpoint
+--------
+GET /api/v1/coverage/matrix?format=csv|json
+    Accepts artifact + link arrays as a JSON request body and returns the
+    coverage matrix in the requested format.
+
+Formats
+-------
+* ``csv``  — RFC 4180 CSV with Content-Disposition attachment header.
+* ``json`` — Structured JSON (default).
+
+PDF is a planned future format (excluded from v1 — heavy dep on
+reportlab/WeasyPrint).
+
+Functional Requirements: FR-TRC-014
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import PlainTextResponse, Response
+from pydantic import BaseModel, Field
+
+from tracertm.api.deps import auth_guard
+from tracertm.models.trace_link import Artifact, ArtifactKind, TraceLink, TraceLinkType
+from tracertm.services.coverage_matrix_service import (
+    build_coverage_matrix,
+    export_csv,
+    export_json,
+)
+
+router: APIRouter = APIRouter(prefix="/coverage", tags=["Coverage"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas (reuse ArtifactIn / TraceLinkIn pattern from
+# traceability_score router — same graph snapshot contract)
+# ---------------------------------------------------------------------------
+
+
+class ArtifactIn(BaseModel):
+    """Minimal artifact payload for the matrix endpoint."""
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    kind: ArtifactKind
+    title: str = Field(min_length=1, max_length=500)
+    description: str | None = None
+    external_id: str | None = None
+
+
+class TraceLinkIn(BaseModel):
+    """Minimal trace link payload for the matrix endpoint."""
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    project_id: uuid.UUID
+    source_artifact_id: uuid.UUID
+    target_artifact_id: uuid.UUID
+    link_type: TraceLinkType
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    rationale: str | None = None
+
+
+class MatrixRequest(BaseModel):
+    """Request body: graph snapshot to export as a coverage matrix."""
+
+    artifacts: list[ArtifactIn] = Field(default_factory=list)
+    links: list[TraceLinkIn] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/matrix")
+async def get_coverage_matrix(
+    body: MatrixRequest,
+    format: Literal["csv", "json"] = "json",  # noqa: A002  # query param name matches FR spec
+    _claims: Annotated[dict[str, Any], Depends(auth_guard)],
+) -> Response:
+    """Export a requirement coverage matrix in CSV or JSON format.
+
+    Supply the artifact list and trace-link list in the request body.
+    The service computes the matrix in-memory (no DB access).
+
+    Query Parameters
+    ----------------
+    format : ``"csv"`` | ``"json"`` (default ``"json"``)
+
+    Returns
+    -------
+    * ``format=json`` — ``application/json`` body with ``meta`` summary and
+      ``rows`` array.
+    * ``format=csv``  — ``text/csv`` attachment
+      (``Content-Disposition: attachment; filename="coverage_matrix.csv"``).
+
+    Functional Requirements: FR-TRC-014
+    """
+    # Convert request payloads to domain value objects
+    artifacts = [
+        Artifact(
+            id=a.id,
+            project_id=a.project_id,
+            kind=a.kind,
+            title=a.title,
+            description=a.description,
+            external_id=a.external_id,
+        )
+        for a in body.artifacts
+    ]
+    links = [
+        TraceLink(
+            id=lnk.id,
+            project_id=lnk.project_id,
+            source_artifact_id=lnk.source_artifact_id,
+            target_artifact_id=lnk.target_artifact_id,
+            link_type=lnk.link_type,
+            confidence=lnk.confidence,
+            rationale=lnk.rationale,
+        )
+        for lnk in body.links
+    ]
+
+    report = build_coverage_matrix(artifacts, links)
+
+    if format == "csv":
+        csv_text = export_csv(report)
+        return PlainTextResponse(
+            content=csv_text,
+            media_type="text/csv",
+            headers={
+                "Content-Disposition": 'attachment; filename="coverage_matrix.csv"'
+            },
+        )
+
+    # default: json
+    json_text = export_json(report)
+    return Response(content=json_text, media_type="application/json")

--- a/src/tracertm/services/coverage_matrix_service.py
+++ b/src/tracertm/services/coverage_matrix_service.py
@@ -1,0 +1,328 @@
+"""Coverage matrix export service for Tracera.
+
+Implements FR-TRC-014: Traceability coverage matrix export (CSV/JSON).
+
+Produces a matrix where:
+- Rows    = Requirement artifacts
+- Columns = Coverage dimensions: ``impl`` (SATISFIES/IMPLEMENTS links)
+             and ``test`` (VERIFIES links), plus ``ArtifactKind`` buckets
+             for linked non-requirement artifacts.
+- Cells   = linked artifact IDs / titles, or empty when uncovered.
+
+The module is a **pure function** (no DB access). Feed it in-memory lists
+of :class:`~tracertm.models.trace_link.Artifact` and
+:class:`~tracertm.models.trace_link.TraceLink` — the same signature used
+by :func:`~tracertm.services.traceability_score_service.score_traceability`
+(DRY: reuses the same graph snapshot pattern).
+
+Formats
+-------
+* **CSV**  — RFC 4180-compliant; header row + one row per requirement.
+* **JSON** — Structured dict with ``meta`` summary + ``rows`` list.
+* **PDF**  — *Future work* (heavy dependency on reportlab/WeasyPrint;
+              excluded from v1 to avoid adding a build-time dep).
+
+Functional Requirements: FR-TRC-014
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from tracertm.models.trace_link import Artifact, ArtifactKind, TraceLink, TraceLinkType
+from tracertm.services.traceability_score_service import (
+    _SATISFIES_TYPES,  # noqa: PLC2701  # shared constant, same module family
+    _VERIFIES_TYPES,
+)
+
+__all__ = [
+    "CoverageMatrixRow",
+    "CoverageMatrixReport",
+    "build_coverage_matrix",
+    "export_csv",
+    "export_json",
+]
+
+# ---------------------------------------------------------------------------
+# Column identifiers
+# ---------------------------------------------------------------------------
+
+_COL_IMPL = "impl_artifacts"
+_COL_TEST = "test_artifacts"
+
+# Non-requirement ArtifactKind columns (one per kind, excluding REQUIREMENT)
+_KIND_COLUMNS: list[ArtifactKind] = [
+    ArtifactKind.DESIGN,
+    ArtifactKind.CODE,
+    ArtifactKind.TEST,
+    ArtifactKind.EVIDENCE,
+    ArtifactKind.RISK,
+    ArtifactKind.RATIONALE,
+]
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageMatrixRow:
+    """Coverage data for a single requirement."""
+
+    requirement_id: uuid.UUID
+    requirement_title: str
+    # Coverage dimensions
+    impl_artifact_ids: list[uuid.UUID]      # SATISFIES / IMPLEMENTS sources
+    impl_artifact_titles: list[str]
+    test_artifact_ids: list[uuid.UUID]      # VERIFIES sources
+    test_artifact_titles: list[str]
+    # Per-ArtifactKind linked artifact titles (keyed by kind.value)
+    kind_artifacts: dict[str, list[str]]
+    # Derived booleans
+    is_impl_covered: bool
+    is_test_covered: bool
+    is_fully_covered: bool                  # both impl + test
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageMatrixReport:
+    """Coverage matrix for a Requirement/Artifact/TraceLink graph snapshot."""
+
+    total_requirements: int
+    total_artifacts: int
+    total_links: int
+    impl_covered_count: int
+    test_covered_count: int
+    fully_covered_count: int
+    impl_coverage_pct: float    # [0.0, 1.0]
+    test_coverage_pct: float    # [0.0, 1.0]
+    rows: list[CoverageMatrixRow] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Core builder — pure function
+# ---------------------------------------------------------------------------
+
+
+def build_coverage_matrix(
+    artifacts: Sequence[Artifact],
+    links: Sequence[TraceLink],
+) -> CoverageMatrixReport:
+    """Build a coverage matrix from an in-memory graph snapshot.
+
+    Parameters
+    ----------
+    artifacts:
+        All artifact nodes (requirements + non-requirements).
+    links:
+        All trace links in the snapshot.
+
+    Returns
+    -------
+    :class:`CoverageMatrixReport` with one :class:`CoverageMatrixRow` per
+    requirement.
+    """
+    requirements = [a for a in artifacts if a.kind == ArtifactKind.REQUIREMENT]
+    artifact_by_id: dict[uuid.UUID, Artifact] = {a.id: a for a in artifacts}
+
+    # Index links by target (impl / test pointing AT requirements)
+    impl_sources_by_req: dict[uuid.UUID, list[Artifact]] = {}
+    test_sources_by_req: dict[uuid.UUID, list[Artifact]] = {}
+    kind_sources_by_req: dict[uuid.UUID, dict[ArtifactKind, list[Artifact]]] = {}
+
+    for lnk in links:
+        src = artifact_by_id.get(lnk.source_artifact_id)
+        tgt_id = lnk.target_artifact_id
+        if src is None:
+            continue
+
+        if lnk.link_type in _SATISFIES_TYPES:
+            impl_sources_by_req.setdefault(tgt_id, []).append(src)
+        if lnk.link_type in _VERIFIES_TYPES:
+            test_sources_by_req.setdefault(tgt_id, []).append(src)
+
+        # Bucket by kind for any link touching a requirement as target
+        if tgt_id in {r.id for r in requirements}:
+            kind_map = kind_sources_by_req.setdefault(tgt_id, {})
+            kind_map.setdefault(src.kind, []).append(src)
+
+    rows: list[CoverageMatrixRow] = []
+    impl_covered_count = 0
+    test_covered_count = 0
+    fully_covered_count = 0
+
+    for req in requirements:
+        impl_arts = impl_sources_by_req.get(req.id, [])
+        test_arts = test_sources_by_req.get(req.id, [])
+        kind_map = kind_sources_by_req.get(req.id, {})
+
+        is_impl = bool(impl_arts)
+        is_test = bool(test_arts)
+        is_full = is_impl and is_test
+
+        kind_artifacts: dict[str, list[str]] = {
+            k.value: [a.title for a in kind_map.get(k, [])]
+            for k in _KIND_COLUMNS
+        }
+
+        row = CoverageMatrixRow(
+            requirement_id=req.id,
+            requirement_title=req.title,
+            impl_artifact_ids=[a.id for a in impl_arts],
+            impl_artifact_titles=[a.title for a in impl_arts],
+            test_artifact_ids=[a.id for a in test_arts],
+            test_artifact_titles=[a.title for a in test_arts],
+            kind_artifacts=kind_artifacts,
+            is_impl_covered=is_impl,
+            is_test_covered=is_test,
+            is_fully_covered=is_full,
+        )
+        rows.append(row)
+
+        if is_impl:
+            impl_covered_count += 1
+        if is_test:
+            test_covered_count += 1
+        if is_full:
+            fully_covered_count += 1
+
+    n_req = len(requirements)
+    return CoverageMatrixReport(
+        total_requirements=n_req,
+        total_artifacts=len(artifacts),
+        total_links=len(links),
+        impl_covered_count=impl_covered_count,
+        test_covered_count=test_covered_count,
+        fully_covered_count=fully_covered_count,
+        impl_coverage_pct=impl_covered_count / n_req if n_req else 0.0,
+        test_coverage_pct=test_covered_count / n_req if n_req else 0.0,
+        rows=rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Export helpers
+# ---------------------------------------------------------------------------
+
+_CSV_COLUMNS = [
+    "requirement_id",
+    "requirement_title",
+    "impl_covered",
+    "impl_artifacts",
+    "test_covered",
+    "test_artifacts",
+] + [f"kind_{k.value}" for k in _KIND_COLUMNS]
+
+
+def export_csv(report: CoverageMatrixReport) -> str:
+    """Serialise *report* to an RFC 4180-compliant CSV string.
+
+    Columns::
+
+        requirement_id, requirement_title,
+        impl_covered, impl_artifacts,
+        test_covered, test_artifacts,
+        kind_design, kind_code, kind_test,
+        kind_evidence, kind_risk, kind_rationale
+
+    Multi-valued cells (multiple linked artifacts) are pipe-separated within
+    the cell (e.g. ``"ArtA|ArtB"``).
+
+    Returns
+    -------
+    str
+        UTF-8 CSV text with CRLF line endings per RFC 4180.
+    """
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\r\n")
+    writer.writerow(_CSV_COLUMNS)
+
+    for row in report.rows:
+        writer.writerow([
+            str(row.requirement_id),
+            row.requirement_title,
+            "covered" if row.is_impl_covered else "uncovered",
+            "|".join(row.impl_artifact_titles),
+            "covered" if row.is_test_covered else "uncovered",
+            "|".join(row.test_artifact_titles),
+            *[
+                "|".join(row.kind_artifacts.get(k.value, []))
+                for k in _KIND_COLUMNS
+            ],
+        ])
+
+    return buf.getvalue()
+
+
+def export_json(report: CoverageMatrixReport) -> str:
+    """Serialise *report* to a JSON string.
+
+    Structure::
+
+        {
+          "meta": {
+            "total_requirements": int,
+            "total_artifacts":    int,
+            "total_links":        int,
+            "impl_covered":       int,
+            "test_covered":       int,
+            "fully_covered":      int,
+            "impl_coverage_pct":  float,
+            "test_coverage_pct":  float
+          },
+          "columns": ["requirement_id", "requirement_title", ...],
+          "rows": [
+            {
+              "requirement_id":      str,
+              "requirement_title":   str,
+              "impl_covered":        bool,
+              "impl_artifacts":      [str, ...],
+              "test_covered":        bool,
+              "test_artifacts":      [str, ...],
+              "kind_design":         [str, ...],
+              ...
+            },
+            ...
+          ]
+        }
+
+    Returns
+    -------
+    str
+        JSON text (UTF-8, 2-space indent).
+    """
+    payload: dict = {
+        "meta": {
+            "total_requirements": report.total_requirements,
+            "total_artifacts": report.total_artifacts,
+            "total_links": report.total_links,
+            "impl_covered": report.impl_covered_count,
+            "test_covered": report.test_covered_count,
+            "fully_covered": report.fully_covered_count,
+            "impl_coverage_pct": round(report.impl_coverage_pct, 4),
+            "test_coverage_pct": round(report.test_coverage_pct, 4),
+        },
+        "columns": _CSV_COLUMNS,
+        "rows": [
+            {
+                "requirement_id": str(row.requirement_id),
+                "requirement_title": row.requirement_title,
+                "impl_covered": row.is_impl_covered,
+                "impl_artifacts": row.impl_artifact_titles,
+                "test_covered": row.is_test_covered,
+                "test_artifacts": row.test_artifact_titles,
+                **{
+                    f"kind_{k.value}": row.kind_artifacts.get(k.value, [])
+                    for k in _KIND_COLUMNS
+                },
+            }
+            for row in report.rows
+        ],
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False)

--- a/tests/unit/services/test_coverage_matrix_service.py
+++ b/tests/unit/services/test_coverage_matrix_service.py
@@ -1,0 +1,403 @@
+"""Unit tests for the coverage matrix export service.
+
+Functional Requirements: FR-TRC-014
+
+Coverage
+--------
+* Empty graph → empty matrix with correct headers in CSV and JSON.
+* Single covered requirement → appears in matrix, is_impl_covered True.
+* Single uncovered requirement → appears in matrix, is_impl_covered False.
+* SATISFIES link counts as impl coverage.
+* IMPLEMENTS link counts as impl coverage (SATISFIES-family, DRY with scorer).
+* VERIFIES link counts as test coverage.
+* Both impl + test → is_fully_covered True.
+* Only impl → is_fully_covered False.
+* Only test → is_fully_covered False.
+* Multiple requirements → correct row count and coverage counts.
+* Coverage percentages computed correctly (covered / total).
+* CSV header row matches _CSV_COLUMNS spec.
+* CSV rows: correct field count; impl/test cells contain artifact titles.
+* CSV cells with multiple linked artifacts are pipe-separated.
+* CSV escaping: titles containing commas/quotes are RFC 4180-escaped.
+* JSON meta block has all required keys.
+* JSON rows have correct keys per requirement.
+* JSON impl_covered / test_covered booleans match domain logic.
+* Kind-bucket columns populated for linked non-req artifacts.
+* Non-requirement artifacts without links don't appear in matrix rows.
+* Graph with requirements and no non-req artifacts → kind columns empty.
+* Non-requirement artifacts not in any req's target links → kind columns empty.
+* Coverage pct = 0.0 when all requirements uncovered.
+* Coverage pct = 1.0 when all requirements covered.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import uuid
+
+import pytest
+
+from tracertm.models.trace_link import Artifact, ArtifactKind, TraceLink, TraceLinkType
+from tracertm.services.coverage_matrix_service import (
+    _CSV_COLUMNS,
+    _KIND_COLUMNS,
+    build_coverage_matrix,
+    export_csv,
+    export_json,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_PROJ = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000001")
+
+
+def _req(title: str = "Requirement A") -> Artifact:
+    return Artifact(
+        id=uuid.uuid4(), project_id=_PROJ, kind=ArtifactKind.REQUIREMENT, title=title
+    )
+
+
+def _code(title: str = "Code A") -> Artifact:
+    return Artifact(
+        id=uuid.uuid4(), project_id=_PROJ, kind=ArtifactKind.CODE, title=title
+    )
+
+
+def _test_art(title: str = "Test A") -> Artifact:
+    return Artifact(
+        id=uuid.uuid4(), project_id=_PROJ, kind=ArtifactKind.TEST, title=title
+    )
+
+
+def _design(title: str = "Design A") -> Artifact:
+    return Artifact(
+        id=uuid.uuid4(), project_id=_PROJ, kind=ArtifactKind.DESIGN, title=title
+    )
+
+
+def _link(
+    src_id: uuid.UUID,
+    tgt_id: uuid.UUID,
+    link_type: TraceLinkType,
+    confidence: float = 1.0,
+) -> TraceLink:
+    return TraceLink(
+        id=uuid.uuid4(),
+        project_id=_PROJ,
+        source_artifact_id=src_id,
+        target_artifact_id=tgt_id,
+        link_type=link_type,
+        confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty graph
+# ---------------------------------------------------------------------------
+
+
+def test_empty_graph_returns_empty_rows() -> None:
+    report = build_coverage_matrix([], [])
+    assert report.total_requirements == 0
+    assert report.total_artifacts == 0
+    assert report.total_links == 0
+    assert report.rows == []
+    assert report.impl_coverage_pct == 0.0
+    assert report.test_coverage_pct == 0.0
+
+
+def test_empty_graph_csv_has_header_only() -> None:
+    report = build_coverage_matrix([], [])
+    csv_text = export_csv(report)
+    reader = csv.reader(io.StringIO(csv_text))
+    rows = list(reader)
+    # Only header row (empty body rows are stripped by csv module from empty input)
+    assert len(rows) == 1
+    assert rows[0] == _CSV_COLUMNS
+
+
+def test_empty_graph_json_has_expected_keys() -> None:
+    report = build_coverage_matrix([], [])
+    data = json.loads(export_json(report))
+    assert "meta" in data
+    assert "columns" in data
+    assert "rows" in data
+    assert data["rows"] == []
+    assert data["meta"]["total_requirements"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Single requirement — uncovered
+# ---------------------------------------------------------------------------
+
+
+def test_single_uncovered_requirement() -> None:
+    req = _req("REQ-001")
+    report = build_coverage_matrix([req], [])
+    assert report.total_requirements == 1
+    assert report.impl_covered_count == 0
+    assert report.test_covered_count == 0
+    assert report.impl_coverage_pct == 0.0
+    assert report.test_coverage_pct == 0.0
+    row = report.rows[0]
+    assert row.requirement_title == "REQ-001"
+    assert row.is_impl_covered is False
+    assert row.is_test_covered is False
+    assert row.is_fully_covered is False
+    assert row.impl_artifact_titles == []
+    assert row.test_artifact_titles == []
+
+
+# ---------------------------------------------------------------------------
+# SATISFIES → impl coverage
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_link_counts_as_impl_covered() -> None:
+    req = _req()
+    code = _code()
+    lnk = _link(code.id, req.id, TraceLinkType.SATISFIES)
+    report = build_coverage_matrix([req, code], [lnk])
+    row = report.rows[0]
+    assert row.is_impl_covered is True
+    assert code.title in row.impl_artifact_titles
+
+
+def test_implements_link_counts_as_impl_covered() -> None:
+    """IMPLEMENTS is in the SATISFIES-family — DRY with traceability scorer."""
+    req = _req()
+    code = _code()
+    lnk = _link(code.id, req.id, TraceLinkType.IMPLEMENTS)
+    report = build_coverage_matrix([req, code], [lnk])
+    row = report.rows[0]
+    assert row.is_impl_covered is True
+
+
+# ---------------------------------------------------------------------------
+# VERIFIES → test coverage
+# ---------------------------------------------------------------------------
+
+
+def test_verifies_link_counts_as_test_covered() -> None:
+    req = _req()
+    test = _test_art()
+    lnk = _link(test.id, req.id, TraceLinkType.VERIFIES)
+    report = build_coverage_matrix([req, test], [lnk])
+    row = report.rows[0]
+    assert row.is_test_covered is True
+    assert test.title in row.test_artifact_titles
+
+
+# ---------------------------------------------------------------------------
+# Fully covered
+# ---------------------------------------------------------------------------
+
+
+def test_both_impl_and_test_is_fully_covered() -> None:
+    req = _req()
+    code = _code()
+    test = _test_art()
+    impl_lnk = _link(code.id, req.id, TraceLinkType.SATISFIES)
+    test_lnk = _link(test.id, req.id, TraceLinkType.VERIFIES)
+    report = build_coverage_matrix([req, code, test], [impl_lnk, test_lnk])
+    assert report.fully_covered_count == 1
+    assert report.rows[0].is_fully_covered is True
+
+
+def test_impl_only_not_fully_covered() -> None:
+    req = _req()
+    code = _code()
+    lnk = _link(code.id, req.id, TraceLinkType.SATISFIES)
+    report = build_coverage_matrix([req, code], [lnk])
+    assert report.rows[0].is_fully_covered is False
+
+
+def test_test_only_not_fully_covered() -> None:
+    req = _req()
+    test = _test_art()
+    lnk = _link(test.id, req.id, TraceLinkType.VERIFIES)
+    report = build_coverage_matrix([req, test], [lnk])
+    assert report.rows[0].is_fully_covered is False
+
+
+# ---------------------------------------------------------------------------
+# Multiple requirements
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_requirements_correct_row_count() -> None:
+    reqs = [_req(f"REQ-{i:03d}") for i in range(5)]
+    codes = [_code(f"CODE-{i}") for i in range(3)]
+    # Link first 3 requirements to code artifacts (impl only)
+    links = [_link(codes[i].id, reqs[i].id, TraceLinkType.SATISFIES) for i in range(3)]
+    report = build_coverage_matrix(reqs + codes, links)
+    assert report.total_requirements == 5
+    assert report.impl_covered_count == 3
+    assert report.test_covered_count == 0
+    assert report.fully_covered_count == 0
+    assert len(report.rows) == 5
+
+
+def test_coverage_pct_all_covered() -> None:
+    reqs = [_req(f"R{i}") for i in range(4)]
+    codes = [_code(f"C{i}") for i in range(4)]
+    links = [_link(codes[i].id, reqs[i].id, TraceLinkType.SATISFIES) for i in range(4)]
+    report = build_coverage_matrix(reqs + codes, links)
+    assert report.impl_coverage_pct == 1.0
+
+
+def test_coverage_pct_none_covered() -> None:
+    reqs = [_req(f"R{i}") for i in range(3)]
+    report = build_coverage_matrix(reqs, [])
+    assert report.impl_coverage_pct == 0.0
+    assert report.test_coverage_pct == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Kind-bucket columns
+# ---------------------------------------------------------------------------
+
+
+def test_kind_column_populated_for_linked_design_artifact() -> None:
+    req = _req()
+    des = _design("DesignDoc")
+    lnk = _link(des.id, req.id, TraceLinkType.SATISFIES)
+    report = build_coverage_matrix([req, des], [lnk])
+    row = report.rows[0]
+    assert "DesignDoc" in row.kind_artifacts.get(ArtifactKind.DESIGN.value, [])
+
+
+def test_kind_columns_empty_when_no_non_req_links() -> None:
+    req = _req()
+    report = build_coverage_matrix([req], [])
+    row = report.rows[0]
+    for k in _KIND_COLUMNS:
+        assert row.kind_artifacts.get(k.value, []) == []
+
+
+# ---------------------------------------------------------------------------
+# CSV well-formedness
+# ---------------------------------------------------------------------------
+
+
+def test_csv_header_matches_spec() -> None:
+    req = _req()
+    report = build_coverage_matrix([req], [])
+    reader = csv.reader(io.StringIO(export_csv(report)))
+    header = next(reader)
+    assert header == _CSV_COLUMNS
+
+
+def test_csv_row_count_matches_requirements() -> None:
+    reqs = [_req(f"R{i}") for i in range(3)]
+    report = build_coverage_matrix(reqs, [])
+    reader = csv.reader(io.StringIO(export_csv(report)))
+    rows = list(reader)
+    assert len(rows) == 4  # header + 3 data rows
+
+
+def test_csv_covered_cell_contains_artifact_title() -> None:
+    req = _req("My Requirement")
+    code = _code("my_module.py")
+    lnk = _link(code.id, req.id, TraceLinkType.SATISFIES)
+    report = build_coverage_matrix([req, code], [lnk])
+    reader = csv.reader(io.StringIO(export_csv(report)))
+    _header = next(reader)
+    data_row = next(reader)
+    impl_artifacts_idx = _CSV_COLUMNS.index("impl_artifacts")
+    assert "my_module.py" in data_row[impl_artifacts_idx]
+
+
+def test_csv_multiple_artifacts_pipe_separated() -> None:
+    req = _req()
+    c1 = _code("CodeA")
+    c2 = _code("CodeB")
+    l1 = _link(c1.id, req.id, TraceLinkType.SATISFIES)
+    l2 = _link(c2.id, req.id, TraceLinkType.SATISFIES)
+    report = build_coverage_matrix([req, c1, c2], [l1, l2])
+    reader = csv.reader(io.StringIO(export_csv(report)))
+    _header = next(reader)
+    data_row = next(reader)
+    impl_artifacts_idx = _CSV_COLUMNS.index("impl_artifacts")
+    cell = data_row[impl_artifacts_idx]
+    parts = cell.split("|")
+    assert len(parts) == 2
+    assert "CodeA" in parts
+    assert "CodeB" in parts
+
+
+def test_csv_commas_and_quotes_in_title_escaped() -> None:
+    """Titles with commas or quotes must be safely enclosed by csv.writer."""
+    req = _req('Req with "quotes" and, commas')
+    report = build_coverage_matrix([req], [])
+    csv_text = export_csv(report)
+    reader = csv.reader(io.StringIO(csv_text))
+    _header = next(reader)
+    data_row = next(reader)
+    req_title_idx = _CSV_COLUMNS.index("requirement_title")
+    assert data_row[req_title_idx] == 'Req with "quotes" and, commas'
+
+
+# ---------------------------------------------------------------------------
+# JSON structure
+# ---------------------------------------------------------------------------
+
+
+def test_json_meta_contains_required_keys() -> None:
+    report = build_coverage_matrix([], [])
+    data = json.loads(export_json(report))
+    required_keys = {
+        "total_requirements",
+        "total_artifacts",
+        "total_links",
+        "impl_covered",
+        "test_covered",
+        "fully_covered",
+        "impl_coverage_pct",
+        "test_coverage_pct",
+    }
+    assert required_keys <= set(data["meta"].keys())
+
+
+def test_json_row_contains_required_keys() -> None:
+    req = _req("R1")
+    report = build_coverage_matrix([req], [])
+    data = json.loads(export_json(report))
+    row = data["rows"][0]
+    required = {
+        "requirement_id",
+        "requirement_title",
+        "impl_covered",
+        "impl_artifacts",
+        "test_covered",
+        "test_artifacts",
+    }
+    assert required <= set(row.keys())
+
+
+def test_json_impl_covered_boolean_true_when_linked() -> None:
+    req = _req()
+    code = _code()
+    lnk = _link(code.id, req.id, TraceLinkType.SATISFIES)
+    report = build_coverage_matrix([req, code], [lnk])
+    data = json.loads(export_json(report))
+    assert data["rows"][0]["impl_covered"] is True
+
+
+def test_json_impl_covered_boolean_false_when_not_linked() -> None:
+    req = _req()
+    report = build_coverage_matrix([req], [])
+    data = json.loads(export_json(report))
+    assert data["rows"][0]["impl_covered"] is False
+
+
+def test_json_columns_field_matches_csv_columns() -> None:
+    report = build_coverage_matrix([], [])
+    data = json.loads(export_json(report))
+    assert data["columns"] == _CSV_COLUMNS


### PR DESCRIPTION
## **User description**
## Summary

- **FR-TRC-014**: Implements traceability coverage matrix export (CSV/JSON).
- Pure-function `coverage_matrix_service.py` — rows = requirements, columns = `impl` (SATISFIES/IMPLEMENTS) + `test` (VERIFIES) + per-`ArtifactKind` buckets. Reuses `_SATISFIES_TYPES`/`_VERIFIES_TYPES` from `traceability_score_service` (DRY).
- New read-only endpoint `GET /api/v1/coverage/matrix?format=csv|json` via `coverage_matrix` router registered in `router_registry.py`.
- CSV: RFC 4180-compliant, pipe-separated multi-artifact cells, header matches spec.
- JSON: `{ meta: {...}, columns: [...], rows: [...] }` structure.
- PDF deferred to future work (heavy dep on reportlab/WeasyPrint — noted in docstring).
- FR-TRC-014 flipped PLANNED → SHIPPED in `docs/requirements/tracera-frnfr.md`.

## Test plan

- [x] 25 pytest unit tests in `tests/unit/services/test_coverage_matrix_service.py` — all green
- [x] Empty graph → empty matrix with correct headers (CSV + JSON)
- [x] SATISFIES/IMPLEMENTS → impl coverage; VERIFIES → test coverage
- [x] Fully covered / partially covered / uncovered cells correct
- [x] Coverage percentages 0.0 and 1.0 boundary cases
- [x] CSV RFC 4180 escaping (commas + quotes in titles)
- [x] Pipe-separated multi-artifact cells
- [x] JSON meta keys + row keys validated
- [x] Kind-bucket columns populated correctly

Cites: FR-TRC-014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only export over client-supplied snapshots with no DB writes; main caveat is GET-with-body (same as traceability score) which some HTTP clients may not support well.
> 
> **Overview**
> Ships **FR-TRC-014** by adding in-memory traceability **coverage matrix export** (CSV/JSON) and wiring it into the API.
> 
> A new pure-function `coverage_matrix_service` builds one row per requirement with **impl** coverage (`SATISFIES`/`IMPLEMENTS`), **test** coverage (`VERIFIES`), per-`ArtifactKind` linked titles, and aggregate coverage counts/percentages. It reuses `_SATISFIES_TYPES` / `_VERIFIES_TYPES` from the traceability scorer for consistent link semantics. **CSV** output is RFC 4180 with pipe-separated multi-artifact cells; **JSON** returns `meta`, `columns`, and `rows`. PDF is explicitly deferred.
> 
> **GET** `/api/v1/coverage/matrix?format=csv|json` is registered via `coverage_matrix` router (auth-guarded, same graph-snapshot body pattern as quality score). Requirements docs mark FR-TRC-014 as **SHIPPED** and add traceability to 25 unit tests in `test_coverage_matrix_service.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc98a25520f8aafa7cfccf81b69483cf6071337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add coverage matrix export for requirements

### What Changed
- Added a new coverage matrix view that lists each requirement with its implementation coverage, test coverage, and linked artifact groups by artifact type
- Users can export the matrix as CSV or JSON from `GET /api/v1/coverage/matrix?format=csv|json`; CSV downloads as a file, JSON returns a structured response with summary counts and rows
- CSV output includes safe formatting for commas, quotes, and multiple linked artifacts in one cell
- Added unit tests for empty graphs, coverage calculations, CSV formatting, JSON shape, and artifact-type grouping
- Marked FR-TRC-014 as shipped in the requirements document

### Impact
`✅ Faster traceability reviews`
`✅ Easier coverage reporting`
`✅ Fewer export formatting issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added traceability coverage matrix export endpoint supporting CSV and JSON formats
  * Coverage matrix displays requirement implementation and test coverage status with linked artifact details

* **Tests**
  * Added 25 unit tests validating coverage matrix computation and export functionality

* **Documentation**
  * Updated requirements documentation marking coverage matrix export feature as shipped

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KooshaPari/Tracera/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->