### PR TITLE
docs: rich-media stub boxes pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,23 @@ Licensed under the MIT License. See [LICENSE](LICENSE) for details.
 ---
 
 **Built with 🛠 for agent-driven development**
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Tracera quickstart — first requirement registered + TraceLink created" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of the Tracera dashboard after creating the first FR and linking it to a commit.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-gif" subject="TraceLink flow — requirement to code to test to PR chain" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *GIF of creating a TraceLink from a requirement through to a PR.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-mp4" subject="Traceability report — full audit trail view" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Video of the traceability report panel showing full FR/NFR chain.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Requirements dashboard — FR/NFR status board" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of the requirements status board.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/RICH_MEDIA.md
+++ b/RICH_MEDIA.md
@@ -1,0 +1,58 @@
+# Rich Media Convention — Phenotype Org
+
+> **Canonical location:** `KooshaPari/phenotype-registry` → `RICH_MEDIA.md`
+> Copied to each participating repo as a docs-only reference.
+
+## Stub Marker Format
+
+Insert stubs using this **exact** HTML-comment pair so fill-agents can grep them:
+
+```html
+<!-- RICH-MEDIA-STUB type="annotated-screenshot|recording-mp4|recording-gif" subject="<what>" journey="<flow>" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *<short human description of what will go here>*
+<!-- END-RICH-MEDIA-STUB -->
+```
+
+### Attribute reference
+
+| attribute | values | notes |
+|-----------|--------|-------|
+| `type` | `annotated-screenshot` \| `recording-mp4` \| `recording-gif` | pick the most appropriate |
+| `subject` | free text | what the media shows (e.g. `"VRAM plan slider UI"`) |
+| `journey` | phenotype-journeys manifest name or `""` | e.g. `"first-plan"`, `"fleet-register"` |
+| `status` | `TODO` \| `CAPTURED` \| `PUBLISHED` | fill-agent updates to `CAPTURED`/`PUBLISHED` |
+
+## Grep Targets
+
+```bash
+# all stubs
+grep -r "RICH-MEDIA-STUB" docs/
+
+# by journey
+grep -r 'journey="first-plan"' docs/
+
+# outstanding TODOs
+grep -r 'status="TODO"' docs/
+```
+
+## Expected Placement Areas (5 categories)
+
+1. **quickstart / getting-started** — `annotated-screenshot` of first-run output or install step
+2. **feature walkthroughs** — `recording-gif` per major feature
+3. **dashboard / UI pages** — `annotated-screenshot` of each major panel or view
+4. **E2E / journey flows** — `recording-mp4` tied to phenotype-journeys journey name
+5. **architecture diagrams** — `annotated-screenshot` of component map or data-flow
+
+## Journey Linkage
+
+Where a `docs/journeys/manifests/` directory exists, the `journey=` attribute **MUST** match the manifest slug exactly.
+
+Known hwLedger journeys (13): `first-plan`, `fleet-register`, `traceability-report`, `vram-reconcile`, `inference-run`, `fleet-probe`, `cost-model`, `audit-log`, `fleet-dispatch`, `model-ingest`, `telemetry-sync`, `kv-cache-plan`, `spot-price-scan`.
+
+## Fill-Agent Instructions
+
+1. Search for `status="TODO"` stubs.
+2. Capture the screenshot/recording described in `subject=`.
+3. Upload asset to `docs/assets/rich-media/<repo>/<slug>.<ext>`.
+4. Replace the placeholder callout with a real `<img>` or `<video>` tag.
+5. Change `status="TODO"` → `status="PUBLISHED"`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,9 @@
+
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Tracera architecture — hexagonal ports and adapters diagram" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated component diagram of Traceras hexagonal architecture.*
+<!-- END-RICH-MEDIA-STUB -->


### PR DESCRIPTION
## **User description**
Additive docs-only PR. Inserts RICH_MEDIA.md convention + 5 stub markers across quickstart, TraceLink flow, traceability report, requirements dashboard, and architecture. Status=TODO for fill-agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and placeholder markers only; no application, auth, or data-path changes.
> 
> **Overview**
> Introduces a **docs-only** rich-media workflow: new **`RICH_MEDIA.md`** documents the Phenotype org stub format (HTML-comment markers, attributes, grep targets, fill-agent steps).
> 
> **`README.md`** gains a **Rich Media Stubs** section with four **`status="TODO"`** placeholders (quickstart screenshot, TraceLink GIF, traceability report video, requirements dashboard screenshot). **`SPEC.md`** adds one architecture-diagram stub the same way. No runtime or API behavior changes—only placeholders for a later fill-agent pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e9a7c3a4326e8f6cafcef31ea4f2053e652705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a standard way to mark rich media placeholders in the docs**

### What Changed
- Added a shared rich media convention that explains how to mark screenshot and video placeholders
- Added new placeholder stubs in the README for the quickstart, TraceLink flow, traceability report, and requirements dashboard
- Added a placeholder stub in the architecture spec for the hexagonal architecture diagram

### Impact
`✅ Clearer docs capture workflow`
`✅ Faster rich media filling for docs`
`✅ Fewer missed screenshot and video placeholders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New rich media convention documentation establishes standardized guidelines for multimedia content placeholders throughout the repository
  * Added rich media stub placeholders to documentation files for upcoming annotated screenshots, recordings, and instructional videos
  * Defined placement categories and standardized format for managing rich media assets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KooshaPari/Tracera/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->