### PR TITLE
chore(Tracera): add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,104 @@
+# justfile for Tracera
+# Polyglot workspace: TypeScript/Bun (frontend + TUI) and Python/uv (backend).
+# The repo's `make` and `bun` scripts remain canonical; this is a thin
+# convenience layer on top. Use `just` (or `just <recipe>`) to run recipes.
+# `just` is the casey/just command runner: https://just.systems
+
+set shell := ["bash", "-uc"]
+set dotenv-load
+
+# ---- Detected features (eval once, exported as env vars) ----
+
+export HAS_ROOT_PACKAGE := `test -f package.json && echo 1 || echo 0`
+export HAS_PYPROJECT := `test -f pyproject.toml && echo 1 || echo 0`
+export HAS_UV := `command -v uv >/dev/null 2>&1 && echo 1 || echo 0`
+export HAS_MAKE := `command -v make >/dev/null 2>&1 && echo 1 || echo 0`
+export JS_RUNNER := `command -v bun >/dev/null 2>&1 && echo bun || (command -v pnpm >/dev/null 2>&1 && echo pnpm || echo npm)`
+
+# ---- Default recipe: list available recipes ----
+
+default: list
+
+# Show all available recipes
+list:
+    @just --list
+
+# ---- Dev: start the TUI dev environment (delegates to the project's Makefile) ----
+
+dev:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_MAKE}" = "1" ]; then
+      make dev
+    else
+      ${JS_RUNNER} run dev
+    fi
+
+# ---- Build: produce release artifacts for both frontend and backend ----
+
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_MAKE}" = "1" ] && make -n build >/dev/null 2>&1; then
+      make build
+    elif [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+      ${JS_RUNNER} run build
+    fi
+
+# ---- Test: run the test suite (frontend + python) ----
+
+test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_MAKE}" = "1" ]; then
+      make test
+    else
+      if [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+        ${JS_RUNNER} test
+      fi
+      if [ "${HAS_PYPROJECT}" = "1" ] && [ "${HAS_UV}" = "1" ]; then
+        uv run pytest
+      fi
+    fi
+
+# ---- Lint: ruff for Python, eslint/biome for the frontend ----
+
+lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_PYPROJECT}" = "1" ] && [ "${HAS_UV}" = "1" ]; then
+      uv run ruff check .
+    fi
+
+    if [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+      ${JS_RUNNER} run lint || true
+    fi
+
+# ---- Fmt: apply formatter ----
+
+fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_PYPROJECT}" = "1" ] && [ "${HAS_UV}" = "1" ]; then
+      uv run ruff format .
+    fi
+
+    if [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+      ${JS_RUNNER} run format || ${JS_RUNNER} run fix || true
+    fi
+
+# ---- Clean: remove generated artifacts ----
+
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    rm -rf node_modules dist .turbo .next build
+    rm -rf .venv __pycache__ .pytest_cache .mypy_cache .ruff_cache
+    rm -rf frontend/node_modules frontend/dist frontend/.turbo frontend/.next
+    find . -type d -name '__pycache__' -prune -exec rm -rf {} +


### PR DESCRIPTION
## **User description**
Adds a justfile (just.systems) with org-standard dev/build/test/lint/fmt/clean recipes. Optional convenience layer over the existing makefile and bun scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-tooling only; the only operational caveat is the aggressive `clean` recipe deleting local caches and `node_modules`.
> 
> **Overview**
> Introduces a root **justfile** so developers can run org-standard tasks via `just` without replacing the existing **Makefile** or **bun** scripts.
> 
> At startup it exports flags for `package.json`, `pyproject.toml`, **uv**, **make**, and the chosen JS runner (**bun** → **pnpm** → **npm**), with **dotenv** loading enabled. **dev**, **build**, and **test** prefer **make** when available; otherwise they fall back to `${JS_RUNNER}` and, for tests, **uv run pytest** when Python is set up. **lint** / **fmt** run **ruff** via **uv** and optional frontend lint/format scripts (frontend lint is non-failing via `|| true`). **clean** deletes common JS/Python build artifacts and **frontend/** caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25378289ae3ab2d36035e3f55cfc47c621361849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a one-command task runner for common project workflows**

### What Changed
- Added `just` recipes to list, start, build, test, lint, format, and clean the project from one entry point
- Commands now work across the TypeScript/Bun frontend and Python/uv backend when the needed tools are available
- Cleaning removes common generated files and caches from both the root and frontend workspace

### Impact
`✅ Simpler local development setup`
`✅ Faster access to build, test, and lint commands`
`✅ Easier cleanup of generated files and caches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
