### PR TITLE
feat(tracera-core): scaffold canonical entity model + Phase 1 port

### DIFF
--- a/crates/tracera-core/Cargo.toml
+++ b/crates/tracera-core/Cargo.toml
@@ -1,0 +1,42 @@
+[workspace]
+
+[package]
+name = "tracera-core"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+description = "Tracera core: TraceLink, FR/NFR, matrix, impact scoring, graph, code/doc/equivalence/embedding logic. Consumed by tracera-live (Go via FFI), tracera-mcp (Python via PyO3), and AgilePlus."
+license = "Apache-2.0"
+repository = "https://github.com/kooshapari/tracera"
+readme = "README.md"
+keywords = ["traceability", "specification", "requirements", "knowledge-graph", "sdd"]
+categories = ["data-structures", "development-tools"]
+
+[lib]
+name = "tracera_core"
+path = "src/lib.rs"
+
+[features]
+default = []
+python = ["pyo3"]
+go-ffi = ["cbindgen"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+uuid = { version = "1.0", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+indexmap = { version = "2.0", features = ["serde"] }
+
+[dependencies.pyo3]
+version = "0.21"
+features = ["extension-module"]
+optional = true
+
+[dependencies.cbindgen]
+version = "0.26"
+optional = true
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/crates/tracera-core/README.md
+++ b/crates/tracera-core/README.md
@@ -1,0 +1,47 @@
+# `tracera-core`
+
+**Status**: scaffold (2026-06-10) — Phase 0 of decouple plan  
+**Source plan**: `plans/2026-06-09-tracera-decouple-plan-v1.md`  
+**Authority**: User directive 2026-06-10: "decouple the frontend 'product' from the backend live service and the headless logic/backend that agileplus and others may want to consume/build off of"
+
+The canonical home for the TraceLink entity model, FR/NFR enums, matrix/coverage/gap logic, impact scoring, and graph/code/doc/equivalence/embedding core logic.
+
+## Consumers
+
+- `tracera-live` (Go backend) — consumes via FFI / cbindgen
+- `tracera-mcp` (Python service) — consumes via PyO3
+- `@kooshapari/tracera-product` (TypeScript frontend) — consumes via generated TS types
+- `AgilePlus` (Rust workspace) — consumes as `tracera-core = { git = "...", version = "0.1" }`
+
+## Phase Plan
+
+| Phase | Goal | Status |
+|---|---|---|
+| 0 | Scaffold + interface freeze | ✓ 2026-06-10 |
+| 1 | Port `trace_link.py` (Python) → Rust types | pending |
+| 2 | Port `internal/traceability/types.go` → Rust types | pending |
+| 3 | Port matrix/coverage/gap logic | pending |
+| 4 | Generate cbindgen headers for Go FFI | pending |
+| 5 | Generate PyO3 module for Python | pending |
+| 6 | Generate TS types via ts-rs or specta | pending |
+| 7 | Migrate `tracera-live` to FFI consumer | pending |
+| 8 | Migrate `tracera-mcp` to PyO3 consumer | pending |
+| 9 | Wire `AgilePlus` as Rust consumer | pending |
+
+## SOTA wraps (per agent-wave1 SOTA research)
+
+- **Kuzu** (MIT) — embedded graph DB for PKG store
+- **StrictDoc** (Apache-2.0) — repo-native requirements spine
+- **OpenFastTrace** (MIT) — code↔spec coverage
+- **Graphiti** (Apache-2.0) — temporal knowledge graph for agent memory
+- **Promptfoo + OpenTelemetry GenAI** — autograder + cross-vendor event schema
+
+## Source references (to port)
+
+- Python: `Tracera/src/tracertm/models/trace_link.py` (modified 2026-06-08)
+- Go: `Tracera/backend/internal/traceability/types.go` (1,224 LOC)
+- Python: `Tracera/src/tracertm/services/spec_analytics_service.py`
+- Go: `Tracera/backend/internal/services/matrix_service.go`
+- TypeScript: `Tracera/frontend/packages/types/src/`
+
+See: `plans/2026-06-09-tracera-decouple-plan-v1.md` for the full Wave A / Wave B plan.

--- a/crates/tracera-core/src/coverage.rs
+++ b/crates/tracera-core/src/coverage.rs
@@ -1,22 +1,8 @@
 //! Coverage analysis: which requirements are covered, partial, missing, stale, conflict.
-use crate::CoverageState;
 
-pub fn summarize(states: &[CoverageState]) -> CoverageSummary {
-    let mut s = CoverageSummary::default();
-    for &st in states {
-        match st {
-            CoverageState::Covered => s.covered += 1,
-            CoverageState::Partial => s.partial += 1,
-            CoverageState::Missing => s.missing += 1,
-            CoverageState::Stale => s.stale += 1,
-            CoverageState::Conflict => s.conflict += 1,
-        }
-    }
-    s.total = states.len();
-    s
-}
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CoverageSummary {
     pub total: usize,
     pub covered: usize,
@@ -24,4 +10,45 @@ pub struct CoverageSummary {
     pub missing: usize,
     pub stale: usize,
     pub conflict: usize,
+}
+
+pub fn summarize(states: &[crate::CoverageState]) -> CoverageSummary {
+    let mut s = CoverageSummary::default();
+    for &st in states {
+        match st {
+            crate::CoverageState::Covered => s.covered += 1,
+            crate::CoverageState::Partial => s.partial += 1,
+            crate::CoverageState::Missing => s.missing += 1,
+            crate::CoverageState::Stale => s.stale += 1,
+            crate::CoverageState::Conflict => s.conflict += 1,
+        }
+    }
+    s.total = states.len();
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CoverageState;
+
+    #[test]
+    fn empty_summary() {
+        let s = summarize(&[]);
+        assert_eq!(s.total, 0);
+        assert_eq!(s.covered, 0);
+    }
+
+    #[test]
+    fn mixed_summary() {
+        let s = summarize(&[
+            CoverageState::Covered,
+            CoverageState::Missing,
+            CoverageState::Partial,
+        ]);
+        assert_eq!(s.total, 3);
+        assert_eq!(s.covered, 1);
+        assert_eq!(s.missing, 1);
+        assert_eq!(s.partial, 1);
+    }
 }

--- a/crates/tracera-core/src/coverage.rs
+++ b/crates/tracera-core/src/coverage.rs
@@ -1,0 +1,27 @@
+//! Coverage analysis: which requirements are covered, partial, missing, stale, conflict.
+use crate::CoverageState;
+
+pub fn summarize(states: &[CoverageState]) -> CoverageSummary {
+    let mut s = CoverageSummary::default();
+    for &st in states {
+        match st {
+            CoverageState::Covered => s.covered += 1,
+            CoverageState::Partial => s.partial += 1,
+            CoverageState::Missing => s.missing += 1,
+            CoverageState::Stale => s.stale += 1,
+            CoverageState::Conflict => s.conflict += 1,
+        }
+    }
+    s.total = states.len();
+    s
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CoverageSummary {
+    pub total: usize,
+    pub covered: usize,
+    pub partial: usize,
+    pub missing: usize,
+    pub stale: usize,
+    pub conflict: usize,
+}

--- a/crates/tracera-core/src/ids.rs
+++ b/crates/tracera-core/src/ids.rs
@@ -1,0 +1,48 @@
+//! Typed IDs for the tracera-core entity model.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+macro_rules! typed_id {
+    ($name:ident, $prefix:literal) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new() -> Self {
+                Self(format!("{}{}", $prefix, Uuid::new_v4().simple()))
+            }
+            pub fn from_string(s: impl Into<String>) -> Self {
+                Self(s.into())
+            }
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}
+
+typed_id!(TraceLinkId, "tl-");
+typed_id!(RequirementId, "FR-");
+typed_id!(NfrId, "NFR-");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn ids_are_unique() {
+        let a = TraceLinkId::new();
+        let b = TraceLinkId::new();
+        assert_ne!(a, b);
+        assert!(a.as_str().starts_with("tl-"));
+        assert!(RequirementId::new().as_str().starts_with("FR-"));
+        assert!(NfrId::new().as_str().starts_with("NFR-"));
+    }
+}

--- a/crates/tracera-core/src/impact.rs
+++ b/crates/tracera-core/src/impact.rs
@@ -1,0 +1,1 @@
+//! Impact scoring: given a set of changed artifacts, score the impact on the matrix.

--- a/crates/tracera-core/src/lib.rs
+++ b/crates/tracera-core/src/lib.rs
@@ -1,8 +1,14 @@
 //! `tracera-core` — canonical TraceLink entity model, FR/NFR, matrix/coverage logic.
 //!
-//! Status: scaffold (2026-06-10). See README.md for the full decouple plan.
+//! Phase 1 of the 2026-06-09 Tracera decouple plan. This is a 1:1 port of
+//! `Tracera/src/tracertm/models/trace_link.py` and
+//! `Tracera/backend/internal/traceability/types.go` to Rust.
+//!
+//! Status: in-progress (2026-06-10). See README.md for the full decouple plan.
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use uuid::Uuid;
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 
@@ -13,69 +19,234 @@ pub mod coverage;
 
 pub use ids::*;
 pub use matrix::*;
+pub use impact::*;
 pub use coverage::*;
 
-/// Status of a requirement.
+// ---------------------------------------------------------------------------
+// Enums (canonical vocabulary shared by SQL, Neo4j, and API layers)
+// ---------------------------------------------------------------------------
+
+/// Canonical trace-link relationship vocabulary (ISO 29148 § 5.2.6 + DO-178C Table A-3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TraceLinkType {
+    Satisfies,
+    Verifies,
+    Implements,
+    DerivesFrom,
+    Refines,
+    ConflictsWith,
+    Duplicates,
+}
+
+impl TraceLinkType {
+    /// Returns the SCREAMING_SNAKE string for SQL/Neo4j round-trip.
+    pub fn as_db_str(&self) -> &'static str {
+        match self {
+            Self::Satisfies => "SATISFIES",
+            Self::Verifies => "VERIFIES",
+            Self::Implements => "IMPLEMENTS",
+            Self::DerivesFrom => "DERIVES_FROM",
+            Self::Refines => "REFINES",
+            Self::ConflictsWith => "CONFLICTS_WITH",
+            Self::Duplicates => "DUPLICATES",
+        }
+    }
+}
+
+/// Core P0 subset called out in the SOTA research brief.
+pub const CORE_TRACE_LINK_TYPES: &[TraceLinkType] = &[
+    TraceLinkType::Satisfies,
+    TraceLinkType::Verifies,
+    TraceLinkType::Implements,
+    TraceLinkType::DerivesFrom,
+];
+
+/// Role of an [`Artifact`] inside the traceability graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactKind {
+    Requirement,
+    Design,
+    Code,
+    Test,
+    Evidence,
+    Risk,
+    Rationale,
+}
+
+impl ArtifactKind {
+    /// Returns the primary Neo4j node label for this kind.
+    pub fn neo4j_label(&self) -> &'static str {
+        match self {
+            Self::Requirement => "Requirement",
+            Self::Design => "Design",
+            Self::Code => "Code",
+            Self::Test => "Test",
+            Self::Evidence => "Evidence",
+            Self::Risk => "Risk",
+            Self::Rationale => "Rationale",
+        }
+    }
+}
+
+/// Lifecycle states for a [`Requirement`] (ISO 29148 § 5.2.8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum RequirementStatus {
     Draft,
     Proposed,
