### PR TITLE
Fix chaos async fixtures

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import httpx
 import pytest
+import pytest_asyncio
 import redis.asyncio as redis
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -45,7 +46,7 @@ def toxiproxy_url() -> str:
     return f"http://{TOXIPROXY_HOST}:{TOXIPROXY_PORT}"
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def toxiproxy_client(toxiproxy_url: str) -> AsyncGenerator[ToxiproxyClient, None]:
     """Provides a Toxiproxy client for managing proxies and toxics.
 
@@ -66,7 +67,7 @@ async def toxiproxy_client(toxiproxy_url: str) -> AsyncGenerator[ToxiproxyClient
     await client.cleanup_all()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def postgres_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, None]:
     """Creates a Toxiproxy proxy for PostgreSQL.
 
@@ -88,7 +89,7 @@ async def postgres_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[st
     await toxiproxy_client.delete_proxy(proxy_name)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def redis_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, None]:
     """Creates a Toxiproxy proxy for Redis.
 
@@ -108,7 +109,7 @@ async def redis_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, 
     await toxiproxy_client.delete_proxy(proxy_name)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def nats_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, None]:
     """Creates a Toxiproxy proxy for NATS.
 
@@ -128,7 +129,7 @@ async def nats_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, N
     await toxiproxy_client.delete_proxy(proxy_name)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def go_backend_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, None]:
     """Creates a Toxiproxy proxy for Go backend.
 
@@ -148,7 +149,7 @@ async def go_backend_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[
     await toxiproxy_client.delete_proxy(proxy_name)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def python_backend_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenerator[str, None]:
     """Creates a Toxiproxy proxy for Python backend.
 
@@ -168,19 +169,19 @@ async def python_backend_proxy(toxiproxy_client: ToxiproxyClient) -> AsyncGenera
     await toxiproxy_client.delete_proxy(proxy_name)
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def _postgres_proxy(postgres_proxy: str) -> str:
     """Alias for postgres_proxy with underscore prefix (pytest convention for unused fixtures)."""
     return postgres_proxy
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def _redis_proxy(redis_proxy: str) -> str:
     """Alias for redis_proxy with underscore prefix (pytest convention for unused fixtures)."""
     return redis_proxy
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def db_session(postgres_proxy: str) -> AsyncGenerator[AsyncSession, None]:
     """Provides a database session through the Toxiproxy proxy."""
     engine = create_async_engine(postgres_proxy, echo=False)
@@ -192,7 +193,7 @@ async def db_session(postgres_proxy: str) -> AsyncGenerator[AsyncSession, None]:
     await engine.dispose()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def redis_client(redis_proxy: str) -> AsyncGenerator[redis.Redis, None]:
     """Provides a Redis client through the Toxiproxy proxy."""
     client = redis.from_url(redis_proxy, decode_responses=True)


### PR DESCRIPTION
## Summary
- Convert chaos async fixtures to `pytest_asyncio.fixture` so pytest-asyncio strict mode awaits them correctly.
- Keeps synchronous fixtures on `pytest.fixture`.

## Diagnosis
The latest failed `Chaos Engineering Tests` run on `main` was https://github.com/KooshaPari/Tracera/actions/runs/27257431048. The failed logs show async fixtures being passed into tests as raw `async_generator` objects, for example `db_session.execute`, `redis_client.set`, and `toxiproxy_client.add_*` all fail with `AttributeError`. The backend proxy URL failure is the same fixture issue: the async generator fixture is stringified instead of yielding `http://localhost:18080`.

CI reports pytest-asyncio running in strict mode, where async fixtures must be declared with `pytest_asyncio.fixture`.

## Verification
- `git diff --check`
- Full local build intentionally not run per CI-diagnosis instructions; WSL/native C dependencies are not reliable here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture wiring in the chaos suite; no production or runtime behavior changes.
> 
> **Overview**
> Fixes **Chaos Engineering Tests** failures under pytest-asyncio **strict mode**, where async fixtures were not awaited and tests received raw async generators (e.g. `AttributeError` on `db_session.execute`, `redis_client.set`, and proxy URLs stringified instead of resolved).
> 
> In `tests/chaos/conftest.py`, adds `pytest_asyncio` and switches every **`async def`** fixture from `@pytest.fixture` to **`@pytest_asyncio.fixture`**, including session-scoped `toxiproxy_client` and the Toxiproxy proxy/alias/`db_session`/`redis_client` fixtures. The sync **`toxiproxy_url`** and **`assert_recovery_within_target`** fixtures stay on `@pytest.fixture`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9902f57c8f8fff341a530a0b201a3018a1b590f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->