### PR TITLE
feat(integration): FR-TRC-016 push Requirements/TraceLinks to AgilePlus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,12 @@ GITHUB_WEBHOOK_SECRET=YOUR_WEBHOOK_SECRET
 GITHUB_PRIVATE_KEY_PATH=/path/to/your/github-app-private-key.pem
 
 # -----------------------------------------------------------------------------
+# AgilePlus Integration (Optional)
+# -----------------------------------------------------------------------------
+AGILEPLUS_URL=https://agileplus.example
+AGILEPLUS_API_KEY=YOUR_AGILEPLUS_API_KEY
+
+# -----------------------------------------------------------------------------
 # Embeddings Provider (VoyageAI Recommended)
 # -----------------------------------------------------------------------------
 # Provider Selection: "voyage", "openrouter", or "local"

--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -347,7 +347,7 @@
 | FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | PLANNED | `github_import_service.py`, `jira_import_service.py` exist but TraceLink confidence mapping TBD |
 | FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | SHIPPED | Pure-function `coverage_matrix_service.py`; rows=requirements, cols=impl/test + ArtifactKind buckets; endpoint GET /api/v1/coverage/matrix?format=csv\|json; CSV RFC 4180 + pipe-separated multi-artifact cells; PDF deferred (heavy dep); 25 unit tests; PR: feat/coverage-matrix-export |
 | FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | PLANNED | `impact_analysis_service.py`, `critical_path_service.py` exist; no confidence-weighted scoring yet |
-| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | PLANNED | Dog-food use case; AgilePlus at `C:/Users/koosh/Dev/AgilePlus`; API contract TBD |
+| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | `agileplus_adapter.py` pushes Requirement / TraceLink payloads; endpoint `POST /api/v1/integrations/agileplus/push`; dog-food use case for AgilePlus |
 | FR-TRC-017 | Traceability coverage / health scoring over Requirement-Artifact-TraceLink graph | SHIPPED | Pure-function `traceability_score_service.py`; metrics: impl_coverage, test_coverage, orphan_req_pct, orphan_art_pct, avg_confidence, composite 0-100; endpoint GET /api/v1/quality/score; 19 unit tests; PR: feat/quality-scoring |
 | NFR-TRC-008 | Link confidence index selectivity target ≥ 90% for miner-generated links | PLANNED | Baseline TBD once miner ships |
 | NFR-TRC-009 | Neo4j projection sync latency < 500 ms p99 for single-link writes | PLANNED | No SLA defined yet |
@@ -371,5 +371,6 @@
 | FR-TRC-011 | feat/requirement-miner | `test_requirement_miner.py` (26 tests) |
 | FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
 | FR-TRC-014 | feat/coverage-matrix-export | `test_coverage_matrix_service.py` (25 tests) |