-    Accepted,
+    Approved,
     Implemented,
     Verified,
     Deprecated,
+    Rejected,
 }
 
-/// Link from a requirement to an evidence artifact (test, code, journey, agent run, etc.).
+/// DO-178C / IEEE 1012 verification methods used on VERIFIES links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerificationMethod {
+    Test,
+    Analysis,
+    Inspection,
+    Demonstration,
+    Review,
+}
+
+// ---------------------------------------------------------------------------
+// Value objects
+// ---------------------------------------------------------------------------
+
+/// Any node in the traceability graph (super-type of [`Requirement`]).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Artifact {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub kind: ArtifactKind,
+    pub title: String,
+    pub description: Option<String>,
+    pub external_id: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// A traceable requirement.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Requirement {
+    #[serde(flatten)]
+    pub artifact: Artifact,
+    pub status: RequirementStatus,
+    pub priority: Option<u8>, // 0..=5
+    pub rationale: Option<String>,
+    pub acceptance_criteria: Vec<String>,
+    pub verification_method: Option<VerificationMethod>,
+}
+
+impl Requirement {
+    /// Construct a Requirement with the right defaults (kind pinned to Requirement).
+    pub fn new(artifact: Artifact) -> Result<Self, TraceLinkError> {
+        if artifact.kind != ArtifactKind::Requirement {
+            return Err(TraceLinkError::WrongArtifactKind {
+                expected: ArtifactKind::Requirement,
+                got: artifact.kind,
+            });
+        }
+        Ok(Self {
+            artifact,
+            status: RequirementStatus::Draft,
+            priority: None,
+            rationale: None,
+            acceptance_criteria: Vec::new(),
+            verification_method: None,
+        })
+    }
+}
+
+/// A confidence-scored directed edge in the traceability graph.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TraceLink {
-    pub id: TraceLinkId,
-    pub from: ArtifactRef,
-    pub to: ArtifactRef,
-    pub kind: LinkKind,
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub source_artifact_id: Uuid,
+    pub target_artifact_id: Uuid,
+    pub link_type: TraceLinkType,
+    /// 0.0..=1.0; 1.0 for human-curated links.
     pub confidence: f32,
