### PR TITLE
feat(ports): Pillar-A spine — canonical graph contract + ScorerPort (R&D, do not merge)

### DIFF
--- a/docs/02-architecture/PILLAR_A_SPINE.md
+++ b/docs/02-architecture/PILLAR_A_SPINE.md
@@ -60,8 +60,8 @@ callers never change.
 
 ## 4. Follow-on (not in this step)
 
-1. **Neo4j adapter** implementing `GraphPort` by wrapping
-   `storage/neo4j_trace_link_writer.py`.
+1. ~~**Neo4j adapter** implementing `GraphPort` by wrapping
+   `storage/neo4j_trace_link_writer.py`.~~ → landed in `rnd/pillar-a-graphport-wire`.
 2. **Migrate the ~12 trace/impact services** to write *only* via `GraphPort`
    (`traceability_service`, `impact_analysis_service`, `blast_radius_service`, …).
 3. **Refactor `traceability_score_service`** to consume `ScorerPort`; add the

--- a/docs/02-architecture/PILLAR_A_SPINE.md
+++ b/docs/02-architecture/PILLAR_A_SPINE.md
@@ -1,0 +1,76 @@
+# Pillar-A Spine — Canonical Graph Contract + ScorerPort (Phase 0)
+
+**Status:** Scaffolding landed (contracts + tests). Migration of services pending.
+**Epic:** `EPIC-TRC-A-SPINE`
+**Requirements:** `FR-TRC-018`, `FR-TRC-019`, `NFR-TRC-010`, `NFR-TRC-011`
+**Blueprint:** [`docs/TRACERA_PLATFORM_RND.md`](../TRACERA_PLATFORM_RND.md) §3.2–§3.3, §4 (Phase 0)
+
+---
+
+## 1. Why this is the first step
+
+The platform blueprint (PR #493) makes Pillar A (deep traceability) the **spine**:
+Pillars B/C/D all write into the *same* typed graph and are worthless if the schema
+contract and scoring ports are not canonical first. Today the failure mode is **drift** —
+node/edge kinds are invented ad-hoc across ~12 trace/impact services and the Neo4j
+writer, and agreement scoring is heuristic and duplicated. This change introduces the
+two contracts that stop the drift.
+
+This is **one focused Phase-0 step**: the contracts + a dependency-free reference
+implementation + tests. It does **not** migrate the existing services yet (that is the
+follow-on tracked below).
+
+## 2. What landed
+
+| Artifact | Requirement | Purpose |
+|---|---|---|
+| `src/tracertm/ports/graph_contract.py` | `FR-TRC-018`, `NFR-TRC-010` | Canonical `NodeKind` / `EdgeType` enums (closed vocabulary), `GraphNode`/`GraphEdge` value objects, endpoint-validation (`validate_node`/`validate_edge`), and the `GraphPort` protocol — the *sole* graph-write contract. |
+| `src/tracertm/ports/scorer.py` | `FR-TRC-019` | `ScorerPort` strategy protocol + `ScoreResult` (normalized `[0,1]` + rationale) + dependency-free `JaccardScorer` reference strategy. |
+| `tests/unit/ports/test_graph_contract.py` | — | Vocabulary is closed; valid/invalid endpoints; `GraphPort` is satisfiable. |
+| `tests/unit/ports/test_scorer.py` | — | Identical→1.0, disjoint→0.0, partial in-between, strategy is swappable at call site. |
+
+### 2.1 Canonical vocabulary (the contract)
+
+- **Node kinds:** `Requirement, Spec, ADR, Code, Test, PR, Commit, Release, Portfolio,
+  OKR, Roadmap, Evidence, Journey, Keyframe, Repo, Team`.
+- **Edge types:** `TRACES_TO, VERIFIES, IMPACTS, DEPENDS_ON, DUPLICATES, IMPLEMENTS,
+  COVERS, EVIDENCES, BELONGS_TO, RELEASES`.
+- **Endpoint rules:** structural edges (`IMPLEMENTS`, `COVERS`, `VERIFIES`, `EVIDENCES`,
+  `RELEASES`) constrain their source/target kinds; semantic edges (`TRACES_TO`,
+  `IMPACTS`, `DEPENDS_ON`, `DUPLICATES`, `BELONGS_TO`) are open-ended. Anything outside
+  the vocabulary raises `SchemaContractError` — drift is impossible by construction.
+
+### 2.2 ScorerPort strategy
+
+`ScorerPort` is the single seam Pillars A and C both consume. The Jaccard strategy is
+the zero-dependency baseline; embedding (`SentenceTransformer`, `SigLIP`) and VLM
+blind-vs-intent strategies (`FR-TRC-020`, Phase 2) plug in behind the *same* port, so
+callers never change.
+
+## 3. Design choices
+
+- **Stdlib-only contracts.** `ports/` has no graph-driver or ML dependency, so every
+  pillar and the HexaKit Rust canonical ports can mirror it without heavy imports.
+- **`runtime_checkable` Protocols, not ABCs.** Adapters (e.g. a Neo4j adapter wrapping
+  the existing `storage/neo4j_trace_link_writer.py`) satisfy the port structurally —
+  no inheritance coupling.
+- **Validation at the write boundary.** `GraphPort` implementations MUST call
+  `validate_node`/`validate_edge` before persisting; this is the enforcement point for
+  `NFR-TRC-010`.
+
+## 4. Follow-on (not in this step)
+
+1. **Neo4j adapter** implementing `GraphPort` by wrapping
+   `storage/neo4j_trace_link_writer.py`.
+2. **Migrate the ~12 trace/impact services** to write *only* via `GraphPort`
+   (`traceability_service`, `impact_analysis_service`, `blast_radius_service`, …).
+3. **Refactor `traceability_score_service`** to consume `ScorerPort`; add the
+   SentenceTransformer/SigLIP strategies (Phase 1).
+4. **Graduate** `feat/cypher-impact-api`, `feat/trc013` (bulk ingest), `feat/trc015`
+   (blast-radius scoring) onto the contract.
+5. **Mirror** the vocabulary in HexaKit canonical ports (`NFR-TRC-011`).
+
+## 5. Self-hosting
+
+Per `NFR-TRC-012`, this change traces itself: `FR-TRC-018`/`FR-TRC-019` →
+`src/tracertm/ports/*.py` → `tests/unit/ports/*` → this PR.

--- a/src/tracertm/ports/__init__.py
+++ b/src/tracertm/ports/__init__.py
@@ -1,0 +1,56 @@
+"""Canonical platform ports (hexagonal driven ports) for Tracera.
+
+This package is the Python mirror of the canonical port contracts described in
+``docs/TRACERA_PLATFORM_RND.md`` (the 4-pillar platform blueprint, PR #493) and
+registered as requirements ``FR-TRC-018`` / ``FR-TRC-019`` in
+``docs/requirements/tracera-frnfr.md``.
+
+Pillar-A spine (Phase 0) deliverables scaffolded here:
+
+* :mod:`tracertm.ports.graph_contract` -- the single canonical typed-graph schema
+  contract (node kinds, edge types) plus the :class:`GraphPort` protocol that is
+  intended to be the *sole* writer of graph truth (``NFR-TRC-010``).
+* :mod:`tracertm.ports.scorer` -- the pluggable :class:`ScorerPort` strategy
+  interface for requirement<->artifact agreement scoring, with a dependency-free
+  reference implementation (:class:`JaccardScorer`). Embedding/visual strategies
+  (SentenceTransformer / SigLIP / VLM) plug in behind the same port.
+
+These are *contracts and scaffolding only*; wiring the ~12 existing trace/impact
+services onto ``GraphPort`` is the migration tracked by ``EPIC-TRC-A-SPINE``.
+"""
+
+from tracertm.ports.graph_contract import (
+    CANONICAL_EDGE_TYPES,
+    CANONICAL_NODE_KINDS,
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    GraphPort,
+    NodeKind,
+    SchemaContractError,
+    validate_edge,
+    validate_node,
+)
+from tracertm.ports.scorer import (
+    JaccardScorer,
+    ScorerPort,
+    ScoreResult,
+)
+
+__all__ = [
+    # graph contract
+    "NodeKind",
+    "EdgeType",
+    "GraphNode",
+    "GraphEdge",
+    "GraphPort",
+    "SchemaContractError",
+    "CANONICAL_NODE_KINDS",
+    "CANONICAL_EDGE_TYPES",
+    "validate_node",
+    "validate_edge",
+    # scorer
+    "ScorerPort",
+    "ScoreResult",
+    "JaccardScorer",
+]

--- a/src/tracertm/ports/__init__.py
+++ b/src/tracertm/ports/__init__.py
@@ -35,6 +35,8 @@ from tracertm.ports.scorer import (
     JaccardScorer,
     ScorerPort,
     ScoreResult,
+    SentenceTransformerScorer,
+    SigLIPScorer,
 )
 
 __all__ = [
@@ -53,4 +55,6 @@ __all__ = [
     "ScorerPort",
     "ScoreResult",
     "JaccardScorer",
+    "SentenceTransformerScorer",
+    "SigLIPScorer",
 ]

--- a/src/tracertm/ports/graph_contract.py
+++ b/src/tracertm/ports/graph_contract.py
@@ -1,0 +1,201 @@
+"""Canonical typed-graph schema contract + ``GraphPort`` (Pillar-A spine).
+
+Implements ``FR-TRC-018`` (Canonical Typed-Graph Schema Contract) and the
+companion ``NFR-TRC-010`` (all graph writes go through exactly one contract; no
+service writes Neo4j directly). See ``docs/TRACERA_PLATFORM_RND.md`` §3.3.
+
+Why this exists
+---------------
+Today the node/edge kinds drift across the ~12 trace/impact services and the
+Neo4j writer. This module makes the schema *one* enumerated, validated contract
+so that schema drift becomes impossible: any node/edge that is not part of the
+canonical vocabulary is rejected before it can reach the graph.
+
+This module is intentionally dependency-free (stdlib only) so it can be imported
+by any pillar (A/B/C/D) and mirrored by the HexaKit Rust canonical ports without
+dragging in a graph driver.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+
+class NodeKind(str, Enum):
+    """Canonical graph node kinds. The closed vocabulary of the SSOT.
+
+    Spans all four pillars: traceability (A), SDLC/PM (B), evidence (C),
+    multi-repo org intelligence (D). Adding a kind is a deliberate contract
+    change, not an ad-hoc string a service invents.
+    """
+
+    # Pillar A -- traceability core
+    REQUIREMENT = "Requirement"
+    SPEC = "Spec"
+    ADR = "ADR"
+    CODE = "Code"
+    TEST = "Test"
+    PR = "PR"
+    COMMIT = "Commit"
+    # Pillar B -- SDLC / program management
+    RELEASE = "Release"
+    PORTFOLIO = "Portfolio"
+    OKR = "OKR"
+    ROADMAP = "Roadmap"
+    # Pillar C -- evidence & verification
+    EVIDENCE = "Evidence"
+    JOURNEY = "Journey"
+    KEYFRAME = "Keyframe"
+    # Pillar D -- multi-repo org intelligence
+    REPO = "Repo"
+    TEAM = "Team"
+
+
+class EdgeType(str, Enum):
+    """Canonical graph edge types (relationship vocabulary of the SSOT)."""
+
+    TRACES_TO = "TRACES_TO"
+    VERIFIES = "VERIFIES"
+    IMPACTS = "IMPACTS"
+    DEPENDS_ON = "DEPENDS_ON"
+    DUPLICATES = "DUPLICATES"
+    IMPLEMENTS = "IMPLEMENTS"
+    COVERS = "COVERS"
+    EVIDENCES = "EVIDENCES"
+    BELONGS_TO = "BELONGS_TO"
+    RELEASES = "RELEASES"
+
+
+CANONICAL_NODE_KINDS: frozenset[NodeKind] = frozenset(NodeKind)
+CANONICAL_EDGE_TYPES: frozenset[EdgeType] = frozenset(EdgeType)
+
+# Which (source kind) -[edge]-> (target kind) combinations are meaningful.
+# Keeping this explicit is what prevents schema drift (FR-TRC-018 / NFR-TRC-010).
+# A value of ``None`` for either endpoint means "any canonical node kind".
+_ALLOWED_EDGE_ENDPOINTS: dict[EdgeType, tuple[frozenset[NodeKind] | None, frozenset[NodeKind] | None]] = {
+    EdgeType.TRACES_TO: (None, None),
+    EdgeType.IMPLEMENTS: (
+        frozenset({NodeKind.CODE, NodeKind.PR, NodeKind.COMMIT}),
+        frozenset({NodeKind.REQUIREMENT, NodeKind.SPEC, NodeKind.ADR}),
+    ),
+    EdgeType.COVERS: (
+        frozenset({NodeKind.TEST}),
+        frozenset({NodeKind.REQUIREMENT, NodeKind.CODE, NodeKind.SPEC}),
+    ),
+    EdgeType.VERIFIES: (
+        frozenset({NodeKind.EVIDENCE, NodeKind.KEYFRAME, NodeKind.JOURNEY, NodeKind.TEST}),
+        frozenset({NodeKind.REQUIREMENT, NodeKind.CODE}),
+    ),
+    EdgeType.EVIDENCES: (
+        frozenset({NodeKind.EVIDENCE, NodeKind.KEYFRAME}),
+        None,
+    ),
+    EdgeType.IMPACTS: (None, None),
+    EdgeType.DEPENDS_ON: (None, None),
+    EdgeType.DUPLICATES: (None, None),
+    EdgeType.BELONGS_TO: (None, None),
+    EdgeType.RELEASES: (
+        frozenset({NodeKind.RELEASE}),
+        None,
+    ),
+}
+
+
+class SchemaContractError(ValueError):
+    """Raised when a node/edge violates the canonical schema contract.
+
+    This is the enforcement mechanism behind ``NFR-TRC-010``: a write that does
+    not conform to the contract is rejected rather than silently corrupting the
+    graph vocabulary.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class GraphNode:
+    """A typed node addressed by a stable id within its kind."""
+
+    kind: NodeKind
+    id: str
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEdge:
+    """A typed, directed edge between two canonical nodes."""
+
+    type: EdgeType
+    src: GraphNode
+    dst: GraphNode
+    properties: Mapping[str, Any] = field(default_factory=dict)
+
+
+def validate_node(node: GraphNode) -> GraphNode:
+    """Validate a node against the contract; return it unchanged if valid."""
+    if not isinstance(node.kind, NodeKind):
+        raise SchemaContractError(f"non-canonical node kind: {node.kind!r}")
+    if not node.id or not str(node.id).strip():
+        raise SchemaContractError(f"node of kind {node.kind.value} has empty id")
+    return node
+
+
+def validate_edge(edge: GraphEdge) -> GraphEdge:
+    """Validate an edge (type + endpoint kinds) against the contract."""
+    if not isinstance(edge.type, EdgeType):
+        raise SchemaContractError(f"non-canonical edge type: {edge.type!r}")
+    validate_node(edge.src)
+    validate_node(edge.dst)
+    allowed = _ALLOWED_EDGE_ENDPOINTS.get(edge.type)
+    if allowed is not None:
+        allowed_src, allowed_dst = allowed
+        if allowed_src is not None and edge.src.kind not in allowed_src:
+            raise SchemaContractError(
+                f"{edge.type.value} cannot originate from {edge.src.kind.value}"
+            )
+        if allowed_dst is not None and edge.dst.kind not in allowed_dst:
+            raise SchemaContractError(
+                f"{edge.type.value} cannot point to {edge.dst.kind.value}"
+            )
+    return edge
+
+
+@runtime_checkable
+class GraphPort(Protocol):
+    """The sole writer/reader contract for graph truth (``FR-TRC-018``).
+
+    Every pillar writes the graph *only* through an implementation of this port
+    (``NFR-TRC-010``). Concrete adapters (e.g. a Neo4j adapter wrapping the
+    existing ``storage/neo4j_trace_link_writer.py``) live in the storage layer;
+    this protocol is what the application services depend on.
+
+    Implementations MUST run :func:`validate_node` / :func:`validate_edge`
+    before persisting, so that the canonical schema is enforced at the only
+    write boundary.
+    """
+
+    def upsert_node(self, node: GraphNode) -> None:
+        """Create or update a single canonical node."""
+        ...
+
+    def upsert_edge(self, edge: GraphEdge) -> None:
+        """Create or update a single canonical, directed edge."""
+        ...
+
+    def upsert_nodes(self, nodes: Sequence[GraphNode]) -> None:
+        """Bulk node upsert (graduates ``feat/trc013`` bulk ingestion)."""
+        ...
+
+    def upsert_edges(self, edges: Sequence[GraphEdge]) -> None:
+        """Bulk edge upsert."""
+        ...
+
+    def neighbors(
+        self,
+        node: GraphNode,
+        *,
+        edge_type: EdgeType | None = None,
+        direction: str = "out",
+    ) -> Sequence[GraphEdge]:
+        """Return edges incident to ``node`` (impact/blast-radius queries)."""
+        ...

--- a/src/tracertm/ports/scorer.py
+++ b/src/tracertm/ports/scorer.py
@@ -1,0 +1,101 @@
+"""Pluggable agreement ``ScorerPort`` (Pillar-A spine).
+
+Implements ``FR-TRC-019`` (Pluggable Agreement Scorer Port). See
+``docs/TRACERA_PLATFORM_RND.md`` §3.2.
+
+The platform scores requirement<->artifact *agreement* in several places
+(auto-linking, traceability confidence, blind-vs-intent verification). Today the
+scoring is heuristic and baked into individual services. This port makes the
+scoring **strategy** selectable at the call site without changing callers:
+
+* :class:`JaccardScorer`     -- lexical overlap (dependency-free reference impl).
+* ``SentenceTransformerScorer`` -- text embeddings (Pillar A, Phase 1).
+* ``SigLIPScorer``           -- visual embeddings (Pillar C).
+* VLM blind-vs-intent        -- "does the running code match the requirement?"
+                                (Pillar C, Phase 2, ``FR-TRC-020``).
+
+Only the dependency-free Jaccard strategy is implemented here; the embedding /
+VLM strategies plug in behind the same :class:`ScorerPort` so callers never
+change. Every scorer returns a normalized confidence in ``[0.0, 1.0]`` plus a
+human-readable rationale (the acceptance criterion of ``FR-TRC-019``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreResult:
+    """Normalized agreement score with provenance.
+
+    Attributes:
+        score: Confidence in ``[0.0, 1.0]``.
+        rationale: Human-readable explanation of the score.
+        strategy: Name of the scorer that produced this result.
+    """
+
+    score: float
+    rationale: str
+    strategy: str
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.score <= 1.0:
+            raise ValueError(f"score must be in [0.0, 1.0], got {self.score}")
+
+
+@runtime_checkable
+class ScorerPort(Protocol):
+    """Strategy interface for requirement<->artifact agreement scoring.
+
+    Pillars A and C consume the *same* port; the concrete strategy is chosen at
+    the call site (strategy pattern), satisfying ``FR-TRC-019``.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable identifier for this scoring strategy."""
+        ...
+
+    def score(self, requirement_text: str, artifact_text: str) -> ScoreResult:
+        """Return a normalized agreement score in ``[0.0, 1.0]``."""
+        ...
+
+
+def _tokenize(text: str) -> set[str]:
+    return {t.lower() for t in _TOKEN_RE.findall(text or "")}
+
+
+class JaccardScorer:
+    """Lexical (Jaccard) agreement scorer -- the dependency-free reference impl.
+
+    ``score = |tokens(req) ∩ tokens(art)| / |tokens(req) ∪ tokens(art)|``.
+
+    This is the baseline strategy: it ships with zero extra dependencies so the
+    spine is testable and usable immediately, while richer embedding/VLM
+    strategies are added behind the same :class:`ScorerPort`.
+    """
+
+    name = "jaccard"
+
+    def score(self, requirement_text: str, artifact_text: str) -> ScoreResult:
+        req = _tokenize(requirement_text)
+        art = _tokenize(artifact_text)
+        if not req and not art:
+            return ScoreResult(0.0, "both inputs empty", self.name)
+        union = req | art
+        if not union:
+            return ScoreResult(0.0, "no tokens", self.name)
+        inter = req & art
+        value = len(inter) / len(union)
+        rationale = (
+            f"{len(inter)} shared / {len(union)} total tokens"
+            f" (shared: {', '.join(sorted(inter)[:8])})"
+            if inter
+            else "no shared tokens"
+        )
+        return ScoreResult(round(value, 6), rationale, self.name)

--- a/src/tracertm/ports/scorer.py
+++ b/src/tracertm/ports/scorer.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
 
@@ -99,3 +99,84 @@ class JaccardScorer:
             else "no shared tokens"
         )
         return ScoreResult(round(value, 6), rationale, self.name)
+
+
+class SentenceTransformerScorer:
+    """Text-embedding agreement scorer (Pillar A, Phase 1).
+
+    Uses ``sentence-transformers`` when installed; otherwise falls back to
+    :class:`JaccardScorer` with a ``[stub-ST]`` rationale prefix so callers
+    can depend on the port without pulling ML deps in CI.
+    """
+
+    name = "sentence_transformer"
+
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2") -> None:
+        self._model_name = model_name
+        self._model: Any | None = None
+        self._fallback = JaccardScorer()
+
+    def _ensure_model(self) -> Any | None:
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            return None
+        self._model = SentenceTransformer(self._model_name)
+        return self._model
+
+    def score(self, requirement_text: str, artifact_text: str) -> ScoreResult:
+        model = self._ensure_model()
+        if model is None:
+            base = self._fallback.score(requirement_text, artifact_text)
+            return ScoreResult(
+                base.score,
+                f"[stub-ST] {base.rationale} (install sentence-transformers for embeddings)",
+                self.name,
+            )
+        import numpy as np
+
+        emb = model.encode([requirement_text or "", artifact_text or ""])
+        denom = float(np.linalg.norm(emb[0]) * np.linalg.norm(emb[1]))
+        if denom == 0.0:
+            return ScoreResult(0.0, "empty embedding", self.name)
+        sim = float(np.dot(emb[0], emb[1]) / denom)
+        clamped = max(0.0, min(1.0, (sim + 1.0) / 2.0))
+        return ScoreResult(
+            round(clamped, 6),
+            f"cosine similarity via {self._model_name}",
+            self.name,
+        )
+
+
+class SigLIPScorer:
+    """Visual-embedding agreement scorer stub (Pillar C).
+
+    Production use requires ``transformers`` + a SigLIP checkpoint. Until
+    those deps are present the scorer delegates to :class:`JaccardScorer`
+    over any text captions supplied alongside image paths.
+    """
+
+    name = "siglip"
+
+    def __init__(self, model_id: str = "google/siglip-base-patch16-224") -> None:
+        self._model_id = model_id
+        self._fallback = JaccardScorer()
+
+    def score(self, requirement_text: str, artifact_text: str) -> ScoreResult:
+        try:
+            import transformers  # noqa: F401
+        except ImportError:
+            base = self._fallback.score(requirement_text, artifact_text)
+            return ScoreResult(
+                base.score,
+                f"[stub-SigLIP] {base.rationale} (install transformers for SigLIP)",
+                self.name,
+            )
+        base = self._fallback.score(requirement_text, artifact_text)
+        return ScoreResult(
+            base.score,
+            f"[siglip-pending] {base.rationale} (model={self._model_id})",
+            self.name,
+        )

--- a/src/tracertm/storage/neo4j_graph_port.py
+++ b/src/tracertm/storage/neo4j_graph_port.py
@@ -1,0 +1,246 @@
+"""Neo4j ``GraphPort`` adapter — sole typed write boundary (Pillar-A Phase 0).
+
+Wraps the existing :mod:`tracertm.storage.neo4j_trace_link_writer` so every
+graph mutation flows through :class:`~tracertm.ports.graph_contract.GraphPort`
+validation before reaching Neo4j (``NFR-TRC-010``).
+
+The adapter translates canonical :class:`GraphNode` / :class:`GraphEdge` value
+objects into the legacy :class:`~tracertm.models.trace_link.Artifact` /
+:class:`~tracertm.models.trace_link.TraceLink` wire format the writer already
+understands. Vocabulary mapping is explicit and closed — unmapped kinds raise
+:class:`~tracertm.ports.graph_contract.SchemaContractError` at the boundary
+rather than silently inventing labels.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from tracertm.models.trace_link import (
+    Artifact,
+    ArtifactKind,
+    Requirement,
+    RequirementStatus,
+    TraceLink,
+    TraceLinkType,
+)
+from tracertm.ports.graph_contract import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    NodeKind,
+    SchemaContractError,
+    validate_edge,
+    validate_node,
+)
+from tracertm.storage import neo4j_trace_link_writer as _writer
+
+if TYPE_CHECKING:
+    from neo4j import Driver
+
+__all__ = ["Neo4jGraphPort", "GraphPortAdapterError"]
+
+# Canonical NodeKind → legacy ArtifactKind (trace-link projection subset).
+_NODE_KIND_TO_ARTIFACT: dict[NodeKind, ArtifactKind] = {
+    NodeKind.REQUIREMENT: ArtifactKind.REQUIREMENT,
+    NodeKind.SPEC: ArtifactKind.DESIGN,
+    NodeKind.ADR: ArtifactKind.RATIONALE,
+    NodeKind.CODE: ArtifactKind.CODE,
+    NodeKind.TEST: ArtifactKind.TEST,
+    NodeKind.PR: ArtifactKind.CODE,
+    NodeKind.COMMIT: ArtifactKind.CODE,
+    NodeKind.EVIDENCE: ArtifactKind.EVIDENCE,
+}
+
+# Canonical EdgeType → legacy TraceLinkType.
+_EDGE_TO_TRACE: dict[EdgeType, TraceLinkType] = {
+    EdgeType.IMPLEMENTS: TraceLinkType.IMPLEMENTS,
+    EdgeType.VERIFIES: TraceLinkType.VERIFIES,
+    EdgeType.DUPLICATES: TraceLinkType.DUPLICATES,
+    EdgeType.COVERS: TraceLinkType.SATISFIES,
+    EdgeType.TRACES_TO: TraceLinkType.DERIVES_FROM,
+    EdgeType.EVIDENCES: TraceLinkType.VERIFIES,
+    EdgeType.IMPACTS: TraceLinkType.CONFLICTS_WITH,
+    EdgeType.DEPENDS_ON: TraceLinkType.REFINES,
+    EdgeType.BELONGS_TO: TraceLinkType.DERIVES_FROM,
+    EdgeType.RELEASES: TraceLinkType.SATISFIES,
+}
+
+
+class GraphPortAdapterError(SchemaContractError):
+    """Raised when a canonical node/edge cannot be projected to Neo4j."""
+
+
+def _require_project_id(properties: Mapping[str, Any]) -> uuid.UUID:
+    raw = properties.get("project_id")
+    if raw is None:
+        raise GraphPortAdapterError("GraphNode.properties must include project_id")
+    return uuid.UUID(str(raw))
+
+
+def _graph_node_to_artifact(node: GraphNode) -> Artifact | Requirement:
+    """Map a validated canonical node to an Artifact/Requirement value object."""
+    kind = _NODE_KIND_TO_ARTIFACT.get(node.kind)
+    if kind is None:
+        raise GraphPortAdapterError(
+            f"NodeKind {node.kind.value} is not yet projectable to Neo4j"
+        )
+    props = dict(node.properties)
+    project_id = _require_project_id(props)
+    title = str(props.get("title") or node.id)
+    common: dict[str, Any] = {
+        "id": uuid.UUID(str(node.id)),
+        "project_id": project_id,
+        "kind": kind,
+        "title": title,
+        "description": props.get("description"),
+        "external_id": props.get("external_id"),
+        "metadata": dict(props.get("metadata") or {}),
+        "created_at": props.get("created_at"),
+        "updated_at": props.get("updated_at"),
+    }
+    if node.kind is NodeKind.REQUIREMENT:
+        status_raw = props.get("status", RequirementStatus.DRAFT.value)
+        return Requirement(
+            **common,
+            status=RequirementStatus(str(status_raw)),
+            priority=props.get("priority"),
+            rationale=props.get("rationale"),
+            acceptance_criteria=list(props.get("acceptance_criteria") or []),
+            verification_method=props.get("verification_method"),
+        )
+    return Artifact(**common)
+
+
+def _graph_edge_to_trace_link(edge: GraphEdge) -> TraceLink:
+    """Map a validated canonical edge to a TraceLink value object."""
+    link_type = _EDGE_TO_TRACE.get(edge.type)
+    if link_type is None:
+        raise GraphPortAdapterError(
+            f"EdgeType {edge.type.value} is not yet projectable to Neo4j"
+        )
+    props = dict(edge.properties)
+    project_id = _require_project_id(props)
+    confidence = float(props.get("confidence", 1.0))
+    return TraceLink(
+        project_id=project_id,
+        source_artifact_id=uuid.UUID(str(edge.src.id)),
+        target_artifact_id=uuid.UUID(str(edge.dst.id)),
+        link_type=link_type,
+        confidence=confidence,
+        rationale=props.get("rationale"),
+        metadata=dict(props.get("metadata") or {}),
+        id=uuid.UUID(str(props["link_id"])) if props.get("link_id") else uuid.uuid4(),
+        created_at=props.get("created_at"),
+        updated_at=props.get("updated_at"),
+    )
+
+
+class Neo4jGraphPort:
+    """``GraphPort`` implementation backed by Neo4j via the trace-link writer."""
+
+    def __init__(self, driver: Driver) -> None:
+        self._driver = driver
+
+    def upsert_node(self, node: GraphNode) -> None:
+        validated = validate_node(node)
+        artifact = _graph_node_to_artifact(validated)
+        if isinstance(artifact, Requirement):
+            _writer.write_requirement(self._driver, artifact)
+        else:
+            _writer.write_artifact(self._driver, artifact)
+
+    def upsert_edge(self, edge: GraphEdge) -> None:
+        validated = validate_edge(edge)
+        link = _graph_edge_to_trace_link(validated)
+        _writer.write_link(self._driver, link)
+
+    def upsert_nodes(self, nodes: Sequence[GraphNode]) -> None:
+        for node in nodes:
+            self.upsert_node(node)
+
+    def upsert_edges(self, edges: Sequence[GraphEdge]) -> None:
+        for edge in edges:
+            self.upsert_edge(edge)
+
+    def neighbors(
+        self,
+        node: GraphNode,
+        *,
+        edge_type: EdgeType | None = None,
+        direction: str = "out",
+    ) -> Sequence[GraphEdge]:
+        """Return incident edges for impact/blast-radius queries."""
+        validated = validate_node(node)
+        if direction not in ("out", "in", "both"):
+            raise ValueError(f"direction must be out|in|both, got {direction!r}")
+
+        rel_filter = ""
+        params: dict[str, Any] = {"node_id": str(validated.id)}
+        if edge_type is not None:
+            trace_type = _EDGE_TO_TRACE.get(edge_type)
+            if trace_type is None:
+                return ()
+            rel_filter = "AND type(r) = $rel_type"
+            params["rel_type"] = trace_type.value
+
+        if direction == "out":
+            pattern = "(n:Artifact {id: $node_id})-[r]->(m:Artifact)"
+            src_id_key, dst_id_key = "src_id", "dst_id"
+            src_kind_key, dst_kind_key = "src_kind", "dst_kind"
+            return_clause = (
+                "type(r) AS rel_type, n.id AS src_id, m.id AS dst_id, "
+                "n.kind AS src_kind, m.kind AS dst_kind, "
+                "r.confidence AS confidence, r.rationale AS rationale"
+            )
+        elif direction == "in":
+            pattern = "(n:Artifact {id: $node_id})<-[r]-(m:Artifact)"
+            src_id_key, dst_id_key = "src_id", "dst_id"
+            src_kind_key, dst_kind_key = "src_kind", "dst_kind"
+            return_clause = (
+                "type(r) AS rel_type, m.id AS src_id, n.id AS dst_id, "
+                "m.kind AS src_kind, n.kind AS dst_kind, "
+                "r.confidence AS confidence, r.rationale AS rationale"
+            )
+        else:
+            pattern = "(n:Artifact {id: $node_id})-[r]-(m:Artifact)"
+            src_id_key, dst_id_key = "src_id", "dst_id"
+            src_kind_key, dst_kind_key = "src_kind", "dst_kind"
+            return_clause = (
+                "type(r) AS rel_type, "
+                "CASE WHEN startNode(r) = n THEN n.id ELSE m.id END AS src_id, "
+                "CASE WHEN startNode(r) = n THEN m.id ELSE n.id END AS dst_id, "
+                "CASE WHEN startNode(r) = n THEN n.kind ELSE m.kind END AS src_kind, "
+                "CASE WHEN startNode(r) = n THEN m.kind ELSE n.kind END AS dst_kind, "
+                "r.confidence AS confidence, r.rationale AS rationale"
+            )
+
+        cypher = f"MATCH {pattern} WHERE true {rel_filter} RETURN {return_clause}"
+
+        trace_to_edge = {v: k for k, v in _EDGE_TO_TRACE.items()}
+        artifact_to_node = {v: k for k, v in _NODE_KIND_TO_ARTIFACT.items()}
+
+        edges: list[GraphEdge] = []
+        with self._driver.session() as session:
+            for record in session.run(cypher, **params):
+                rel = record["rel_type"]
+                canonical_edge = trace_to_edge.get(TraceLinkType(rel))
+                if canonical_edge is None:
+                    continue
+                src_kind = artifact_to_node.get(ArtifactKind(record[src_kind_key]))
+                dst_kind = artifact_to_node.get(ArtifactKind(record[dst_kind_key]))
+                if src_kind is None or dst_kind is None:
+                    continue
+                edges.append(
+                    GraphEdge(
+                        type=canonical_edge,
+                        src=GraphNode(kind=src_kind, id=str(record[src_id_key])),
+                        dst=GraphNode(kind=dst_kind, id=str(record[dst_id_key])),
+                        properties={
+                            "confidence": record.get("confidence"),
+                            "rationale": record.get("rationale"),
+                        },
+                    )
+                )
+        return edges

--- a/tests/unit/ports/test_graph_contract.py
+++ b/tests/unit/ports/test_graph_contract.py
@@ -1,0 +1,122 @@
+"""Unit tests for the canonical typed-graph schema contract.
+
+Covers ``FR-TRC-018`` / ``NFR-TRC-010`` (single contract; drift impossible).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracertm.ports.graph_contract import (
+    CANONICAL_EDGE_TYPES,
+    CANONICAL_NODE_KINDS,
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    GraphPort,
+    NodeKind,
+    SchemaContractError,
+    validate_edge,
+    validate_node,
+)
+
+
+def _node(kind: NodeKind, id_: str = "x") -> GraphNode:
+    return GraphNode(kind=kind, id=id_)
+
+
+def test_canonical_vocabulary_is_closed_and_nonempty():
+    assert CANONICAL_NODE_KINDS == frozenset(NodeKind)
+    assert CANONICAL_EDGE_TYPES == frozenset(EdgeType)
+    assert NodeKind.REQUIREMENT in CANONICAL_NODE_KINDS
+    assert EdgeType.TRACES_TO in CANONICAL_EDGE_TYPES
+
+
+def test_validate_node_accepts_canonical_node():
+    n = _node(NodeKind.REQUIREMENT, "FR-TRC-018")
+    assert validate_node(n) is n
+
+
+def test_validate_node_rejects_empty_id():
+    with pytest.raises(SchemaContractError):
+        validate_node(GraphNode(kind=NodeKind.CODE, id="   "))
+
+
+def test_validate_edge_accepts_valid_endpoints():
+    edge = GraphEdge(
+        type=EdgeType.IMPLEMENTS,
+        src=_node(NodeKind.CODE, "mod.py"),
+        dst=_node(NodeKind.REQUIREMENT, "FR-TRC-018"),
+    )
+    assert validate_edge(edge) is edge
+
+
+def test_validate_edge_rejects_bad_source_kind():
+    # A Requirement cannot IMPLEMENTS another node.
+    edge = GraphEdge(
+        type=EdgeType.IMPLEMENTS,
+        src=_node(NodeKind.REQUIREMENT, "FR-TRC-018"),
+        dst=_node(NodeKind.REQUIREMENT, "FR-TRC-019"),
+    )
+    with pytest.raises(SchemaContractError):
+        validate_edge(edge)
+
+
+def test_validate_edge_rejects_bad_target_kind():
+    # COVERS must point at Requirement/Code/Spec, not a PR.
+    edge = GraphEdge(
+        type=EdgeType.COVERS,
+        src=_node(NodeKind.TEST, "t1"),
+        dst=_node(NodeKind.PR, "pr-1"),
+    )
+    with pytest.raises(SchemaContractError):
+        validate_edge(edge)
+
+
+def test_open_ended_edges_allow_any_endpoints():
+    edge = GraphEdge(
+        type=EdgeType.TRACES_TO,
+        src=_node(NodeKind.PR, "pr-1"),
+        dst=_node(NodeKind.OKR, "okr-1"),
+    )
+    assert validate_edge(edge) is edge
+
+
+def test_graph_port_is_runtime_checkable_protocol():
+    class _InMemoryGraph:
+        def __init__(self) -> None:
+            self.nodes: list[GraphNode] = []
+            self.edges: list[GraphEdge] = []
+
+        def upsert_node(self, node):
+            self.nodes.append(validate_node(node))
+
+        def upsert_edge(self, edge):
+            self.edges.append(validate_edge(edge))
+
+        def upsert_nodes(self, nodes):
+            for n in nodes:
+                self.upsert_node(n)
+
+        def upsert_edges(self, edges):
+            for e in edges:
+                self.upsert_edge(e)
+
+        def neighbors(self, node, *, edge_type=None, direction="out"):
+            return [
+                e
+                for e in self.edges
+                if (e.src == node if direction == "out" else e.dst == node)
+                and (edge_type is None or e.type == edge_type)
+            ]
+
+    g = _InMemoryGraph()
+    assert isinstance(g, GraphPort)
+    g.upsert_edge(
+        GraphEdge(
+            type=EdgeType.IMPLEMENTS,
+            src=_node(NodeKind.CODE, "graph_contract.py"),
+            dst=_node(NodeKind.REQUIREMENT, "FR-TRC-018"),
+        )
+    )
+    assert len(g.neighbors(_node(NodeKind.CODE, "graph_contract.py"))) == 1

--- a/tests/unit/ports/test_neo4j_graph_port.py
+++ b/tests/unit/ports/test_neo4j_graph_port.py
@@ -1,0 +1,129 @@
+"""Unit tests for the Neo4j ``GraphPort`` adapter."""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracertm.ports.graph_contract import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    GraphPort,
+    NodeKind,
+    SchemaContractError,
+)
+from tracertm.storage.neo4j_graph_port import GraphPortAdapterError, Neo4jGraphPort
+
+_PROJECT = str(uuid.uuid4())
+_CODE_ID = str(uuid.uuid4())
+_REQ_ID = str(uuid.uuid4())
+
+
+def _node(kind: NodeKind, id_: str, **props) -> GraphNode:
+    base = {"project_id": _PROJECT, "title": f"{kind.value}-{id_}"}
+    base.update(props)
+    return GraphNode(kind=kind, id=id_, properties=base)
+
+
+def test_neo4j_graph_port_satisfies_graph_port_protocol():
+    driver = MagicMock()
+    assert isinstance(Neo4jGraphPort(driver), GraphPort)
+
+
+def test_upsert_node_validates_before_write():
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    with pytest.raises(SchemaContractError):
+        port.upsert_node(GraphNode(kind=NodeKind.CODE, id="   ", properties={"project_id": _PROJECT}))
+
+
+@patch("tracertm.storage.neo4j_graph_port._writer.write_artifact")
+def test_upsert_code_node_delegates_to_writer(mock_write: MagicMock):
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    node = _node(NodeKind.CODE, _CODE_ID)
+    port.upsert_node(node)
+    mock_write.assert_called_once()
+    assert mock_write.call_args[0][0] is driver
+    artifact = mock_write.call_args[0][1]
+    assert artifact.kind.value == "code"
+    assert str(artifact.id) == _CODE_ID
+
+
+@patch("tracertm.storage.neo4j_graph_port._writer.write_requirement")
+def test_upsert_requirement_node_delegates_to_writer(mock_write: MagicMock):
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    node = _node(NodeKind.REQUIREMENT, _REQ_ID, status="draft")
+    port.upsert_node(node)
+    mock_write.assert_called_once()
+    req = mock_write.call_args[0][1]
+    assert req.kind.value == "requirement"
+
+
+def test_upsert_unmapped_node_kind_raises():
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    with pytest.raises(GraphPortAdapterError, match="not yet projectable"):
+        port.upsert_node(_node(NodeKind.TEAM, str(uuid.uuid4())))
+
+
+@patch("tracertm.storage.neo4j_graph_port._writer.write_link")
+def test_upsert_edge_maps_canonical_type(mock_write: MagicMock):
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    edge = GraphEdge(
+        type=EdgeType.IMPLEMENTS,
+        src=_node(NodeKind.CODE, _CODE_ID),
+        dst=_node(NodeKind.REQUIREMENT, _REQ_ID),
+        properties={"project_id": _PROJECT, "confidence": 0.9, "rationale": "implements"},
+    )
+    port.upsert_edge(edge)
+    mock_write.assert_called_once()
+    link = mock_write.call_args[0][1]
+    assert link.link_type.value == "IMPLEMENTS"
+    assert link.confidence == 0.9
+
+
+def test_upsert_edge_rejects_invalid_endpoint_kinds():
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    edge = GraphEdge(
+        type=EdgeType.IMPLEMENTS,
+        src=_node(NodeKind.REQUIREMENT, _REQ_ID),
+        dst=_node(NodeKind.REQUIREMENT, str(uuid.uuid4())),
+        properties={"project_id": _PROJECT},
+    )
+    with pytest.raises(SchemaContractError):
+        port.upsert_edge(edge)
+
+
+def test_neighbors_returns_mapped_edges():
+    driver = MagicMock()
+    session = MagicMock()
+    session.run.return_value = [
+        {
+            "rel_type": "IMPLEMENTS",
+            "src_id": _CODE_ID,
+            "dst_id": _REQ_ID,
+            "src_kind": "code",
+            "dst_kind": "requirement",
+            "confidence": 1.0,
+            "rationale": "ok",
+        }
+    ]
+
+    @contextmanager
+    def _session():
+        yield session
+
+    driver.session.return_value = _session()
+    port = Neo4jGraphPort(driver)
+    edges = port.neighbors(_node(NodeKind.CODE, _CODE_ID))
+    assert len(edges) == 1
+    assert edges[0].type is EdgeType.IMPLEMENTS
+    assert edges[0].dst.kind is NodeKind.REQUIREMENT

--- a/tests/unit/ports/test_scorer.py
+++ b/tests/unit/ports/test_scorer.py
@@ -1,0 +1,46 @@
+"""Unit tests for the pluggable agreement ``ScorerPort`` (``FR-TRC-019``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracertm.ports.scorer import JaccardScorer, ScorerPort, ScoreResult
+
+
+def test_jaccard_satisfies_scorer_port_protocol():
+    assert isinstance(JaccardScorer(), ScorerPort)
+
+
+def test_identical_text_scores_one():
+    r = JaccardScorer().score("user can log in", "user can log in")
+    assert r.score == 1.0
+    assert r.strategy == "jaccard"
+
+
+def test_disjoint_text_scores_zero():
+    r = JaccardScorer().score("alpha bravo", "charlie delta")
+    assert r.score == 0.0
+    assert "no shared tokens" in r.rationale
+
+
+def test_partial_overlap_is_between_zero_and_one():
+    r = JaccardScorer().score("user can log in securely", "user logs in")
+    assert 0.0 < r.score < 1.0
+
+
+def test_both_empty_scores_zero_without_error():
+    r = JaccardScorer().score("", "")
+    assert r.score == 0.0
+
+
+def test_score_result_rejects_out_of_range():
+    with pytest.raises(ValueError):
+        ScoreResult(score=1.5, rationale="bad", strategy="x")
+
+
+def test_callers_can_swap_strategy_without_changing_call_site():
+    # Strategy pattern: any ScorerPort is interchangeable at the call site.
+    def confidence(scorer: ScorerPort, a: str, b: str) -> float:
+        return scorer.score(a, b).score
+
+    assert confidence(JaccardScorer(), "trace link graph", "trace link graph") == 1.0

--- a/tests/unit/ports/test_scorer.py
+++ b/tests/unit/ports/test_scorer.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from tracertm.ports.scorer import JaccardScorer, ScorerPort, ScoreResult
+from tracertm.ports.scorer import (
+    JaccardScorer,
+    ScorerPort,
+    ScoreResult,
+    SentenceTransformerScorer,
+    SigLIPScorer,
+)
 
 
 def test_jaccard_satisfies_scorer_port_protocol():
@@ -44,3 +50,19 @@ def test_callers_can_swap_strategy_without_changing_call_site():
         return scorer.score(a, b).score
 
     assert confidence(JaccardScorer(), "trace link graph", "trace link graph") == 1.0
+
+
+def test_sentence_transformer_stub_satisfies_port_without_ml_deps():
+    scorer = SentenceTransformerScorer()
+    assert isinstance(scorer, ScorerPort)
+    r = scorer.score("user login", "user login")
+    assert r.strategy == "sentence_transformer"
+    assert "[stub-ST]" in r.rationale or "cosine" in r.rationale
+
+
+def test_siglip_stub_satisfies_port_without_ml_deps():
+    scorer = SigLIPScorer()
+    assert isinstance(scorer, ScorerPort)
+    r = scorer.score("dashboard screenshot", "ui mock")
+    assert r.strategy == "siglip"
+    assert "[stub-SigLIP]" in r.rationale or "[siglip-pending]" in r.rationale


### PR DESCRIPTION
## **User description**
## Pillar-A spine — canonical graph contract + ScorerPort (Phase 0)

First concrete code step toward the platform spine defined in the R&D blueprint **PR #493**. Implements the Phase-0 priority: solidify Pillar A (deep traceability) as the platform spine *before* wiring B/C/D, by landing the two contracts that stop schema/scoring drift.

### What this adds (contracts + reference impl + tests only)
- **`src/tracertm/ports/graph_contract.py`** — canonical `NodeKind`/`EdgeType` vocabulary (closed enum), `GraphNode`/`GraphEdge` value objects, endpoint validation (`validate_node`/`validate_edge`), and the `GraphPort` protocol as the **sole** graph-write contract. Implements **FR-TRC-018** / **NFR-TRC-010**.
- **`src/tracertm/ports/scorer.py`** — `ScorerPort` strategy protocol + `ScoreResult` (normalized `[0,1]` + rationale) + dependency-free `JaccardScorer` reference strategy. Implements **FR-TRC-019**. Embedding/VLM strategies plug in behind the same port.
- **`tests/unit/ports/*`** — contract + scorer unit tests (vocabulary closed, endpoint rules enforced, `GraphPort` satisfiable, scorer strategy swappable).
- **`docs/02-architecture/PILLAR_A_SPINE.md`** — design doc + the service-migration follow-on.

### Scope guard
Stdlib-only contracts; **no** service migration, **no** Neo4j driver. Migrating the ~12 trace/impact services onto `GraphPort` and refactoring `traceability_score_service` onto `ScorerPort` is the follow-on tracked under **EPIC-TRC-A-SPINE**.

### Traceability (self-hosting, NFR-TRC-012)
FR-TRC-018 / FR-TRC-019 → `src/tracertm/ports/*.py` → `tests/unit/ports/*` → this PR.

> R&D step. **DO NOT MERGE** without review — depends on the direction set by #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> New graph write boundary and Neo4j projection mappings could reject or mis-map data once services adopt GraphPort; until migration, production paths are unchanged because nothing calls the new ports yet.
> 
> **Overview**
> Introduces **Phase 0 Pillar-A spine** scaffolding: a stdlib-only canonical typed-graph contract and a pluggable agreement-scoring port, plus docs and unit tests. Existing trace/impact services are **not** rewired yet.
> 
> **Graph contract (`graph_contract.py`):** Adds closed `NodeKind` / `EdgeType` enums, `GraphNode` / `GraphEdge` value types, `validate_node` / `validate_edge` (endpoint rules + `SchemaContractError`), and a `runtime_checkable` **`GraphPort`** protocol for upserts and `neighbors` queries.
> 
> **Scoring (`scorer.py`):** Adds **`ScorerPort`**, **`ScoreResult`** (score clamped to `[0,1]`), a full **`JaccardScorer`**, and **`SentenceTransformerScorer` / `SigLIPScorer`** stubs that fall back to Jaccard when ML deps are missing.
> 
> **Neo4j adapter (`neo4j_graph_port.py`):** Adds **`Neo4jGraphPort`**, which validates then maps canonical nodes/edges onto the legacy trace-link writer; unmapped kinds/types fail at the adapter boundary. Implements read-back via Cypher for impact-style **`neighbors`** calls.
> 
> **Tests & docs:** Unit coverage for contract validation, scorer behavior, and mocked Neo4j adapter behavior; **`PILLAR_A_SPINE.md`** describes vocabulary, design choices, and follow-on migration (services onto `GraphPort`, scoring refactor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd44e6e9b90666db757d6f0517a16731d7f9873e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Connect the canonical graph contract to Neo4j writes**

### What Changed
- Added a Neo4j-backed graph port that accepts the new typed nodes and edges, validates them before saving, and then writes them through the existing graph store
- Unmapped node and edge kinds are rejected at the boundary instead of being saved with invented labels or relationships
- Added neighbor lookups that return canonical edges in a consistent format for impact and blast-radius queries
- Added tests for contract validation, Neo4j delegation, and neighbor mapping
- Updated the architecture note to reflect that the Neo4j adapter is now in place

### Impact
`✅ Fewer invalid graph writes`
`✅ Clearer graph contract enforcement`
`✅ More reliable impact and blast-radius queries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
