### PR TITLE
feat(pillar-a): wire GraphPort to Neo4j writer + scorer stubs (R&D, do not merge)

### DIFF
--- a/docs/02-architecture/PILLAR_A_SPINE.md
+++ b/docs/02-architecture/PILLAR_A_SPINE.md
@@ -60,8 +60,8 @@ callers never change.
 
 ## 4. Follow-on (not in this step)
 
-1. **Neo4j adapter** implementing `GraphPort` by wrapping
-   `storage/neo4j_trace_link_writer.py`.
+1. ~~**Neo4j adapter** implementing `GraphPort` by wrapping
+   `storage/neo4j_trace_link_writer.py`.~~ → landed in `rnd/pillar-a-graphport-wire`.
 2. **Migrate the ~12 trace/impact services** to write *only* via `GraphPort`
    (`traceability_service`, `impact_analysis_service`, `blast_radius_service`, …).
 3. **Refactor `traceability_score_service`** to consume `ScorerPort`; add the

--- a/src/tracertm/ports/__init__.py
+++ b/src/tracertm/ports/__init__.py
@@ -35,6 +35,8 @@ from tracertm.ports.scorer import (
     JaccardScorer,
     ScorerPort,
     ScoreResult,
+    SentenceTransformerScorer,
+    SigLIPScorer,
 )
 
 __all__ = [
@@ -53,4 +55,6 @@ __all__ = [
     "ScorerPort",
     "ScoreResult",
     "JaccardScorer",
+    "SentenceTransformerScorer",
+    "SigLIPScorer",
 ]

--- a/src/tracertm/ports/scorer.py
+++ b/src/tracertm/ports/scorer.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
 
@@ -99,3 +99,84 @@ class JaccardScorer:
             else "no shared tokens"
         )
         return ScoreResult(round(value, 6), rationale, self.name)
+
+
+class SentenceTransformerScorer:
+    """Text-embedding agreement scorer (Pillar A, Phase 1).
+
+    Uses ``sentence-transformers`` when installed; otherwise falls back to
+    :class:`JaccardScorer` with a ``[stub-ST]`` rationale prefix so callers
+    can depend on the port without pulling ML deps in CI.
+    """
+
+    name = "sentence_transformer"
+
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2") -> None:
+        self._model_name = model_name
+        self._model: Any | None = None
+        self._fallback = JaccardScorer()
+
+    def _ensure_model(self) -> Any | None:
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            return None
+        self._model = SentenceTransformer(self._model_name)
+        return self._model
+
+    def score(self, requirement_text: str, artifact_text: str) -> ScoreResult:
+        model = self._ensure_model()
+        if model is None:
+            base = self._fallback.score(requirement_text, artifact_text)
+            return ScoreResult(
+                base.score,
+                f"[stub-ST] {base.rationale} (install sentence-transformers for embeddings)",
+                self.name,
+            )
+        import numpy as np
+
+        emb = model.encode([requirement_text or "", artifact_text or ""])
+        denom = float(np.linalg.norm(emb[0]) * np.linalg.norm(emb[1]))
+        if denom == 0.0:
+            return ScoreResult(0.0, "empty embedding", self.name)
+        sim = float(np.dot(emb[0], emb[1]) / denom)
+        clamped = max(0.0, min(1.0, (sim + 1.0) / 2.0))
+        return ScoreResult(
+            round(clamped, 6),
+            f"cosine similarity via {self._model_name}",
+            self.name,
+        )
+
+
+class SigLIPScorer:
+    """Visual-embedding agreement scorer stub (Pillar C).
+
+    Production use requires ``transformers`` + a SigLIP checkpoint. Until
+    those deps are present the scorer delegates to :class:`JaccardScorer`
+    over any text captions supplied alongside image paths.
+    """
+
+    name = "siglip"
+
+    def __init__(self, model_id: str = "google/siglip-base-patch16-224") -> None:
+        self._model_id = model_id
+        self._fallback = JaccardScorer()
+
+    def score(self, requirement_text: str, artifact_text: str) -> ScoreResult:
+        try:
+            import transformers  # noqa: F401
+        except ImportError:
+            base = self._fallback.score(requirement_text, artifact_text)
+            return ScoreResult(
+                base.score,
+                f"[stub-SigLIP] {base.rationale} (install transformers for SigLIP)",
+                self.name,
+            )
+        base = self._fallback.score(requirement_text, artifact_text)
+        return ScoreResult(
+            base.score,
+            f"[siglip-pending] {base.rationale} (model={self._model_id})",
+            self.name,
+        )