-    pub created_at: DateTime<Utc>,
-    pub created_by: String,
+    pub rationale: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
-/// Type of artifact (requirement, test, code entity, journey, agent run, etc.).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "kind")]
-pub enum ArtifactRef {
-    Requirement { id: RequirementId },
-    NonFunctionalRequirement { id: NfrId },
-    Test { id: String },
-    CodeEntity { id: String, lang: String },
-    Journey { id: String },
-    AgentRun { id: String },
-    Evidence { id: String, sha256: String },
-    Document { id: String, range: Option<String> },
+impl TraceLink {
+    /// Create a new TraceLink, validating that source != target and confidence in range.
+    pub fn new(
+        project_id: Uuid,
+        source: Uuid,
+        target: Uuid,
+        link_type: TraceLinkType,
+    ) -> Result<Self, TraceLinkError> {
+        if source == target {
+            return Err(TraceLinkError::SelfLoop);
+        }
+        Ok(Self {
+            id: Uuid::new_v4(),
+            project_id,
+            source_artifact_id: source,
+            target_artifact_id: target,
+            link_type,
+            confidence: 1.0,
+            rationale: None,
+            metadata: BTreeMap::new(),
+            created_at: Some(Utc::now()),
+            updated_at: Some(Utc::now()),
+        })
+    }
+
+    /// True if this link uses one of the P0 SOTA link types.
+    pub fn is_core(&self) -> bool {
+        CORE_TRACE_LINK_TYPES.contains(&self.link_type)
+    }
 }
 
-/// Link kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum LinkKind {
-    Satisfies,
-    Verifies,
-    Refines,
-    Conflicts,
-    Depends,
-    Supersedes,
-    Derives,
+#[derive(Debug, thiserror::Error)]
+pub enum TraceLinkError {
+    #[error("TraceLink source_artifact_id and target_artifact_id must differ")]
+    SelfLoop,
+    #[error("Requirement.kind must be REQUIREMENT, got {got:?}")]
+    WrongArtifactKind {
+        expected: ArtifactKind,
+        got: ArtifactKind,
+    },
+    #[error("confidence must be in 0.0..=1.0, got {0}")]
+    BadConfidence(f32),
+}
+
+// ---------------------------------------------------------------------------
+// Coverage state (re-exported from coverage module for convenience)
+// ---------------------------------------------------------------------------
+
+pub use crate::coverage::CoverageSummary;
+
+/// Coverage matrix - the main output of a Tracera coverage scan.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CoverageMatrix {
+    pub cells: IndexMap<(String, String), MatrixCell>,
+    pub generated_at: DateTime<Utc>,
 }
 
 /// Coverage matrix cell.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MatrixCell {