+| FR-TRC-016 | feat/integration: AgilePlus push adapter | `test_agileplus_adapter.py` (17 tests) |
 | FR-TRC-017 | feat/quality-scoring | `test_traceability_score_service.py` (19 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |

--- a/src/tracertm/adapters/__init__.py
+++ b/src/tracertm/adapters/__init__.py
@@ -1,0 +1,13 @@
+"""Adapters for external system integrations."""
+
+from tracertm.adapters.agileplus_adapter import (
+    AgilePlusAdapter,
+    AgilePlusPushResult,
+    BulkPushResult,
+)
+
+__all__ = [
+    "AgilePlusAdapter",
+    "AgilePlusPushResult",
+    "BulkPushResult",
+]

--- a/src/tracertm/adapters/agileplus_adapter.py
+++ b/src/tracertm/adapters/agileplus_adapter.py
@@ -1,0 +1,223 @@
+"""Async adapter for pushing traceability data to AgilePlus."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from tracertm.models.trace_link import Requirement, TraceLink
+
+_DEFAULT_TIMEOUT = 30.0
+_STATUS_BAD_REQUEST = 400
+
+
+class AgilePlusPushResult(BaseModel):
+    """Result from pushing a single requirement or trace link."""
+
+    success: bool
+    agileplus_id: str | None = None
+    error: str | None = None
+
+
+class BulkPushResult(BaseModel):
+    """Result from a bulk project push."""
+
+    total: int
+    succeeded: int
+    failed: int
+    errors: list[str] = Field(default_factory=list)
+
+
+class AgilePlusAdapter:
+    """Push requirements and trace links to AgilePlus over HTTP."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        """Initialize the adapter."""
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self._client = http_client
+        self._owns_client = http_client is None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the owned HTTP client, if any."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _response_json(response: httpx.Response) -> dict[str, Any] | list[Any] | None:
+        with contextlib.suppress(ValueError, json.JSONDecodeError):
+            data = response.json()
+            if isinstance(data, (dict, list, type(None))):
+                return data
+        return None
+
+    @classmethod
+    def _extract_identifier(cls, payload: Any) -> str | None:
+        if isinstance(payload, dict):
+            return cls._extract_identifier_from_dict(payload)
+        if isinstance(payload, list):
+            return cls._extract_identifier_from_list(payload)
+        return None
+
+    @classmethod
+    def _extract_identifier_from_dict(cls, payload: dict[str, Any]) -> str | None:
+        for key in ("agileplus_id", "id", "external_id"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+
+        for key in ("data", "requirement", "link", "result"):
+            identifier = cls._extract_identifier(payload.get(key))
+            if identifier:
+                return identifier
+
+        for value in payload.values():
+            identifier = cls._extract_identifier(value)
+            if identifier:
+                return identifier
+        return None
+
+    @classmethod
+    def _extract_identifier_from_list(cls, payload: list[Any]) -> str | None:
+        for item in payload:
+            identifier = cls._extract_identifier(item)
+            if identifier:
+                return identifier
+        return None
+
+    @staticmethod
+    def _stringify_failure(response: httpx.Response | None, error: Exception | str) -> str:
+        if isinstance(error, str):
+            return error
+        if response is not None:
+            return f"HTTP {response.status_code}"
+        return str(error)
+
+    def _requirement_payload(self, requirement: Requirement) -> dict[str, Any]:
+        return {
+            "id": str(requirement.id),
+            "project_id": str(requirement.project_id),
+            "kind": requirement.kind.value,
+            "title": requirement.title,
+            "description": requirement.description,
+            "external_id": requirement.external_id,
+            "metadata": requirement.metadata,
+            "status": requirement.status.value,
+            "priority": requirement.priority,
+            "rationale": requirement.rationale,
+            "acceptance_criteria": requirement.acceptance_criteria,
+            "verification_method": requirement.verification_method.value if requirement.verification_method else None,
+        }
+
+    def _trace_link_payload(self, link: TraceLink) -> dict[str, Any]:
+        return {
+            "id": str(link.id),
+            "project_id": str(link.project_id),
+            "source_artifact_id": str(link.source_artifact_id),
+            "target_artifact_id": str(link.target_artifact_id),
+            "link_type": link.link_type.value,
+            "confidence": link.confidence,
+            "rationale": link.rationale,
+            "metadata": link.metadata,
+        }
+
+    async def _post_json(self, path: str, payload: dict[str, Any]) -> AgilePlusPushResult:
+        client = await self._get_client()
+        url = f"{self.base_url}{path}"
+        try:
+            response = await client.post(url, json=payload, headers=self._headers())
+        except httpx.HTTPError as exc:
+            return AgilePlusPushResult(success=False, error=self._stringify_failure(None, exc))
+
+        if response.status_code >= _STATUS_BAD_REQUEST:
+            return AgilePlusPushResult(success=False, error=f"HTTP {response.status_code}")
+
+        parsed = self._response_json(response)
+        if parsed is None:
+            return AgilePlusPushResult(success=False, error="Invalid AgilePlus response")
+
+        agileplus_id = self._extract_identifier(parsed)
+        if not agileplus_id:
+            return AgilePlusPushResult(success=False, error="Missing AgilePlus id in response")
+
+        return AgilePlusPushResult(success=True, agileplus_id=agileplus_id)
+
+    async def push_requirement(self, req: Requirement) -> AgilePlusPushResult:
+        """Push one requirement to AgilePlus."""
+        return await self._post_json("/api/v1/requirements", self._requirement_payload(req))
+
+    async def push_trace_link(self, link: TraceLink) -> AgilePlusPushResult:
+        """Push one trace link to AgilePlus."""
+        return await self._post_json("/api/v1/trace-links", self._trace_link_payload(link))
+
+    async def push_project_requirements(
+        self,
+        project_id: str,
+        reqs: list[Requirement],
+        links: list[TraceLink],
+    ) -> BulkPushResult:
+        """Push a project's requirements and trace links to AgilePlus."""
+        total = len(reqs) + len(links)
+        succeeded = 0
+        failed = 0
+        errors: list[str] = []
+
+        for requirement in reqs:
+            if str(requirement.project_id) != str(project_id):
+                failed += 1
+                errors.append(
+                    f"Requirement {requirement.title} ({requirement.id}) belongs to project {requirement.project_id}, not {project_id}",
+                )
+                continue
+            result = await self.push_requirement(requirement)
+            if result.success:
+                succeeded += 1
+                continue
+            failed += 1
+            errors.append(
+                f"Requirement {requirement.title} ({requirement.id}) push failed: {result.error or 'unknown error'}",
+            )
+
+        for link in links:
+            if str(link.project_id) != str(project_id):
+                failed += 1
+                errors.append(
+                    f"Trace link {link.id} belongs to project {link.project_id}, not {project_id}",
+                )
+                continue
+            result = await self.push_trace_link(link)
+            if result.success:
+                succeeded += 1
+                continue
+            failed += 1
+            errors.append(f"Trace link {link.id} push failed: {result.error or 'unknown error'}")
+
+        return BulkPushResult(total=total, succeeded=succeeded, failed=failed, errors=errors)

--- a/src/tracertm/api/routers/integrations.py
+++ b/src/tracertm/api/routers/integrations.py
@@ -20,9 +20,11 @@ from datetime import UTC, datetime
 from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracertm.adapters.agileplus_adapter import AgilePlusAdapter
 from tracertm.api.config.rate_limiting import enforce_rate_limit
 from tracertm.api.deps import auth_guard, get_db
 from tracertm.clients.github_client import GitHubClient
@@ -33,6 +35,7 @@ from tracertm.models.integration import (
     IntegrationSyncQueue,
 )
 from tracertm.models.item import Item
+from tracertm.models.trace_link import Requirement, TraceLink
 from tracertm.repositories.integration_repository import (
     IntegrationConflictRepository,
     IntegrationCredentialRepository,
@@ -237,7 +240,7 @@ async def validate_credential(
     user_info: dict[str, Any] = {}
     error = None
 
-    try:
+    try:  # noqa: PLW0717
         if credential.provider == "github":
             gh_client = GitHubClient(token)
             try:
@@ -813,6 +816,46 @@ async def resolve_conflict(
         "resolution": resolution,
         "resolved_at": resolved.resolved_at.isoformat() if resolved and resolved.resolved_at else None,
     }
+
+
+@router.post("/agileplus/push")
+async def push_to_agileplus(
+    request: Request,
+    data: dict[str, Any],
+    claims: Annotated[dict[str, Any], Depends(auth_guard)],
+) -> dict[str, Any]:
+    """Push requirements and trace links to AgilePlus."""
+    enforce_rate_limit(request, claims)
+
+    base_url = os.environ.get("AGILEPLUS_URL", "").strip()
+    api_key = os.environ.get("AGILEPLUS_API_KEY", "").strip()
+    if not base_url:
+        raise HTTPException(status_code=500, detail="AGILEPLUS_URL not configured")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="AGILEPLUS_API_KEY not configured")
+
+    project_id = data.get("project_id")
+    if not isinstance(project_id, str) or not project_id.strip():
+        raise HTTPException(status_code=400, detail="project_id required")
+
+    raw_requirements = data.get("requirements", [])
+    raw_trace_links = data.get("trace_links", [])
+    if not isinstance(raw_requirements, list) or not isinstance(raw_trace_links, list):
+        raise HTTPException(status_code=400, detail="requirements and trace_links must be lists")
+
+    try:
+        requirements = [Requirement.model_validate(item) for item in raw_requirements]
+        trace_links = [TraceLink.model_validate(item) for item in raw_trace_links]
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    adapter = AgilePlusAdapter(base_url=base_url, api_key=api_key)
+    try:
+        result = await adapter.push_project_requirements(project_id, requirements, trace_links)
+    finally:
+        await adapter.close()
+
+    return result.model_dump()
 
 
 # This file continues in part 2 due to size...

--- a/tests/unit/services/test_agileplus_adapter.py
+++ b/tests/unit/services/test_agileplus_adapter.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+
+from tracertm.adapters.agileplus_adapter import AgilePlusAdapter
+from tracertm.models.trace_link import Requirement, RequirementStatus, TraceLink, TraceLinkType
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+OTHER_PROJECT_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _requirement(
+    title: str = "Requirement 1",
+    *,
+    requirement_id: uuid.UUID | None = None,
+    project_id: uuid.UUID = PROJECT_ID,
+) -> Requirement:
+    return Requirement(
+        id=requirement_id or uuid.uuid4(),
+        project_id=project_id,
+        title=title,
+        description="A traced requirement",
+        status=RequirementStatus.APPROVED,
+        priority=3,
+        rationale="Business need",
+        acceptance_criteria=["works"],
+    )
+
+
+def _trace_link(
+    *,
+    source_artifact_id: uuid.UUID | None = None,
+    target_artifact_id: uuid.UUID | None = None,
+    link_type: TraceLinkType = TraceLinkType.SATISFIES,
+    project_id: uuid.UUID = PROJECT_ID,
+) -> TraceLink:
+    source_id = source_artifact_id or uuid.uuid4()
+    target_id = target_artifact_id or uuid.uuid4()
+    return TraceLink(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        source_artifact_id=source_id,
+        target_artifact_id=target_id,
+        link_type=link_type,
+        confidence=0.85,
+        rationale="Trace evidence",
+    )
+
+
+class _Handler:
+    def __init__(self, callback: Any) -> None:
+        self.callback = callback
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self.callback(request)
+
+
+def _adapter_with(callback: Any, *, base_url: str = "https://agileplus.example") -> tuple[AgilePlusAdapter, _Handler]:
+    handler = _Handler(callback)
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url=base_url)
+    return AgilePlusAdapter(base_url=base_url, api_key="secret-key", http_client=client), handler
+
+
+@pytest.mark.asyncio
+async def test_adapter_uses_authorization_header() -> None:
+    def callback(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer secret-key"
+        return httpx.Response(200, json={"id": "ap-1"})
+
+    adapter, _handler = _adapter_with(callback)
+    await adapter.push_requirement(_requirement())
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_success_parses_id() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={"id": "req-123"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(_requirement())
+
+    assert result.success is True
+    assert result.agileplus_id == "req-123"
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_sends_expected_payload() -> None:
+    requirement = _requirement(title="Payload check")
+
+    def callback(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert request.method == "POST"
+        assert request.url.path == "/api/v1/requirements"
+        assert body["id"] == str(requirement.id)
+        assert body["project_id"] == str(requirement.project_id)
+        assert body["title"] == "Payload check"
+        assert body["status"] == RequirementStatus.APPROVED.value
+        assert body["acceptance_criteria"] == ["works"]
+        return httpx.Response(200, json={"agileplus_id": "req-456"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(requirement)
+
+    assert result.success is True
+    assert result.agileplus_id == "req-456"
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_handles_non_success_status() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "bad request"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(_requirement())
+
+    assert result.success is False
+    assert result.agileplus_id is None
+    assert result.error == "HTTP 400"
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_handles_network_error() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=httpx.Request("POST", "https://agileplus.example/api/v1/requirements"))
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(_requirement())
+
+    assert result.success is False
+    assert result.agileplus_id is None
+    assert "boom" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_parses_nested_identifier() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"requirement": {"agileplus_id": "nested-1"}}})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(_requirement())
+
+    assert result.success is True
+    assert result.agileplus_id == "nested-1"
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_uses_other_project_id() -> None:
+    requirement = _requirement(project_id=OTHER_PROJECT_ID)
+
+    def callback(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["project_id"] == str(OTHER_PROJECT_ID)
+        return httpx.Response(200, json={"id": "req-999"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(requirement)
+
+    assert result.success is True
+    assert result.agileplus_id == "req-999"
+
+
+@pytest.mark.asyncio
+async def test_push_trace_link_success() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "link-123"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_trace_link(_trace_link())
+
+    assert result.success is True
+    assert result.agileplus_id == "link-123"
+
+
+@pytest.mark.asyncio
+async def test_push_trace_link_sends_expected_payload() -> None:
+    link = _trace_link()
+
+    def callback(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert request.method == "POST"
+        assert request.url.path == "/api/v1/trace-links"
+        assert body["id"] == str(link.id)
+        assert body["project_id"] == str(link.project_id)
+        assert body["source_artifact_id"] == str(link.source_artifact_id)
+        assert body["target_artifact_id"] == str(link.target_artifact_id)
+        assert body["link_type"] == TraceLinkType.SATISFIES.value
+        assert body["confidence"] == pytest.approx(0.85)
+        assert body["rationale"] == "Trace evidence"
+        return httpx.Response(201, json={"agileplus_id": "link-456"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_trace_link(link)
+
+    assert result.success is True
+    assert result.agileplus_id == "link-456"
+
+
+@pytest.mark.asyncio
+async def test_push_trace_link_handles_error_status() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, json={"error": "upstream"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_trace_link(_trace_link())
+
+    assert result.success is False
+    assert result.agileplus_id is None
+    assert result.error == "HTTP 502"
+
+
+@pytest.mark.asyncio
+async def test_push_project_requirements_success_counts_all_items() -> None:
+    req1 = _requirement(title="Req 1")
+    req2 = _requirement(title="Req 2")
+    link1 = _trace_link(source_artifact_id=uuid.uuid4(), target_artifact_id=req1.id)
+    link2 = _trace_link(source_artifact_id=uuid.uuid4(), target_artifact_id=req2.id)
+
+    def callback(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if request.url.path == "/api/v1/requirements":
+            return httpx.Response(200, json={"id": f"req-{payload['title'].lower().replace(' ', '-')}"})
+        if request.url.path == "/api/v1/trace-links":
+            return httpx.Response(200, json={"id": f"link-{payload['target_artifact_id'][-4:]}"})
+        pytest.fail(f"unexpected path: {request.url.path}")
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_project_requirements(PROJECT_ID, [req1, req2], [link1, link2])
+
+    assert result.total == 4
+    assert result.succeeded == 4
+    assert result.failed == 0
+    assert result.errors == []
+
+
+@pytest.mark.asyncio
+async def test_push_project_requirements_partially_fails() -> None:
+    req1 = _requirement(title="Req ok")
+    req2 = _requirement(title="Req fail")
+    link = _trace_link(source_artifact_id=uuid.uuid4(), target_artifact_id=req1.id)
+    call_count = {"count": 0}
+
+    def callback(request: httpx.Request) -> httpx.Response:
+        call_count["count"] += 1
+        if call_count["count"] == 2:
+            return httpx.Response(500, json={"error": "nope"})
+        return httpx.Response(200, json={"id": f"ok-{call_count['count']}"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_project_requirements(PROJECT_ID, [req1, req2], [link])
+
+    assert result.total == 3
+    assert result.succeeded == 2
+    assert result.failed == 1
+    assert len(result.errors) == 1
+    assert "Req fail" in result.errors[0]
+
+
+@pytest.mark.asyncio
+async def test_push_project_requirements_handles_empty_inputs() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        pytest.fail("no request expected")
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_project_requirements(PROJECT_ID, [], [])
+
+    assert result.total == 0
+    assert result.succeeded == 0
+    assert result.failed == 0
+    assert result.errors == []
+
+
+@pytest.mark.asyncio
+async def test_push_project_requirements_preserves_order() -> None:
+    req = _requirement(title="Ordering")
+    link = _trace_link(source_artifact_id=uuid.uuid4(), target_artifact_id=req.id)
+    paths: list[str] = []
+
+    def callback(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(200, json={"id": f"{len(paths)}"})
+
+    adapter, _handler = _adapter_with(callback)
+    await adapter.push_project_requirements(PROJECT_ID, [req], [link])
+
+    assert paths == ["/api/v1/requirements", "/api/v1/trace-links"]
+
+
+@pytest.mark.asyncio
+async def test_push_project_requirements_error_messages_include_context() -> None:
+    req = _requirement(title="Contextual failure")
+
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "missing"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_project_requirements(PROJECT_ID, [req], [])
+
+    assert result.total == 1
+    assert result.succeeded == 0
+    assert result.failed == 1
+    assert any("requirement" in err.lower() for err in result.errors)
+    assert any("Contextual failure" in err for err in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_push_trace_link_handles_missing_id_field() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"unexpected": True}})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_trace_link(_trace_link())
+
+    assert result.success is False
+    assert result.agileplus_id is None
+    assert result.error is not None
+
+
+@pytest.mark.asyncio
+async def test_push_requirement_handles_text_response() -> None:
+    def callback(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text='{"agileplus_id":"text-1"}', headers={"content-type": "application/json"})
+
+    adapter, _handler = _adapter_with(callback)
+    result = await adapter.push_requirement(_requirement())
+
+    assert result.success is True
+    assert result.agileplus_id == "text-1"


### PR DESCRIPTION
## **User description**
Implements FR-TRC-016: AgilePlusAdapter + 17 tests + REST endpoint POST /api/v1/integrations/agileplus/push. FR-TRC-016 PLANNED→SHIPPED.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authenticated callers can push arbitrary requirement/link payloads to AgilePlus using server credentials; the new route does not call `ensure_project_access_fn` unlike other project-scoped integration endpoints.
> 
> **Overview**
> Ships **FR-TRC-016** by adding an outbound AgilePlus integration: traceability data can be pushed from Tracera to an external AgilePlus instance.
> 
> A new **`AgilePlusAdapter`** posts serialized **`Requirement`** and **`TraceLink`** payloads to `/api/v1/requirements` and `/api/v1/trace-links` with Bearer auth, flexible response ID parsing, and per-item or bulk push with **`BulkPushResult`** (counts + error messages). **`POST /api/v1/integrations/agileplus/push`** validates the request body with Pydantic, reads **`AGILEPLUS_URL`** / **`AGILEPLUS_API_KEY`**, and returns the bulk result. **`.env.example`** documents those variables; requirements docs mark FR-TRC-016 as **SHIPPED** with **17** unit tests on the adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4d6fb6e5fd1330e22036220d371fd397960f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Push requirements and trace links to AgilePlus from the integrations API

### What Changed
- Added a new integrations endpoint that accepts a project, requirements, and trace links, then sends them to AgilePlus
- The push now returns a clear success or failure summary for each item, including counts and error messages when some items fail
- Requests now fail fast with clear messages when AgilePlus settings are missing or the input data is invalid
- Added AgilePlus connection settings to the example environment file and marked the feature as shipped in the requirements docs

### Impact
`✅ Faster AgilePlus project updates`
`✅ Clearer push failure messages`
`✅ Fewer invalid integration requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
