### PR TITLE
feat(integration): FR-TRC-016 push Requirements/TraceLinks to AgilePlus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,7 +144,7 @@ GITHUB_PRIVATE_KEY_PATH=/path/to/your/github-app-private-key.pem
 # -----------------------------------------------------------------------------
 # AgilePlus Integration (Optional)
 # -----------------------------------------------------------------------------
-AGILEPLUS_URL=https://agileplus.example
+AGILEPLUS_URL=http://localhost:3000
 AGILEPLUS_API_KEY=YOUR_AGILEPLUS_API_KEY
 
 # -----------------------------------------------------------------------------

--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -347,7 +347,7 @@
 | FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | SHIPPED | Branch `feat/trc013-bulk-tracelink-ingestion`; sources: `src/tracertm/services/github_import_service.py`, `src/tracertm/services/jira_import_service.py`, `src/tracertm/api/routers/ingest.py`; validated with 28 unit tests; `uv run python -c "import tracertm"` |
 | FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | SHIPPED | Pure-function `coverage_matrix_service.py`; rows=requirements, cols=impl/test + ArtifactKind buckets; endpoint GET /api/v1/coverage/matrix?format=csv\|json; CSV RFC 4180 + pipe-separated multi-artifact cells; PDF deferred (heavy dep); 25 unit tests; PR: feat/coverage-matrix-export |
 | FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | SHIPPED | Pure-function `blast_radius_service.py`; BFS over Requirement/Artifact/TraceLink graph with per-ArtifactKind risk weights + link-confidence multipliers; score 0–100 with LOW/MEDIUM/HIGH/CRITICAL tiers; endpoint `GET /api/v1/impact/blast-radius/{artifact_id}`; 20 unit tests; PR: feat/trc015-blast-radius-scoring |
-| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | `agileplus_adapter.py` pushes Requirement / TraceLink payloads; endpoint `POST /api/v1/integrations/agileplus/push`; dog-food use case for AgilePlus |
+| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | branch `feat/trc016-agileplus-push`; `tests/unit/services/test_agileplus_adapter.py` (17 tests); `src/tracertm/adapters/agileplus_adapter.py`; endpoint `POST /api/v1/integrations/agileplus/push`; `.env.example` AgilePlus config |
 | FR-TRC-017 | Traceability coverage / health scoring over Requirement-Artifact-TraceLink graph | SHIPPED | Pure-function `traceability_score_service.py`; metrics: impl_coverage, test_coverage, orphan_req_pct, orphan_art_pct, avg_confidence, composite 0-100; endpoint GET /api/v1/quality/score; 19 unit tests; PR: feat/quality-scoring |
 | NFR-TRC-008 | Link confidence index selectivity target ≥ 90% for miner-generated links | PLANNED | Baseline TBD once miner ships |
 | NFR-TRC-009 | Neo4j projection sync latency < 500 ms p99 for single-link writes | PLANNED | No SLA defined yet |
@@ -372,6 +372,6 @@
 | FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
 | FR-TRC-014 | feat/coverage-matrix-export | `test_coverage_matrix_service.py` (25 tests) |
 | FR-TRC-015 | feat/trc015-blast-radius-scoring | `test_blast_radius_scoring.py` (20 tests) |