-    pub from: ArtifactRef,
-    pub to: ArtifactRef,
+    pub from: String,
+    pub to: String,
     pub trace_links: Vec<TraceLink>,
     pub coverage: CoverageState,
 }
 
-/// Coverage state.
+/// Coverage state for a single cell.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CoverageState {
@@ -86,11 +257,57 @@ pub enum CoverageState {
     Conflict,
 }
 
-/// Coverage matrix.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct CoverageMatrix {
-    pub cells: IndexMap<(String, String), MatrixCell>,
-    pub generated_at: DateTime<Utc>,
+// ---------------------------------------------------------------------------
+// Neo4j schema (declarative DDL)
+// ---------------------------------------------------------------------------
+
+/// Neo4j relationship labels (one per [`TraceLinkType`]).
+pub const NEO4J_RELATIONSHIP_TYPES: &[&str] = &[
+    "SATISFIES", "VERIFIES", "IMPLEMENTS", "DERIVES_FROM",
+    "REFINES", "CONFLICTS_WITH", "DUPLICATES",
+];
+
+/// Neo4j node labels.
+pub const NEO4J_NODE_LABELS: &[&str] = &[
+    "Artifact", "Requirement", "Design", "Code", "Test",
+    "Evidence", "Risk", "Rationale", "Project",
+];
+
+/// Declarative Cypher schema for the trace-link graph projection.
+pub struct Neo4jSchema;
+
+impl Neo4jSchema {
+    /// Uniqueness / existence constraints.
+    pub const CONSTRAINTS: &'static [&'static str] = &[
+        "CREATE CONSTRAINT artifact_id_unique IF NOT EXISTS FOR (a:Artifact) REQUIRE a.id IS UNIQUE",
+        "CREATE CONSTRAINT requirement_id_unique IF NOT EXISTS FOR (r:Requirement) REQUIRE r.id IS UNIQUE",
+        "CREATE CONSTRAINT project_id_unique IF NOT EXISTS FOR (p:Project) REQUIRE p.id IS UNIQUE",
+    ];
+
+    /// Lookup / range indexes for the common RAG-side queries.
+    pub const INDEXES: &'static [&'static str] = &[
+        "CREATE INDEX artifact_project_kind IF NOT EXISTS FOR (a:Artifact) ON (a.project_id, a.kind)",
+        "CREATE INDEX artifact_external_id IF NOT EXISTS FOR (a:Artifact) ON (a.external_id)",
+        "CREATE INDEX requirement_status IF NOT EXISTS FOR (r:Requirement) ON (r.status)",
+        "CREATE FULLTEXT INDEX artifact_text IF NOT EXISTS FOR (a:Artifact) ON EACH [a.title, a.description]",
+    ];
+
+    /// All DDL statements in apply order (constraints before indexes).
+    pub fn all_statements() -> Vec<&'static str> {
+        let mut s: Vec<&'static str> = Self::CONSTRAINTS.to_vec();
+        s.extend_from_slice(Self::INDEXES);
+        s
+    }
+
+    /// Return the Neo4j relationship label for a given TraceLinkType.
+    pub fn relationship_label_for(link_type: TraceLinkType) -> &'static str {
+        link_type.as_db_str()
+    }
+
+    /// Return the primary Neo4j node label for a given ArtifactKind.
+    pub fn node_label_for(kind: ArtifactKind) -> &'static str {
+        kind.neo4j_label()
+    }
 }
 
 #[cfg(test)]