--- a/src/tracertm/storage/neo4j_graph_port.py
+++ b/src/tracertm/storage/neo4j_graph_port.py
@@ -1,0 +1,246 @@
+"""Neo4j ``GraphPort`` adapter — sole typed write boundary (Pillar-A Phase 0).
+
+Wraps the existing :mod:`tracertm.storage.neo4j_trace_link_writer` so every
+graph mutation flows through :class:`~tracertm.ports.graph_contract.GraphPort`
+validation before reaching Neo4j (``NFR-TRC-010``).
+
+The adapter translates canonical :class:`GraphNode` / :class:`GraphEdge` value
+objects into the legacy :class:`~tracertm.models.trace_link.Artifact` /
+:class:`~tracertm.models.trace_link.TraceLink` wire format the writer already
+understands. Vocabulary mapping is explicit and closed — unmapped kinds raise
+:class:`~tracertm.ports.graph_contract.SchemaContractError` at the boundary
+rather than silently inventing labels.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from tracertm.models.trace_link import (
+    Artifact,
+    ArtifactKind,
+    Requirement,
+    RequirementStatus,
+    TraceLink,
+    TraceLinkType,
+)
+from tracertm.ports.graph_contract import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    NodeKind,
+    SchemaContractError,
+    validate_edge,
+    validate_node,
+)
+from tracertm.storage import neo4j_trace_link_writer as _writer
+
+if TYPE_CHECKING:
+    from neo4j import Driver
+
+__all__ = ["Neo4jGraphPort", "GraphPortAdapterError"]
+
+# Canonical NodeKind → legacy ArtifactKind (trace-link projection subset).
+_NODE_KIND_TO_ARTIFACT: dict[NodeKind, ArtifactKind] = {
+    NodeKind.REQUIREMENT: ArtifactKind.REQUIREMENT,
+    NodeKind.SPEC: ArtifactKind.DESIGN,
+    NodeKind.ADR: ArtifactKind.RATIONALE,
+    NodeKind.CODE: ArtifactKind.CODE,
+    NodeKind.TEST: ArtifactKind.TEST,
+    NodeKind.PR: ArtifactKind.CODE,
+    NodeKind.COMMIT: ArtifactKind.CODE,
+    NodeKind.EVIDENCE: ArtifactKind.EVIDENCE,
+}
+
+# Canonical EdgeType → legacy TraceLinkType.
+_EDGE_TO_TRACE: dict[EdgeType, TraceLinkType] = {
+    EdgeType.IMPLEMENTS: TraceLinkType.IMPLEMENTS,
+    EdgeType.VERIFIES: TraceLinkType.VERIFIES,
+    EdgeType.DUPLICATES: TraceLinkType.DUPLICATES,
+    EdgeType.COVERS: TraceLinkType.SATISFIES,
+    EdgeType.TRACES_TO: TraceLinkType.DERIVES_FROM,
+    EdgeType.EVIDENCES: TraceLinkType.VERIFIES,
+    EdgeType.IMPACTS: TraceLinkType.CONFLICTS_WITH,
+    EdgeType.DEPENDS_ON: TraceLinkType.REFINES,
+    EdgeType.BELONGS_TO: TraceLinkType.DERIVES_FROM,
+    EdgeType.RELEASES: TraceLinkType.SATISFIES,
+}
+
+
+class GraphPortAdapterError(SchemaContractError):
+    """Raised when a canonical node/edge cannot be projected to Neo4j."""
+
+
+def _require_project_id(properties: Mapping[str, Any]) -> uuid.UUID:
+    raw = properties.get("project_id")
+    if raw is None:
+        raise GraphPortAdapterError("GraphNode.properties must include project_id")
+    return uuid.UUID(str(raw))
+
+
+def _graph_node_to_artifact(node: GraphNode) -> Artifact | Requirement:
+    """Map a validated canonical node to an Artifact/Requirement value object."""
+    kind = _NODE_KIND_TO_ARTIFACT.get(node.kind)
+    if kind is None:
+        raise GraphPortAdapterError(
+            f"NodeKind {node.kind.value} is not yet projectable to Neo4j"
+        )
+    props = dict(node.properties)
+    project_id = _require_project_id(props)
+    title = str(props.get("title") or node.id)
+    common: dict[str, Any] = {
+        "id": uuid.UUID(str(node.id)),
+        "project_id": project_id,
+        "kind": kind,
+        "title": title,
+        "description": props.get("description"),
+        "external_id": props.get("external_id"),
+        "metadata": dict(props.get("metadata") or {}),
+        "created_at": props.get("created_at"),
+        "updated_at": props.get("updated_at"),
+    }
+    if node.kind is NodeKind.REQUIREMENT:
+        status_raw = props.get("status", RequirementStatus.DRAFT.value)
+        return Requirement(
+            **common,
+            status=RequirementStatus(str(status_raw)),
+            priority=props.get("priority"),
+            rationale=props.get("rationale"),
+            acceptance_criteria=list(props.get("acceptance_criteria") or []),
+            verification_method=props.get("verification_method"),
+        )
+    return Artifact(**common)
+
+
+def _graph_edge_to_trace_link(edge: GraphEdge) -> TraceLink:
+    """Map a validated canonical edge to a TraceLink value object."""
+    link_type = _EDGE_TO_TRACE.get(edge.type)
+    if link_type is None:
+        raise GraphPortAdapterError(
+            f"EdgeType {edge.type.value} is not yet projectable to Neo4j"
+        )
+    props = dict(edge.properties)
+    project_id = _require_project_id(props)
+    confidence = float(props.get("confidence", 1.0))
+    return TraceLink(
+        project_id=project_id,
+        source_artifact_id=uuid.UUID(str(edge.src.id)),
+        target_artifact_id=uuid.UUID(str(edge.dst.id)),
+        link_type=link_type,
+        confidence=confidence,
+        rationale=props.get("rationale"),
+        metadata=dict(props.get("metadata") or {}),
+        id=uuid.UUID(str(props["link_id"])) if props.get("link_id") else uuid.uuid4(),
+        created_at=props.get("created_at"),
+        updated_at=props.get("updated_at"),
+    )
+
+
+class Neo4jGraphPort:
+    """``GraphPort`` implementation backed by Neo4j via the trace-link writer."""
+
+    def __init__(self, driver: Driver) -> None:
+        self._driver = driver
+
+    def upsert_node(self, node: GraphNode) -> None:
+        validated = validate_node(node)
+        artifact = _graph_node_to_artifact(validated)
+        if isinstance(artifact, Requirement):
+            _writer.write_requirement(self._driver, artifact)
+        else:
+            _writer.write_artifact(self._driver, artifact)
+
+    def upsert_edge(self, edge: GraphEdge) -> None:
+        validated = validate_edge(edge)
+        link = _graph_edge_to_trace_link(validated)
+        _writer.write_link(self._driver, link)
+
+    def upsert_nodes(self, nodes: Sequence[GraphNode]) -> None:
+        for node in nodes:
+            self.upsert_node(node)
+
+    def upsert_edges(self, edges: Sequence[GraphEdge]) -> None:
+        for edge in edges:
+            self.upsert_edge(edge)
+
+    def neighbors(
+        self,
+        node: GraphNode,
+        *,
+        edge_type: EdgeType | None = None,
+        direction: str = "out",
+    ) -> Sequence[GraphEdge]:
+        """Return incident edges for impact/blast-radius queries."""
+        validated = validate_node(node)
+        if direction not in ("out", "in", "both"):
+            raise ValueError(f"direction must be out|in|both, got {direction!r}")
+
+        rel_filter = ""
+        params: dict[str, Any] = {"node_id": str(validated.id)}
+        if edge_type is not None:
+            trace_type = _EDGE_TO_TRACE.get(edge_type)
+            if trace_type is None:
+                return ()
+            rel_filter = "AND type(r) = $rel_type"
+            params["rel_type"] = trace_type.value
+
+        if direction == "out":
+            pattern = "(n:Artifact {id: $node_id})-[r]->(m:Artifact)"
+            src_id_key, dst_id_key = "src_id", "dst_id"
+            src_kind_key, dst_kind_key = "src_kind", "dst_kind"
+            return_clause = (
+                "type(r) AS rel_type, n.id AS src_id, m.id AS dst_id, "
+                "n.kind AS src_kind, m.kind AS dst_kind, "
+                "r.confidence AS confidence, r.rationale AS rationale"
+            )
+        elif direction == "in":
+            pattern = "(n:Artifact {id: $node_id})<-[r]-(m:Artifact)"
+            src_id_key, dst_id_key = "src_id", "dst_id"
+            src_kind_key, dst_kind_key = "src_kind", "dst_kind"
+            return_clause = (
+                "type(r) AS rel_type, m.id AS src_id, n.id AS dst_id, "
+                "m.kind AS src_kind, n.kind AS dst_kind, "
+                "r.confidence AS confidence, r.rationale AS rationale"
+            )
+        else:
+            pattern = "(n:Artifact {id: $node_id})-[r]-(m:Artifact)"
+            src_id_key, dst_id_key = "src_id", "dst_id"
+            src_kind_key, dst_kind_key = "src_kind", "dst_kind"
+            return_clause = (
+                "type(r) AS rel_type, "
+                "CASE WHEN startNode(r) = n THEN n.id ELSE m.id END AS src_id, "
+                "CASE WHEN startNode(r) = n THEN m.id ELSE n.id END AS dst_id, "
+                "CASE WHEN startNode(r) = n THEN n.kind ELSE m.kind END AS src_kind, "
+                "CASE WHEN startNode(r) = n THEN m.kind ELSE n.kind END AS dst_kind, "
+                "r.confidence AS confidence, r.rationale AS rationale"
+            )
+
+        cypher = f"MATCH {pattern} WHERE true {rel_filter} RETURN {return_clause}"
+
+        trace_to_edge = {v: k for k, v in _EDGE_TO_TRACE.items()}
+        artifact_to_node = {v: k for k, v in _NODE_KIND_TO_ARTIFACT.items()}
+
+        edges: list[GraphEdge] = []
+        with self._driver.session() as session:
+            for record in session.run(cypher, **params):
+                rel = record["rel_type"]
+                canonical_edge = trace_to_edge.get(TraceLinkType(rel))
+                if canonical_edge is None:
+                    continue
+                src_kind = artifact_to_node.get(ArtifactKind(record[src_kind_key]))
+                dst_kind = artifact_to_node.get(ArtifactKind(record[dst_kind_key]))
+                if src_kind is None or dst_kind is None:
+                    continue
+                edges.append(
+                    GraphEdge(
+                        type=canonical_edge,
+                        src=GraphNode(kind=src_kind, id=str(record[src_id_key])),
+                        dst=GraphNode(kind=dst_kind, id=str(record[dst_id_key])),
+                        properties={
+                            "confidence": record.get("confidence"),
+                            "rationale": record.get("rationale"),
+                        },
+                    )
+                )
+        return edges

--- a/tests/unit/ports/test_neo4j_graph_port.py
+++ b/tests/unit/ports/test_neo4j_graph_port.py
@@ -1,0 +1,129 @@
+"""Unit tests for the Neo4j ``GraphPort`` adapter."""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tracertm.ports.graph_contract import (
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    GraphPort,
+    NodeKind,
+    SchemaContractError,
+)
+from tracertm.storage.neo4j_graph_port import GraphPortAdapterError, Neo4jGraphPort
+
+_PROJECT = str(uuid.uuid4())
+_CODE_ID = str(uuid.uuid4())
+_REQ_ID = str(uuid.uuid4())
+
+
+def _node(kind: NodeKind, id_: str, **props) -> GraphNode:
+    base = {"project_id": _PROJECT, "title": f"{kind.value}-{id_}"}
+    base.update(props)
+    return GraphNode(kind=kind, id=id_, properties=base)
+
+
+def test_neo4j_graph_port_satisfies_graph_port_protocol():
+    driver = MagicMock()
+    assert isinstance(Neo4jGraphPort(driver), GraphPort)
+
+
+def test_upsert_node_validates_before_write():
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    with pytest.raises(SchemaContractError):
+        port.upsert_node(GraphNode(kind=NodeKind.CODE, id="   ", properties={"project_id": _PROJECT}))
+
+
+@patch("tracertm.storage.neo4j_graph_port._writer.write_artifact")
+def test_upsert_code_node_delegates_to_writer(mock_write: MagicMock):
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    node = _node(NodeKind.CODE, _CODE_ID)
+    port.upsert_node(node)
+    mock_write.assert_called_once()
+    assert mock_write.call_args[0][0] is driver
+    artifact = mock_write.call_args[0][1]
+    assert artifact.kind.value == "code"
+    assert str(artifact.id) == _CODE_ID
+
+
+@patch("tracertm.storage.neo4j_graph_port._writer.write_requirement")
+def test_upsert_requirement_node_delegates_to_writer(mock_write: MagicMock):
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    node = _node(NodeKind.REQUIREMENT, _REQ_ID, status="draft")
+    port.upsert_node(node)
+    mock_write.assert_called_once()
+    req = mock_write.call_args[0][1]
+    assert req.kind.value == "requirement"
+
+
+def test_upsert_unmapped_node_kind_raises():
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    with pytest.raises(GraphPortAdapterError, match="not yet projectable"):
+        port.upsert_node(_node(NodeKind.TEAM, str(uuid.uuid4())))
+
+
+@patch("tracertm.storage.neo4j_graph_port._writer.write_link")
+def test_upsert_edge_maps_canonical_type(mock_write: MagicMock):
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    edge = GraphEdge(
+        type=EdgeType.IMPLEMENTS,
+        src=_node(NodeKind.CODE, _CODE_ID),
+        dst=_node(NodeKind.REQUIREMENT, _REQ_ID),
+        properties={"project_id": _PROJECT, "confidence": 0.9, "rationale": "implements"},
+    )
+    port.upsert_edge(edge)
+    mock_write.assert_called_once()
+    link = mock_write.call_args[0][1]
+    assert link.link_type.value == "IMPLEMENTS"
+    assert link.confidence == 0.9
+
+
+def test_upsert_edge_rejects_invalid_endpoint_kinds():
+    driver = MagicMock()
+    port = Neo4jGraphPort(driver)
+    edge = GraphEdge(
+        type=EdgeType.IMPLEMENTS,
+        src=_node(NodeKind.REQUIREMENT, _REQ_ID),
+        dst=_node(NodeKind.REQUIREMENT, str(uuid.uuid4())),
+        properties={"project_id": _PROJECT},
+    )
+    with pytest.raises(SchemaContractError):
+        port.upsert_edge(edge)
+
+
+def test_neighbors_returns_mapped_edges():
+    driver = MagicMock()
+    session = MagicMock()
+    session.run.return_value = [
+        {
+            "rel_type": "IMPLEMENTS",
+            "src_id": _CODE_ID,
+            "dst_id": _REQ_ID,
+            "src_kind": "code",
+            "dst_kind": "requirement",
+            "confidence": 1.0,
+            "rationale": "ok",
+        }
+    ]
+
+    @contextmanager
+    def _session():
+        yield session
+
+    driver.session.return_value = _session()
+    port = Neo4jGraphPort(driver)
+    edges = port.neighbors(_node(NodeKind.CODE, _CODE_ID))
+    assert len(edges) == 1
+    assert edges[0].type is EdgeType.IMPLEMENTS
+    assert edges[0].dst.kind is NodeKind.REQUIREMENT

--- a/tests/unit/ports/test_scorer.py
+++ b/tests/unit/ports/test_scorer.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from tracertm.ports.scorer import JaccardScorer, ScorerPort, ScoreResult
+from tracertm.ports.scorer import (
+    JaccardScorer,
+    ScorerPort,
+    ScoreResult,
+    SentenceTransformerScorer,
+    SigLIPScorer,
+)
 
 
 def test_jaccard_satisfies_scorer_port_protocol():
@@ -44,3 +50,19 @@ def test_callers_can_swap_strategy_without_changing_call_site():
         return scorer.score(a, b).score
 
     assert confidence(JaccardScorer(), "trace link graph", "trace link graph") == 1.0
+
+
+def test_sentence_transformer_stub_satisfies_port_without_ml_deps():
+    scorer = SentenceTransformerScorer()
+    assert isinstance(scorer, ScorerPort)
+    r = scorer.score("user login", "user login")
+    assert r.strategy == "sentence_transformer"
+    assert "[stub-ST]" in r.rationale or "cosine" in r.rationale
+
+
+def test_siglip_stub_satisfies_port_without_ml_deps():
+    scorer = SigLIPScorer()
+    assert isinstance(scorer, ScorerPort)
+    r = scorer.score("dashboard screenshot", "ui mock")
+    assert r.strategy == "siglip"
+    assert "[stub-SigLIP]" in r.rationale or "[siglip-pending]" in r.rationale


### PR DESCRIPTION
## **User description**
## Summary
- Add `Neo4jGraphPort` adapter implementing `GraphPort` by delegating to `neo4j_trace_link_writer` with canonical NodeKind/EdgeType → trace-link projection and contract validation at the write boundary (`NFR-TRC-010`).
- Add `SentenceTransformerScorer` and `SigLIPScorer` stubs behind `ScorerPort` (fallback to Jaccard when ML deps absent).
- Unit tests: adapter validation/delegation/neighbors + stub scorer protocol checks.

Stacks on #494 (`feat/pillar-a-spine-contracts`). **Do not merge** — Phase-0 R&D increment.

## Test plan
- [x] `pytest tests/unit/ports/ -q` — 25 passed locally
- [ ] CI green on adapter + scorer tests

## Next
Migrate trace/impact services to write only via `GraphPort`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Graph writes now go through explicit canonical→legacy mappings and custom Cypher reads; incorrect mappings could mislabel trace data until services migrate, but existing writer paths are reused and contract validation runs at the boundary.
> 
> **Overview**
> Adds **`Neo4jGraphPort`**, the first concrete **`GraphPort`** implementation: canonical nodes/edges are validated, mapped to legacy trace-link models, and persisted via **`neo4j_trace_link_writer`**, with **`neighbors`** for read-side impact queries. Unmapped kinds/types fail at the adapter with **`GraphPortAdapterError`** instead of inventing schema.
> 
> Extends **`ScorerPort`** with **`SentenceTransformerScorer`** (cosine embeddings when **`sentence-transformers`** is present) and **`SigLIPScorer`** (still Jaccard-backed pending real SigLIP). Both export from **`tracertm.ports`** and fall back to Jaccard in CI when ML deps are missing.
> 
> Docs mark the Neo4j adapter follow-on as landed; unit tests cover adapter delegation, validation, neighbor mapping, and stub scorer protocol behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049eac5d32c68e165ccd21904998f689ca878033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Wire the Neo4j graph path through the new GraphPort and add scorer stubs**

### What Changed
- Graph writes now go through a typed adapter before reaching Neo4j, with invalid nodes or edges rejected at the boundary instead of being written loosely.
- Canonical graph kinds and link types are translated into the existing Neo4j trace-link format, and neighbor lookups now return mapped graph edges for impact and blast-radius queries.
- Added sentence-embedding and image-scoring stubs behind the scorer interface so callers can use them without ML dependencies installed; they fall back with clear stub messages.
- Added tests for graph-port validation, Neo4j delegation, neighbor mapping, and scorer-port compatibility.

### Impact
`✅ Safer graph writes to Neo4j`
`✅ Clearer impact and traceability queries`
`✅ Working scorer interface in environments without ML packages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
