### PR TITLE
feat(impact): FR-TRC-015 blast-radius / risk-weighted path scoring

### DIFF
--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -346,7 +346,7 @@
 | FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | SHIPPED | Token-Jaccard duplicate detector + structural conflict detector; `dup_conflict_detector.py`; endpoints POST /api/v1/quality/duplicates + /conflicts; PR: feat/dup-conflict-detector |
 | FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | SHIPPED | Branch `feat/trc013-bulk-tracelink-ingestion`; sources: `src/tracertm/services/github_import_service.py`, `src/tracertm/services/jira_import_service.py`, `src/tracertm/api/routers/ingest.py`; validated with 28 unit tests; `uv run python -c "import tracertm"` |
 | FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | SHIPPED | Pure-function `coverage_matrix_service.py`; rows=requirements, cols=impl/test + ArtifactKind buckets; endpoint GET /api/v1/coverage/matrix?format=csv\|json; CSV RFC 4180 + pipe-separated multi-artifact cells; PDF deferred (heavy dep); 25 unit tests; PR: feat/coverage-matrix-export |
-| FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | PLANNED | `impact_analysis_service.py`, `critical_path_service.py` exist; no confidence-weighted scoring yet |
+| FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | SHIPPED | Pure-function `blast_radius_service.py`; BFS over Requirement/Artifact/TraceLink graph with per-ArtifactKind risk weights + link-confidence multipliers; score 0–100 with LOW/MEDIUM/HIGH/CRITICAL tiers; endpoint `GET /api/v1/impact/blast-radius/{artifact_id}`; 20 unit tests; PR: feat/trc015-blast-radius-scoring |
 | FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | `agileplus_adapter.py` pushes Requirement / TraceLink payloads; endpoint `POST /api/v1/integrations/agileplus/push`; dog-food use case for AgilePlus |
 | FR-TRC-017 | Traceability coverage / health scoring over Requirement-Artifact-TraceLink graph | SHIPPED | Pure-function `traceability_score_service.py`; metrics: impl_coverage, test_coverage, orphan_req_pct, orphan_art_pct, avg_confidence, composite 0-100; endpoint GET /api/v1/quality/score; 19 unit tests; PR: feat/quality-scoring |
 | NFR-TRC-008 | Link confidence index selectivity target ≥ 90% for miner-generated links | PLANNED | Baseline TBD once miner ships |
@@ -371,6 +371,7 @@
 | FR-TRC-011 | feat/requirement-miner | `test_requirement_miner.py` (26 tests) |
 | FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
 | FR-TRC-014 | feat/coverage-matrix-export | `test_coverage_matrix_service.py` (25 tests) |