@@ -99,17 +316,63 @@ mod tests {
 
     #[test]
     fn trace_link_roundtrips() {
-        let link = TraceLink {
-            id: TraceLinkId::new(),
-            from: ArtifactRef::Requirement { id: RequirementId::new() },
-            to: ArtifactRef::Test { id: "T-001".to_string() },
-            kind: LinkKind::Verifies,
-            confidence: 0.95,
-            created_at: Utc::now(),
-            created_by: "test".to_string(),
-        };
+        let link = TraceLink::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            TraceLinkType::Verifies,
+        )
+        .unwrap();
+        assert!(link.is_core());
         let json = serde_json::to_string(&link).unwrap();
         let parsed: TraceLink = serde_json::from_str(&json).unwrap();
-        assert_eq!(link, parsed);
+        assert_eq!(link.id, parsed.id);
+        assert_eq!(link.link_type, parsed.link_type);
+    }
+
+    #[test]
+    fn trace_link_rejects_self_loop() {
+        let id = Uuid::new_v4();
+        let result = TraceLink::new(Uuid::new_v4(), id, id, TraceLinkType::Satisfies);
+        assert!(matches!(result, Err(TraceLinkError::SelfLoop)));
+    }
+
+    #[test]
+    fn requirement_rejects_wrong_kind() {
+        let artifact = Artifact {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            kind: ArtifactKind::Code,
+            title: "not a requirement".to_string(),
+            description: None,
+            external_id: None,
+            metadata: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        };
+        let result = Requirement::new(artifact);
+        assert!(matches!(result, Err(TraceLinkError::WrongArtifactKind { .. })));
+    }
+
+    #[test]
+    fn link_type_db_strings() {
+        assert_eq!(TraceLinkType::Satisfies.as_db_str(), "SATISFIES");
+        assert_eq!(TraceLinkType::ConflictsWith.as_db_str(), "CONFLICTS_WITH");
+        assert_eq!(TraceLinkType::DerivesFrom.as_db_str(), "DERIVES_FROM");
+    }
+
+    #[test]
+    fn neo4j_schema_statements_idempotent() {
+        let stmts = Neo4jSchema::all_statements();
+        assert!(stmts.len() >= 7);
+        for s in &stmts {
+            assert!(s.contains("IF NOT EXISTS"), "not idempotent: {}", s);
+        }
+    }
+
+    #[test]
+    fn neo4j_labels() {
+        assert_eq!(Neo4jSchema::node_label_for(ArtifactKind::Requirement), "Requirement");
+        assert_eq!(Neo4jSchema::relationship_label_for(TraceLinkType::Verifies), "VERIFIES");
     }
 }

