### PR TITLE
chore(Tracera): align editorconfig with org standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,24 +9,24 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.{py,pyi}]
-indent_style = space
-indent_size = 4
+indent_style = tab
+indent_size = 2
 max_line_length = 120
 
 [*.{ts,tsx,js,jsx,mjs,cjs}]
-indent_style = space
+indent_style = tab
 indent_size = 2
 
 [*.go]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 
 [*.{yml,yaml}]
-indent_style = space
+indent_style = tab
 indent_size = 2
 
 [*.{json,jsonc}]
-indent_style = space
+indent_style = tab
 indent_size = 2
 
 [Makefile]


### PR DESCRIPTION
## **User description**
Align .editorconfig indentation settings with the org majority from the tick 20 audit.\n\n- Set indent_style = tab anywhere indentation style is declared\n- Set indent_size = 2 anywhere indentation size is declared\n- Scope is limited to .editorconfig

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only formatting defaults; no runtime, security, or data-path changes.
> 
> **Overview**
> Updates **`.editorconfig`** only so indentation matches the org majority from the tick 20 audit.
> 
> **Indentation style** switches from spaces to **tabs** for Python, JS/TS, YAML, and JSON sections (Go and Makefile were already tab-based).
> 
> **Indent size** is set to **2** everywhere a size is declared, including Go (previously 4) and Python (previously 4 with spaces).
> 
> No application or build logic changes—only what EditorConfig-aware editors use for new edits and format-on-save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e111ceeef695be3820939cad3f76112929b9619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Align project editor settings with the shared org indentation standard**

### What Changed
- Files that use Python, TypeScript, JavaScript, Go, YAML, and JSON now follow the same tab-based indentation rule
- Go files now use the same 2-space indent size as the rest of the project rules
- Markdown files keep their existing trailing-space and line-length behavior

### Impact
`✅ Consistent file formatting across more file types`
`✅ Fewer editor formatting conflicts`
`✅ Easier onboarding for contributors using shared indentation rules`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