+| FR-TRC-015 | feat/trc015-blast-radius-scoring | `test_blast_radius_scoring.py` (20 tests) |
 | FR-TRC-016 | feat/integration: AgilePlus push adapter | `test_agileplus_adapter.py` (17 tests) |
 | FR-TRC-017 | feat/quality-scoring | `test_traceability_score_service.py` (19 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -28,6 +28,7 @@ from tracertm.api.routers import (
     graphs,
     health,
     impact,
+    impact_scoring,
     ingest,
     items,
     items_summary,
@@ -102,6 +103,9 @@ def register_api_routers(app: FastAPI) -> None:
 
     # Impact analysis (Cypher forward/reverse traversal)
     app.include_router(impact.router, prefix="/api/v1")
+
+    # Blast-radius risk-weighted scoring (FR-TRC-015)
+    app.include_router(impact_scoring.router, prefix="/api/v1")
 
     # Duplicate / conflict detection (FR-TRC-012)
     app.include_router(dup_conflict.router, prefix="/api/v1")

--- a/src/tracertm/api/routers/impact.py
+++ b/src/tracertm/api/routers/impact.py
@@ -1,7 +1,7 @@
 """Impact analysis API routes for TraceRTM.
 
 Exposes Cypher-backed forward and reverse impact traversal over the Neo4j
-trace-link graph.
+trace-link graph, plus in-memory blast-radius / risk-weighted scoring.
 
 Endpoints
 ---------
@@ -11,14 +11,17 @@ GET /api/v1/impact/forward/{artifact_id}
 GET /api/v1/impact/reverse/{artifact_id}
     Return all artifacts *upstream* of the given artifact (reverse impact).
 
-Functional Requirements: FR-TRACE-003
+GET /api/v1/impact/blast-radius/{artifact_id}
+    Return risk-weighted blast-radius score for the given artifact (FR-TRC-015).
+
+Functional Requirements: FR-TRACE-003, FR-TRC-015
 """
 
 from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from tracertm.api.deps import auth_guard
 from tracertm.api.handlers.impact import (
@@ -26,6 +29,7 @@ from tracertm.api.handlers.impact import (
     query_forward_impact,
     query_reverse_impact,
 )
+from tracertm.services.blast_radius_service import BlastRadiusResult, compute_blast_radius
 
 router = APIRouter(prefix="/impact", tags=["impact"])
 
@@ -83,4 +87,88 @@ async def reverse_impact(
         "direction": "reverse",
         "total": len(upstream),
         "upstream": upstream,
+    }
+
+
+@router.get(
+    "/blast-radius/{artifact_id}",
+    summary="Risk-weighted blast-radius score for an artifact (FR-TRC-015)",
+    response_model=None,
+)
+async def blast_radius(
+    artifact_id: str,
+    claims: Annotated[dict[str, Any], Depends(auth_guard)],
+    driver: Annotated[Any, Depends(get_neo4j_driver)],
+    depth: int = Query(default=5, ge=1, le=20, description="Maximum traversal depth"),
+) -> dict[str, Any]:
+    """Compute risk-weighted blast-radius for ``artifact_id``.
+
+    Uses the forward impact traversal (Neo4j trace-link graph) to determine
+    the reachable downstream artifact set, then applies per-ArtifactKind risk
+    weights and link-confidence factors to produce a normalised 0–100 score.
+
+    A ``CRITICAL`` score (≥ 75) means changes to this artifact risk cascading
+    regressions across a large, high-weight downstream surface.
+
+    Args:
+        artifact_id: UUID of the artifact whose change-impact is assessed.
+        depth: Maximum BFS hops (default 5, max 20).
+
+    Returns:
+        JSON body with ``artifact_id``, ``blast_radius_score`` (0–100),
+        ``risk_level`` (LOW/MEDIUM/HIGH/CRITICAL), ``affected_count``,
+        ``affected_artifacts``, and ``critical_path``.
+    """
+    import uuid as _uuid
+
+    from tracertm.models.trace_link import Artifact as _Artifact, ArtifactKind as _ArtifactKind, TraceLink as _TraceLink, TraceLinkType as _TraceLinkType
+
+    # Retrieve the forward impact set from Neo4j.
+    affected_rows = await query_forward_impact(driver, artifact_id)
+
+    # Build a lightweight in-memory graph for the pure-function scorer.
+    # Each Neo4j row gives us the downstream artifact; we synthesise a single
+    # IMPLEMENTS link from artifact_id to each direct descendant so the
+    # risk-weighting accounts for ArtifactKind differences.
+    _proj_id = _uuid.uuid4()
+
+    def _make_artifact(row: dict[str, Any]) -> _Artifact:
+        kind = _ArtifactKind(row["kind"]) if row.get("kind") in _ArtifactKind.__members__ else _ArtifactKind.CODE
+        return _Artifact(
+            id=_uuid.UUID(row["id"]) if row.get("id") else _uuid.uuid4(),
+            project_id=_proj_id,
+            kind=kind,
+            title=row.get("title", row.get("id", "unknown")),
+            external_id=row.get("external_id"),
+        )
+
+    src_artifact_uuid = _uuid.UUID(artifact_id)
+    artifacts: dict[str, _Artifact] = {}
+    graph: dict[str, list[_TraceLink]] = {}
+
+    for row in affected_rows:
+        tgt_id = row.get("id", "")
+        if not tgt_id:
+            continue
+        art = _make_artifact(row)
+        artifacts[tgt_id] = art
+        link = _TraceLink(
+            id=_uuid.uuid4(),
+            project_id=_proj_id,
+            source_artifact_id=src_artifact_uuid,
+            target_artifact_id=art.id,
+            link_type=_TraceLinkType.IMPLEMENTS,
+            confidence=1.0,
+        )
+        graph.setdefault(artifact_id, []).append(link)
+
+    result = compute_blast_radius(artifact_id, graph, artifacts, depth=depth)
+
+    return {
+        "artifact_id": result.artifact_id,
+        "blast_radius_score": result.blast_radius_score,
+        "risk_level": result.risk_level,
+        "affected_count": len(result.affected_artifacts),
+        "affected_artifacts": result.affected_artifacts,
+        "critical_path": result.critical_path,
     }

--- a/src/tracertm/api/routers/impact_scoring.py
+++ b/src/tracertm/api/routers/impact_scoring.py
@@ -1,0 +1,51 @@
+"""Blast-radius / risk-weighted impact scoring endpoints — FR-TRC-015.
+
+POST /api/v1/impact/blast-radius
+    Compute risk-weighted blast radius for an artifact over an in-memory
+    TraceLink graph supplied in the request body (pure function, no DB).
+"""
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from tracertm.api.deps import auth_guard
+from tracertm.models.trace_link import Artifact, TraceLink
+from tracertm.services.blast_radius_service import BlastRadiusResult, compute_blast_radius
+
+router = APIRouter(prefix="/impact", tags=["impact"])
+
+
+class BlastRadiusRequest(BaseModel):
+    """Request body for blast-radius scoring."""
+
+    artifact_id: str = Field(min_length=1)
+    artifacts: list[Artifact] = Field(default_factory=list)
+    links: list[TraceLink] = Field(default_factory=list)
+    depth: int = Field(default=5, ge=1, le=20)
+
+
+@router.post("/blast-radius")
+async def blast_radius(
+    body: BlastRadiusRequest,
+    _claims: Annotated[dict[str, Any], Depends(auth_guard)],
+) -> BlastRadiusResult:
+    """Compute risk-weighted blast radius for the given artifact.
+
+    The trace-link graph and artifact metadata are supplied in the request so
+    the endpoint is a pure read-only computation over caller-provided data.
+    """
+    artifacts_map: dict[str, Artifact] = {str(a.id): a for a in body.artifacts}
+    graph: dict[str, list[TraceLink]] = {}
+    for link in body.links:
+        source_id = str(link.source_artifact_id)
+        graph.setdefault(source_id, []).append(link)
+
+    return compute_blast_radius(
+        body.artifact_id,
+        graph,
+        artifacts_map,
+        depth=body.depth,
+    )

--- a/src/tracertm/services/blast_radius_service.py
+++ b/src/tracertm/services/blast_radius_service.py
@@ -1,0 +1,146 @@
+"""Blast-radius / risk-weighted path scoring for TraceRTM.
+
+Pure function over in-memory TraceLink graphs; no DB access required.
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Literal
+
+from tracertm.models.trace_link import ArtifactKind, Artifact, TraceLink
+
+# Risk-weighted scoring by ArtifactKind
+_KIND_WEIGHT: dict[ArtifactKind, float] = {
+    ArtifactKind.REQUIREMENT: 1.0,
+    ArtifactKind.TEST: 0.9,
+    ArtifactKind.CODE: 0.8,
+    ArtifactKind.DESIGN: 0.7,
+    ArtifactKind.RISK: 0.6,
+    ArtifactKind.EVIDENCE: 0.5,
+    ArtifactKind.RATIONALE: 0.4,
+}
+
+_DEFAULT_WEIGHT = 0.5
+
+
+def _kind_weight(kind: ArtifactKind | None) -> float:
+    if kind is None:
+        return _DEFAULT_WEIGHT
+    return _KIND_WEIGHT.get(kind, _DEFAULT_WEIGHT)
+
+
+RiskLevel = Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+
+@dataclass
+class BlastRadiusResult:
+    """Result of blast-radius computation for a single artifact."""
+
+    artifact_id: str
+    blast_radius_score: float  # 0.0 – 100.0
+    affected_artifacts: list[str] = field(default_factory=list)
+    critical_path: list[str] = field(default_factory=list)
+    risk_level: RiskLevel = "LOW"
+
+
+def _risk_level(score: float) -> RiskLevel:
+    if score < 25.0:
+        return "LOW"
+    if score < 50.0:
+        return "MEDIUM"
+    if score < 75.0:
+        return "HIGH"
+    return "CRITICAL"
+
+
+def compute_blast_radius(
+    artifact_id: str,
+    graph: dict[str, list[TraceLink]],
+    artifacts: dict[str, Artifact],
+    depth: int = 5,
+) -> BlastRadiusResult:
+    """Compute risk-weighted blast radius for *artifact_id*.
+
+    Parameters
+    ----------
+    artifact_id:
+        Source artifact whose downstream impact is assessed.
+    graph:
+        Adjacency list: source_id -> list[TraceLink].  Directed edges represent
+        downstream dependencies (source → affects → target).
+    artifacts:
+        Flat map of id -> Artifact for weight lookup.
+    depth:
+        Maximum BFS depth to traverse.
+
+    Returns
+    -------
+    BlastRadiusResult
+        Affected artifacts, weighted score (0-100), critical path, risk level.
+    """
+    visited: set[str] = set()
+    queue: deque[tuple[str, int]] = deque()
+    queue.append((artifact_id, 0))
+    visited.add(artifact_id)
+
+    weighted_sum = 0.0
+    # Track edge confidence along every path for critical-path selection
+    # best_confidence[node] = (max accumulated confidence, predecessor)
+    best_conf: dict[str, tuple[float, str | None]] = {artifact_id: (1.0, None)}
+
+    while queue:
+        current_id, current_depth = queue.popleft()
+        if current_depth >= depth:
+            continue
+        for link in graph.get(current_id, []):
+            target_id = str(link.target_artifact_id) if hasattr(link, "target_artifact_id") else str(getattr(link, "target_id", ""))
+            if not target_id or target_id == artifact_id:
+                continue
+            artifact = artifacts.get(target_id)
+            kind = artifact.kind if artifact is not None else None
+            weight = _kind_weight(kind)
+            edge_conf = float(getattr(link, "confidence", 1.0))
+
+            if target_id not in visited:
+                visited.add(target_id)
+                queue.append((target_id, current_depth + 1))
+
+            # Accumulate: add this edge's contribution to the score
+            weighted_sum += edge_conf * weight
+
+            # Track path with highest confidence
+            parent_conf, _ = best_conf.get(current_id, (1.0, None))
+            path_conf = parent_conf * edge_conf
+            existing = best_conf.get(target_id, (0.0, None))[0]
+            if path_conf > existing:
+                best_conf[target_id] = (path_conf, current_id)
+
+    affected = [aid for aid in visited if aid != artifact_id]
+
+    # Normalise to 0-100: cap at 100
+    score = min(weighted_sum * 10.0, 100.0) if affected else 0.0
+
+    # Reconstruct critical path: find leaf with highest confidence, trace back
+    if best_conf:
+        leaf = max(
+            (aid for aid in visited if aid != artifact_id),
+            key=lambda aid: best_conf.get(aid, (0.0, None))[0],
+            default=None,
+        )
+        path: list[str] = []
+        node = leaf
+        while node is not None:
+            path.append(node)
+            node = best_conf.get(node, (0.0, None))[1]
+        critical_path = list(reversed(path))
+    else:
+        critical_path = []
+
+    return BlastRadiusResult(
+        artifact_id=artifact_id,
+        blast_radius_score=round(score, 2),
+        affected_artifacts=affected,
+        critical_path=critical_path,
+        risk_level=_risk_level(score),
+    )

--- a/tests/unit/services/test_blast_radius_scoring.py
+++ b/tests/unit/services/test_blast_radius_scoring.py
@@ -1,0 +1,206 @@
+"""Unit tests for blast_radius_service — FR-TRC-015.
+
+All tests are pure-function; no DB or graph-DB required.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tracertm.models.trace_link import ArtifactKind, Artifact, TraceLink, TraceLinkType
+from tracertm.services.blast_radius_service import BlastRadiusResult, _kind_weight, _risk_level, compute_blast_radius
+
+_PROJECT_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+# Stable artifact IDs for tests
+_IDS: dict[str, uuid.UUID] = {
+    label: uuid.UUID(f"00000000-0000-0000-0000-{i:012d}")
+    for i, label in enumerate(["A", "B", "C", "D", "src"] + [str(i) for i in range(1000)], start=1)
+}
+
+
+def _aid(label: str) -> str:
+    """Return a stable string UUID for the given label."""
+    return str(_IDS[label])
+
+
+def _artifact(label: str, kind: ArtifactKind = ArtifactKind.CODE) -> Artifact:
+    return Artifact(
+        id=_IDS[label],
+        project_id=_PROJECT_ID,
+        kind=kind,
+        title=f"Artifact {label}",
+        external_id=label,
+    )
+
+
+def _link(source_label: str, target_label: str, confidence: float = 1.0) -> TraceLink:
+    return TraceLink(
+        id=uuid.uuid4(),
+        project_id=_PROJECT_ID,
+        source_artifact_id=_IDS[source_label],
+        target_artifact_id=_IDS[target_label],
+        link_type=TraceLinkType.IMPLEMENTS,
+        confidence=confidence,
+    )
+
+
+def _graph(*edges: tuple[str, str, float | None]) -> dict[str, list[TraceLink]]:
+    """Build adjacency dict keyed by string UUID."""
+    g: dict[str, list[TraceLink]] = {}
+    for edge in edges:
+        src, tgt = edge[0], edge[1]
+        conf = edge[2] if len(edge) > 2 and edge[2] is not None else 1.0  # type: ignore[misc]
+        link = _link(src, tgt, conf)
+        g.setdefault(_aid(src), []).append(link)
+    return g
+
+
+def _artifacts(*labels: str, **kind_overrides: ArtifactKind) -> dict[str, Artifact]:
+    return {_aid(lbl): _artifact(lbl, kind_overrides.get(lbl, ArtifactKind.CODE)) for lbl in labels}
+
+
+# --- _kind_weight ------------------------------------------------------------------
+
+
+def test_kind_weight_requirement_is_highest() -> None:
+    assert _kind_weight(ArtifactKind.REQUIREMENT) == 1.0
+
+
+def test_kind_weight_rationale_is_lowest() -> None:
+    assert _kind_weight(ArtifactKind.RATIONALE) == 0.4
+
+
+def test_kind_weight_none_returns_default() -> None:
+    assert _kind_weight(None) == 0.5
+
+
+# --- _risk_level -------------------------------------------------------------------
+
+
+def test_risk_level_low_below_25() -> None:
+    assert _risk_level(0.0) == "LOW"
+    assert _risk_level(24.9) == "LOW"
+
+
+def test_risk_level_medium_25_to_50() -> None:
+    assert _risk_level(25.0) == "MEDIUM"
+    assert _risk_level(49.9) == "MEDIUM"
+
+
+def test_risk_level_high_50_to_75() -> None:
+    assert _risk_level(50.0) == "HIGH"
+    assert _risk_level(74.9) == "HIGH"
+
+
+def test_risk_level_critical_75_and_above() -> None:
+    assert _risk_level(75.0) == "CRITICAL"
+    assert _risk_level(100.0) == "CRITICAL"
+
+
+# --- compute_blast_radius ----------------------------------------------------------
+
+
+def test_isolated_artifact_returns_zero_score() -> None:
+    result = compute_blast_radius(_aid("A"), {}, {})
+    assert result.blast_radius_score == 0.0
+    assert result.affected_artifacts == []
+    assert result.risk_level == "LOW"
+
+
+def test_single_edge_produces_affected_artifact() -> None:
+    g = _graph(("A", "B"))
+    arts = _artifacts("A", "B")
+    result = compute_blast_radius(_aid("A"), g, arts)
+    assert _aid("B") in result.affected_artifacts
+    assert result.blast_radius_score > 0.0
+
+
+def test_chain_three_artifacts_all_affected() -> None:
+    g = _graph(("A", "B"), ("B", "C"))
+    arts = _artifacts("A", "B", "C")
+    result = compute_blast_radius(_aid("A"), g, arts)
+    assert set(result.affected_artifacts) == {_aid("B"), _aid("C")}
+
+
+def test_depth_limit_truncates_traversal() -> None:
+    g = _graph(("A", "B"), ("B", "C"), ("C", "D"))
+    arts = _artifacts("A", "B", "C", "D")
+    result = compute_blast_radius(_aid("A"), g, arts, depth=1)
+    assert _aid("B") in result.affected_artifacts
+    assert _aid("C") not in result.affected_artifacts
+    assert _aid("D") not in result.affected_artifacts
+
+
+def test_high_confidence_link_raises_score() -> None:
+    g_high = _graph(("A", "B", 1.0))
+    g_low = _graph(("A", "B", 0.1))
+    arts = _artifacts("A", "B")
+    result_high = compute_blast_radius(_aid("A"), g_high, arts)
+    result_low = compute_blast_radius(_aid("A"), g_low, arts)
+    assert result_high.blast_radius_score > result_low.blast_radius_score
+
+
+def test_requirement_kind_heavier_than_code() -> None:
+    """REQUIREMENT-typed artifact should produce higher score than CODE-typed."""
+    g = _graph(("A", "B"))
+    arts_req = {_aid("A"): _artifact("A"), _aid("B"): _artifact("B", ArtifactKind.REQUIREMENT)}
+    arts_code = {_aid("A"): _artifact("A"), _aid("B"): _artifact("B", ArtifactKind.CODE)}
+    score_req = compute_blast_radius(_aid("A"), g, arts_req).blast_radius_score
+    score_code = compute_blast_radius(_aid("A"), g, arts_code).blast_radius_score
+    assert score_req > score_code
+
+
+def test_score_capped_at_100() -> None:
+    """Very wide graphs should not produce score > 100."""
+    targets = [str(i) for i in range(50)]
+    g: dict[str, list[TraceLink]] = {
+        _aid("src"): [_link("src", t) for t in targets]
+    }
+    arts: dict[str, Artifact] = {_aid("src"): _artifact("src")}
+    arts.update({_aid(t): _artifact(t) for t in targets})
+    result = compute_blast_radius(_aid("src"), g, arts)
+    assert result.blast_radius_score <= 100.0
+
+
+def test_critical_path_starts_at_source() -> None:
+    g = _graph(("A", "B"), ("B", "C"))
+    arts = _artifacts("A", "B", "C")
+    result = compute_blast_radius(_aid("A"), g, arts)
+    assert result.critical_path[0] == _aid("A")
+
+
+def test_critical_path_ends_at_highest_confidence_leaf() -> None:
+    # A->B (0.9), A->C (0.5) — critical path should end at B
+    g = _graph(("A", "B", 0.9), ("A", "C", 0.5))
+    arts = _artifacts("A", "B", "C")
+    result = compute_blast_radius(_aid("A"), g, arts)
+    assert result.critical_path[-1] == _aid("B")
+
+
+def test_artifact_id_in_result() -> None:
+    result = compute_blast_radius(_aid("A"), {}, {})
+    assert result.artifact_id == _aid("A")
+
+
+def test_empty_graph_critical_path_is_empty() -> None:
+    result = compute_blast_radius(_aid("A"), {}, {})
+    assert result.critical_path == []
+
+
+def test_cyclic_links_do_not_loop_forever() -> None:
+    """Cycle A->B->A must not infinite-loop."""
+    g = _graph(("A", "B"), ("B", "A"))
+    arts = _artifacts("A", "B")
+    result = compute_blast_radius(_aid("A"), g, arts)
+    assert isinstance(result.blast_radius_score, float)
+
+
+def test_blast_radius_result_is_dataclass_with_expected_fields() -> None:
+    r = BlastRadiusResult(artifact_id="x", blast_radius_score=42.0)
+    assert r.artifact_id == "x"
+    assert r.blast_radius_score == 42.0
+    assert r.risk_level == "LOW"
+    assert r.affected_artifacts == []
+    assert r.critical_path == []


### PR DESCRIPTION
## **User description**
## Summary

- Implements FR-TRC-015: confidence-weighted blast-radius scoring over the Requirement/Artifact/TraceLink graph
- `blast_radius_service.py`: pure-function BFS with per-ArtifactKind risk weights × link-confidence; 0–100 score; LOW/MEDIUM/HIGH/CRITICAL tiers; critical-path reconstruction
- `GET /api/v1/impact/blast-radius/{artifact_id}`: read-only endpoint wired onto existing impact router; fetches Neo4j forward-impact set then runs pure scorer
- 20 unit tests (pure-function, no DB); fixes pre-existing SyntaxError in coverage_matrix.py
- FR-TRC-015 flipped PLANNED → SHIPPED in requirements catalog

## Traceability

- FR: FR-TRC-015
- Source: `src/tracertm/services/blast_radius_service.py`, `src/tracertm/api/routers/impact.py`
- Tests: `tests/unit/services/test_blast_radius_scoring.py` (20 tests, all green)

## Test plan

- [x] `uv run pytest tests/unit/services/test_blast_radius_scoring.py` — 20 passed
- [x] `uv run pytest tests/unit/api/` — 26 passed
- [x] Pre-existing `test_async_database.py` failure confirmed present on main (DB auth, not our change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated impact endpoints depend on Neo4j forward-impact data and approximate graph topology via star-shaped synthetic links on GET, which can skew scores versus the real multi-hop graph; scoring logic is well covered by unit tests but GET integration behavior is not in this diff.
> 
> **Overview**
> Ships **FR-TRC-015** by adding pure-function blast-radius scoring over TraceLink graphs and wiring it into the impact API.
> 
> **`blast_radius_service`** BFS-walks a caller-supplied adjacency list (depth-limited), weights each reached artifact by `ArtifactKind`, multiplies by link confidence, normalizes to a 0–100 score, maps **LOW/MEDIUM/HIGH/CRITICAL**, and returns affected IDs plus a confidence-based **critical path**.
> 
> **API:** **`GET /api/v1/impact/blast-radius/{artifact_id}`** loads downstream artifacts from Neo4j forward impact, builds a simplified in-memory graph (synthetic **IMPLEMENTS** edges from the source to each row), then runs the scorer; optional **`depth`** query param (1–20). **`POST /api/v1/impact/blast-radius`** scores an in-memory graph from the request body (artifacts + links) with no DB. The new **`impact_scoring`** router is registered alongside the existing impact router.
> 
> Requirements docs mark FR-TRC-015 **SHIPPED** and add traceability to **20** unit tests in **`test_blast_radius_scoring.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11bd306dd000f9b4b85254e0e29e59a48f77606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add risk-weighted blast-radius scoring for impacted artifacts**

### What Changed
- Added a new impact endpoint that returns a blast-radius score, risk level, affected artifacts, and a critical path for a chosen artifact
- The score now reflects both artifact type and trace-link confidence, with depth limits to control how far impact is traced
- Marked FR-TRC-015 as shipped in the requirements catalog and added coverage for the new behavior
- Fixed the coverage matrix route so it continues to accept its query options correctly

### Impact
`✅ Clearer change-risk reviews`
`✅ Faster impact checks on large trace graphs`
`✅ Fewer missed downstream risks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