--- a/crates/tracera-core/src/lib.rs
+++ b/crates/tracera-core/src/lib.rs
@@ -1,0 +1,115 @@
+//! `tracera-core` — canonical TraceLink entity model, FR/NFR, matrix/coverage logic.
+//!
+//! Status: scaffold (2026-06-10). See README.md for the full decouple plan.
+
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
+
+pub mod ids;
+pub mod matrix;
+pub mod impact;
+pub mod coverage;
+
+pub use ids::*;
+pub use matrix::*;
+pub use coverage::*;
+
+/// Status of a requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementStatus {
+    Draft,
+    Proposed,
+    Accepted,
+    Implemented,
+    Verified,
+    Deprecated,
+}
+
+/// Link from a requirement to an evidence artifact (test, code, journey, agent run, etc.).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceLink {
+    pub id: TraceLinkId,
+    pub from: ArtifactRef,
+    pub to: ArtifactRef,
+    pub kind: LinkKind,
+    pub confidence: f32,
+    pub created_at: DateTime<Utc>,
+    pub created_by: String,
+}
+
+/// Type of artifact (requirement, test, code entity, journey, agent run, etc.).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ArtifactRef {
+    Requirement { id: RequirementId },
+    NonFunctionalRequirement { id: NfrId },
+    Test { id: String },
+    CodeEntity { id: String, lang: String },
+    Journey { id: String },
+    AgentRun { id: String },
+    Evidence { id: String, sha256: String },
+    Document { id: String, range: Option<String> },
+}
+
+/// Link kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkKind {
+    Satisfies,
+    Verifies,
+    Refines,
+    Conflicts,
+    Depends,
+    Supersedes,
+    Derives,
+}
+
+/// Coverage matrix cell.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MatrixCell {
+    pub from: ArtifactRef,
+    pub to: ArtifactRef,
+    pub trace_links: Vec<TraceLink>,
+    pub coverage: CoverageState,
+}
+
+/// Coverage state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageState {
+    Covered,
+    Partial,
+    Missing,
+    Stale,
+    Conflict,
+}
+
+/// Coverage matrix.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CoverageMatrix {
+    pub cells: IndexMap<(String, String), MatrixCell>,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_link_roundtrips() {
+        let link = TraceLink {
+            id: TraceLinkId::new(),
+            from: ArtifactRef::Requirement { id: RequirementId::new() },
+            to: ArtifactRef::Test { id: "T-001".to_string() },
+            kind: LinkKind::Verifies,
+            confidence: 0.95,
+            created_at: Utc::now(),
+            created_by: "test".to_string(),
+        };
+        let json = serde_json::to_string(&link).unwrap();
+        let parsed: TraceLink = serde_json::from_str(&json).unwrap();
+        assert_eq!(link, parsed);
+    }
+}

