### PR TITLE
chore(Tracera): gitignore worktree dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ __pycache__/
 .claudeignore
 .llmignore
 .hypothesis/
+/worktrees/
+/*-wtrees/


### PR DESCRIPTION
Adds /worktrees/ and /*-wtrees/ to .gitignore to keep local-only artifacts out of the index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.gitignore` is updated; no application code, CI, or deployment paths are affected.
> 
> **Overview**
> Extends **`.gitignore`** so local git worktree checkout folders are not tracked. It adds **`/worktrees/`** at the repo root and **`/*-wtrees/`** for sibling directories whose names end in `-wtrees`, alongside the existing AI-tool artifact ignores.
> 
> This is housekeeping only: it keeps developer-only worktree paths out of `git status` and accidental commits, with no runtime or build behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c59c9e10b7504970fcabc781704939b6a05a6561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->