-| FR-TRC-016 | feat/integration: AgilePlus push adapter | `test_agileplus_adapter.py` (17 tests) |
+| FR-TRC-016 | feat/trc016-agileplus-push | `test_agileplus_adapter.py` (17 tests) |
 | FR-TRC-017 | feat/quality-scoring | `test_traceability_score_service.py` (19 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |

--- a/src/tracertm/adapters/agileplus_adapter.py
+++ b/src/tracertm/adapters/agileplus_adapter.py
@@ -122,23 +122,33 @@ class AgilePlusAdapter:
         return str(error)
 
     def _requirement_payload(self, requirement: Requirement) -> dict[str, Any]:
-        return {
-            "id": str(requirement.id),
+        metadata: dict[str, Any] = {
+            "external_id": str(requirement.id),
             "project_id": str(requirement.project_id),
             "kind": requirement.kind.value,
-            "title": requirement.title,
-            "description": requirement.description,
-            "external_id": requirement.external_id,
-            "metadata": requirement.metadata,
             "status": requirement.status.value,
-            "priority": requirement.priority,
-            "rationale": requirement.rationale,
-            "acceptance_criteria": requirement.acceptance_criteria,
-            "verification_method": requirement.verification_method.value if requirement.verification_method else None,
+        }
+        if requirement.priority is not None:
+            metadata["priority"] = requirement.priority
+        if requirement.rationale is not None:
+            metadata["rationale"] = requirement.rationale
+        if requirement.acceptance_criteria:
+            metadata["acceptance_criteria"] = requirement.acceptance_criteria
+        if requirement.verification_method is not None:
+            metadata["verification_method"] = requirement.verification_method.value
+        if requirement.external_id is not None:
+            metadata["source_external_id"] = requirement.external_id
+        if requirement.metadata:
+            metadata["source_metadata"] = requirement.metadata
+
+        return {
+            "title": requirement.title,
+            "body": requirement.description,
+            "metadata": metadata,
         }
 
     def _trace_link_payload(self, link: TraceLink) -> dict[str, Any]:
-        return {
+        trace_link = {
             "id": str(link.id),
             "project_id": str(link.project_id),
             "source_artifact_id": str(link.source_artifact_id),
@@ -148,12 +158,20 @@ class AgilePlusAdapter:
             "rationale": link.rationale,
             "metadata": link.metadata,
         }
+        return {
+            "tags": [
+                f"trace-link:{link.link_type.value.lower()}",
+                f"trace-link:{link.id}",
+            ],
+            "metadata": {
+                "trace_link": trace_link,
+            },
+        }
 
     async def _post_json(self, path: str, payload: dict[str, Any]) -> AgilePlusPushResult:
         client = await self._get_client()
-        url = f"{self.base_url}{path}"
         try:
-            response = await client.post(url, json=payload, headers=self._headers())
+            response = await client.post(path, json=payload, headers=self._headers())
         except httpx.HTTPError as exc:
             return AgilePlusPushResult(success=False, error=self._stringify_failure(None, exc))
 
@@ -172,25 +190,28 @@ class AgilePlusAdapter:
 
     async def push_requirement(self, req: Requirement) -> AgilePlusPushResult:
         """Push one requirement to AgilePlus."""
-        return await self._post_json("/api/v1/requirements", self._requirement_payload(req))
+        return await self._post_json("/api/stories", self._requirement_payload(req))
 
     async def push_trace_link(self, link: TraceLink) -> AgilePlusPushResult:
         """Push one trace link to AgilePlus."""
-        return await self._post_json("/api/v1/trace-links", self._trace_link_payload(link))
+        return await self._post_json(
+            f"/api/stories/{link.target_artifact_id}/tags",
+            self._trace_link_payload(link),
+        )
 
     async def push_project_requirements(
         self,
         project_id: str,
-        reqs: list[Requirement],
+        requirements: list[Requirement],
         links: list[TraceLink],
     ) -> BulkPushResult:
         """Push a project's requirements and trace links to AgilePlus."""
-        total = len(reqs) + len(links)
+        total = len(requirements) + len(links)
         succeeded = 0
         failed = 0
         errors: list[str] = []
 
-        for requirement in reqs:
+        for requirement in requirements:
             if str(requirement.project_id) != str(project_id):
                 failed += 1
                 errors.append(

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -8,13 +8,13 @@ from tracertm.api.routers import (
     agent,
     analysis,
     auth,
-    code_trace,
     auth_public,
     auth_refresh,
     auth_session,
     blockchain,
     cache,
     chat,
+    code_trace,
     codex,
     comments,
     contracts,
@@ -30,6 +30,7 @@ from tracertm.api.routers import (
     impact,
     impact_scoring,
     ingest,
+    integrations,
     items,
     items_summary,
     linear,
@@ -37,7 +38,6 @@ from tracertm.api.routers import (
     mcp,
     mine,
     notifications,
-    traceability_score,
     oauth,
     problems,
     processes,
@@ -50,6 +50,7 @@ from tracertm.api.routers import (
     test_run_results,
     test_runs,
     test_suites,
+    traceability_score,
     webhooks,
     websocket,
     workflows,
@@ -130,6 +131,7 @@ def register_api_routers(app: FastAPI) -> None:
     app.include_router(github.router)
     app.include_router(github.webhook_router)
     app.include_router(linear.router)
+    app.include_router(integrations.router)
     app.include_router(webhooks.router)
     app.include_router(webhooks.project_router)
     app.include_router(websocket.router)

--- a/tests/unit/services/test_agileplus_adapter.py
+++ b/tests/unit/services/test_agileplus_adapter.py
@@ -101,12 +101,12 @@ async def test_push_requirement_sends_expected_payload() -> None:
     def callback(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         assert request.method == "POST"
-        assert request.url.path == "/api/v1/requirements"
-        assert body["id"] == str(requirement.id)
-        assert body["project_id"] == str(requirement.project_id)
+        assert request.url.path == "/api/stories"
         assert body["title"] == "Payload check"
-        assert body["status"] == RequirementStatus.APPROVED.value
-        assert body["acceptance_criteria"] == ["works"]
+        assert body["body"] == "A traced requirement"
+        assert body["metadata"]["external_id"] == str(requirement.id)
+        assert body["metadata"]["project_id"] == str(requirement.project_id)
+        assert body["metadata"]["status"] == RequirementStatus.APPROVED.value
         return httpx.Response(200, json={"agileplus_id": "req-456"})
 
     adapter, _handler = _adapter_with(callback)
@@ -132,7 +132,7 @@ async def test_push_requirement_handles_non_success_status() -> None:
 @pytest.mark.asyncio
 async def test_push_requirement_handles_network_error() -> None:
     def callback(_request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=httpx.Request("POST", "https://agileplus.example/api/v1/requirements"))
+        raise httpx.ConnectError("boom", request=httpx.Request("POST", "https://agileplus.example/api/stories"))
 
     adapter, _handler = _adapter_with(callback)
     result = await adapter.push_requirement(_requirement())
@@ -160,7 +160,7 @@ async def test_push_requirement_uses_other_project_id() -> None:
 
     def callback(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
-        assert body["project_id"] == str(OTHER_PROJECT_ID)
+        assert body["metadata"]["project_id"] == str(OTHER_PROJECT_ID)
         return httpx.Response(200, json={"id": "req-999"})
 
     adapter, _handler = _adapter_with(callback)
@@ -189,14 +189,19 @@ async def test_push_trace_link_sends_expected_payload() -> None:
     def callback(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         assert request.method == "POST"
-        assert request.url.path == "/api/v1/trace-links"
-        assert body["id"] == str(link.id)
-        assert body["project_id"] == str(link.project_id)
-        assert body["source_artifact_id"] == str(link.source_artifact_id)
-        assert body["target_artifact_id"] == str(link.target_artifact_id)
-        assert body["link_type"] == TraceLinkType.SATISFIES.value
-        assert body["confidence"] == pytest.approx(0.85)
-        assert body["rationale"] == "Trace evidence"
+        assert request.url.path == f"/api/stories/{link.target_artifact_id}/tags"
+        assert body["tags"] == [
+            f"trace-link:{link.link_type.value.lower()}",
+            f"trace-link:{link.id}",
+        ]
+        trace_link = body["metadata"]["trace_link"]
+        assert trace_link["id"] == str(link.id)
+        assert trace_link["project_id"] == str(link.project_id)
+        assert trace_link["source_artifact_id"] == str(link.source_artifact_id)
+        assert trace_link["target_artifact_id"] == str(link.target_artifact_id)
+        assert trace_link["link_type"] == TraceLinkType.SATISFIES.value
+        assert trace_link["confidence"] == pytest.approx(0.85)
+        assert trace_link["rationale"] == "Trace evidence"
         return httpx.Response(201, json={"agileplus_id": "link-456"})
 
     adapter, _handler = _adapter_with(callback)
@@ -228,10 +233,10 @@ async def test_push_project_requirements_success_counts_all_items() -> None:
 
     def callback(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content)
-        if request.url.path == "/api/v1/requirements":
+        if request.url.path == "/api/stories":
             return httpx.Response(200, json={"id": f"req-{payload['title'].lower().replace(' ', '-')}"})
-        if request.url.path == "/api/v1/trace-links":
-            return httpx.Response(200, json={"id": f"link-{payload['target_artifact_id'][-4:]}"})
+        if request.url.path.endswith("/tags"):
+            return httpx.Response(200, json={"id": f"link-{payload['metadata']['trace_link']['target_artifact_id'][-4:]}"})
         pytest.fail(f"unexpected path: {request.url.path}")
 
     adapter, _handler = _adapter_with(callback)
@@ -293,7 +298,7 @@ async def test_push_project_requirements_preserves_order() -> None:
     adapter, _handler = _adapter_with(callback)
     await adapter.push_project_requirements(PROJECT_ID, [req], [link])
 
-    assert paths == ["/api/v1/requirements", "/api/v1/trace-links"]
+    assert paths == ["/api/stories", f"/api/stories/{req.id}/tags"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## **User description**
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes external integration contract and assumes trace link targets map to AgilePlus story IDs; misalignment could cause failed or mis-tagged pushes in production.
> 
> **Overview**
> **FR-TRC-016** updates the AgilePlus outbound integration so TraceRTM pushes match AgilePlus’s **stories** and **story tags** API instead of generic `/api/v1/requirements` and `/api/v1/trace-links`.
> 
> Requirements are sent as **POST `/api/stories`** with `title`, `body`, and traceability fields nested under `metadata` (including `external_id`, `project_id`, status, and optional priority/rationale/acceptance criteria). Trace links go to **POST `/api/stories/{target_artifact_id}/tags`** as tag strings plus full link detail in `metadata.trace_link`. HTTP calls use the client’s configured `base_url` with relative paths only.
> 
> **`.env.example`** sets default `AGILEPLUS_URL` to `http://localhost:3000` for local dogfooding. Requirements docs record branch **`feat/trc016-agileplus-push`**. **`router_registry`** registers the **`integrations`** router (AgilePlus push lives there). Unit tests assert the new paths and payload shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa92cd9f6488f503028788108a3081420e4543e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Push requirements and trace links to AgilePlus in its story/tag format

### What Changed
- Requirements are now sent as AgilePlus stories, with the requirement details kept in story metadata
- Trace links are now sent as tags on the linked story, with the full link details included in metadata
- The AgilePlus integration router is now available in the API
- The example AgilePlus setup now points to a local AgilePlus server

### Impact
`✅ AgilePlus sync uses the current story/tag structure`
`✅ Requirement data stays available during sync`
`✅ Trace links are attached to the correct AgilePlus story`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