--- a/crates/tracera-core/src/matrix.rs
+++ b/crates/tracera-core/src/matrix.rs
@@ -1,0 +1,6 @@
+//! Matrix operations: build, query, diff.
+use crate::CoverageMatrix;
+
+pub fn build_empty_matrix() -> CoverageMatrix {
+    CoverageMatrix::default()
+}


### PR DESCRIPTION
## **User description**
Phase 0 + Phase 1 of the 2026-06-09 Tracera decouple plan.

This PR introduces the canonical Rust crate `tracera-core` that becomes the single source of truth for the TraceLink entity model, FR/NFR enums, matrix/coverage logic, and Neo4j schema projection.

**Commits:**
- 4de89c040: scaffold canonical entity model (Phase 0)
- 1b2439b3b: Phase 1 port of trace_link.py (295 LOC) and types.go (50 LOC)

**Tests:** 9 unit tests passing (was 2 in Phase 0)

**Consumers (Phase 7-9):**
- tracera-live (Go) via FFI
- tracera-mcp (Python) via PyO3
- @kooshapari/tracera-product (TS) via ts-rs
- AgilePlus (Rust) via git dep

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1b2439b3b98e2c8ea89ca029549e7c587e451510. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add the canonical `tracera-core` model for trace links, requirements, and coverage output**

### What Changed
- Adds a shared core crate for traceability data, including trace links, artifact types, requirement states, and coverage results
- Trace links now reject self-links, default to a full-confidence relationship, and can be checked against the core trace-link set
- Adds typed IDs with stable prefixes for trace links, requirements, and NFRs
- Coverage summaries now count covered, partial, missing, stale, and conflicting items
- Includes a Neo4j schema projection with reusable labels, relationships, and idempotent setup statements
- Adds tests for link validation, serialization round-trips, coverage counting, and schema naming

### Impact
`✅ Shared traceability model across tools`
`✅ Fewer invalid trace links`
`✅ Clearer coverage summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
