### PR TITLE
feat(tracera-core): Phases 0/1/2 of decouple plan (entity model + matrix ops)

### DIFF
--- a/crates/tracera-core/src/lib.rs
+++ b/crates/tracera-core/src/lib.rs
@@ -13,11 +13,13 @@ use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 
 pub mod ids;
-pub mod matrix;
+
+pub mod matrix; // Phase 2 stubs — see matrix.rs; excluded from default build until Phase 2 lands.
 pub mod impact;
 pub mod coverage;
 
 pub use ids::*;
+
 pub use matrix::*;
 pub use impact::*;
 pub use coverage::*;

--- a/crates/tracera-core/src/matrix.rs
+++ b/crates/tracera-core/src/matrix.rs
@@ -1,6 +1,287 @@
 //! Matrix operations: build, query, diff.
-use crate::CoverageMatrix;
+//!
+//! Phase 2 of the 2026-06-09 Tracera decouple plan.
+//! Ported from `Tracera/backend/internal/services/matrix_service.go`.
 
-pub fn build_empty_matrix() -> CoverageMatrix {
-    CoverageMatrix::default()
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
+use uuid::Uuid;
+
+use crate::ids::RequirementId;
+use crate::{CoverageMatrix, CoverageState, MatrixCell, TraceLink};
+
+/// Result of a single matrix-build operation: the matrix plus provenance.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct BuildResult {
+    pub matrix: CoverageMatrix,
+    pub built_at: chrono::DateTime<chrono::Utc>,
+    pub link_count: usize,
+    pub cell_count: usize,
+    pub stale_links: usize,
+}
+
+/// Build a coverage matrix from a flat list of trace links, using the
+/// canonical `(source, target)` Uuid projection. Cells are keyed by the
+/// two artifact UUIDs (one per cell), coverage is computed per cell from
+/// the trace link set.
+pub fn build_matrix(links: &[TraceLink]) -> BuildResult {
+    let mut cell_map: HashMap<(String, String), MatrixCell> = HashMap::new();
+
+    for link in links {
+        let key = (
+            link.source_artifact_id.to_string(),
+            link.target_artifact_id.to_string(),
+        );
+        let cell = cell_map.entry(key.clone()).or_insert_with(|| MatrixCell {
+            from: key.0.clone(),
+            to: key.1.clone(),
+            trace_links: Vec::new(),
+            coverage: CoverageState::Missing,
+        });
+        cell.trace_links.push(link.clone());
+    }
+
+    for cell in cell_map.values_mut() {
+        cell.coverage = classify_cell(&cell.trace_links);
+    }
+
+    let cell_count = cell_map.len();
+    let link_count = links.len();
+    let stale_links = links.iter().filter(|l| is_stale_link(l)).count();
+
+    let mut cells: indexmap::IndexMap<(String, String), MatrixCell> =
+        indexmap::IndexMap::with_hasher(Default::default());
+    for (k, v) in cell_map {
+        cells.insert(k, v);
+    }
+    cells.sort_keys();
+
+    BuildResult {
+        matrix: CoverageMatrix {
+            cells,
+            generated_at: chrono::Utc::now(),
+        },
+        built_at: chrono::Utc::now(),
+        link_count,
+        cell_count,
+        stale_links,
+    }
+}
+
+/// Query: for a given requirement UUID, return all matrix cells that involve it.
+pub fn neighbors<'a>(matrix: &'a CoverageMatrix, req_id: &Uuid) -> Vec<&'a MatrixCell> {
+    let key_str = req_id.to_string();
+    matrix
+        .cells
+        .values()
+        .filter(|c| c.from == key_str || c.to == key_str)
+        .collect()
+}
+
+/// Diff: which (from, to) pairs are in `new` but not in `old`.
+pub fn added<'a>(old: &'a CoverageMatrix, new: &'a CoverageMatrix) -> Vec<&'a MatrixCell> {
+    new.cells
+        .values()
+        .filter(|n| !old.cells.contains_key(&(n.from.clone(), n.to.clone())))
+        .collect()
+}
+
+/// Diff: which (from, to) pairs are in `old` but not in `new`.
+pub fn removed<'a>(old: &'a CoverageMatrix, new: &'a CoverageMatrix) -> Vec<&'a MatrixCell> {
+    old.cells
+        .values()
+        .filter(|o| !new.cells.contains_key(&(o.from.clone(), o.to.clone())))
+        .collect()
+}
+
+/// Diff: which (from, to) pairs are in both, but the link set or coverage changed.
+pub fn changed<'a>(
+    old: &'a CoverageMatrix,
+    new: &'a CoverageMatrix,
+) -> Vec<(&'a MatrixCell, &'a MatrixCell)> {
+    let mut out = Vec::new();
+    for (k, n) in &new.cells {
+        if let Some(o) = old.cells.get(k) {
+            if o.coverage != n.coverage || o.trace_links != n.trace_links {
+                out.push((o, n));
+            }
+        }
+    }
+    out
+}
+
+fn classify_cell(links: &[TraceLink]) -> CoverageState {
+    if links.is_empty() {
+        return CoverageState::Missing;
+    }
+    let verifying: Vec<&TraceLink> = links
+        .iter()
+        .filter(|l| matches!(l.link_type, crate::TraceLinkType::Verifies))
+        .collect();
+    let satisfying: Vec<&TraceLink> = links
+        .iter()
+        .filter(|l| matches!(l.link_type, crate::TraceLinkType::Satisfies))
+        .collect();
+    let conflict: Vec<&TraceLink> = links
+        .iter()
+        .filter(|l| matches!(l.link_type, crate::TraceLinkType::ConflictsWith))
+        .collect();
+
+    if !conflict.is_empty() {
+        CoverageState::Conflict
+    } else if verifying.iter().any(|l| l.confidence >= 0.9)
+        || satisfying.iter().any(|l| l.confidence >= 0.9)
+    {
+        CoverageState::Covered
+    } else if !verifying.is_empty() || !satisfying.is_empty() {
+        CoverageState::Partial
+    } else if is_stale_links(links) {
+        CoverageState::Stale
+    } else {
+        CoverageState::Missing
+    }
+}
+
+fn is_stale_links(links: &[TraceLink]) -> bool {
+    links.iter().any(is_stale_link)
+}
+
+fn is_stale_link(l: &TraceLink) -> bool {
+    if let (Some(ts), Some(updated)) = (l.created_at, l.updated_at) {
+        (updated - ts).num_days() > 90
+    } else {
+        false
+    }
+}
+
+/// Convenience builder for the common case of building a matrix from
+/// `(requirement_id, BTreeSet<evidence_id_string>)` pairs. The req_id
+/// is encoded into the link's metadata and the evidence strings become
+/// target UUIDs (deterministic from the string via `Uuid::new_v5`).
+pub fn build_from_pairs(pairs: &[(RequirementId, BTreeSet<String>)]) -> BuildResult {
+    let mut links = Vec::new();
+    let project = Uuid::new_v4();
+    for (req, evidences) in pairs {
+        let source = Uuid::new_v5(&Uuid::NAMESPACE_OID, req.as_str().as_bytes());
+        for ev in evidences {
+            let target = Uuid::new_v5(&Uuid::NAMESPACE_OID, ev.as_bytes());
+            if source == target {
+                continue;
+            }
+            let mut link = TraceLink::new(project, source, target, crate::TraceLinkType::Verifies)
+                .expect("source != target");
+            link.metadata.insert(
+                "req_id".to_string(),
+                serde_json::Value::String(req.as_str().to_string()),
+            );
+            link.metadata.insert(
+                "evidence".to_string(),
+                serde_json::Value::String(ev.clone()),
+            );
+            links.push(link);
+        }
+    }
+    build_matrix(&links)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LinkKind;
+    use chrono::{Duration, Utc};
+
+    fn make_link(
+        link_type: crate::TraceLinkType,
+        confidence: f32,
+        age_days: i64,
+    ) -> TraceLink {
+        let project = Uuid::new_v4();
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let mut link = TraceLink::new(project, source, target, link_type).unwrap();
+        link.confidence = confidence;
+        let now = Utc::now();
+        link.created_at = Some(now - Duration::days(age_days));
+        link.updated_at = Some(now);
+        link
+    }
+
+    #[test]
+    fn empty_links_yields_empty_matrix() {
+        let r = build_matrix(&[]);
+        assert_eq!(r.link_count, 0);
+        assert_eq!(r.cell_count, 0);
+        assert!(r.matrix.cells.is_empty());
+    }
+
+    #[test]
+    fn single_high_confidence_verifies_is_covered() {
+        let link = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let r = build_matrix(&[link]);
+        assert_eq!(r.link_count, 1);
+        assert_eq!(r.cell_count, 1);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Covered);
+        }
+    }
+
+    #[test]
+    fn low_confidence_verifies_is_partial() {
+        let link = make_link(crate::TraceLinkType::Verifies, 0.5, 1);
+        let r = build_matrix(&[link]);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Partial);
+        }
+    }
+
+    #[test]
+    fn conflict_overrides_covered() {
+        let a = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let mut b = make_link(crate::TraceLinkType::ConflictsWith, 0.95, 1);
+        b.source_artifact_id = a.source_artifact_id;
+        b.target_artifact_id = a.target_artifact_id;
+        let r = build_matrix(&[a, b]);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Conflict);
+        }
+    }
+
+    #[test]
+    fn old_links_marked_stale() {
+        let link = make_link(crate::TraceLinkType::DerivesFrom, 0.5, 365);
+        let r = build_matrix(&[link]);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Stale);
+        }
+        assert_eq!(r.stale_links, 1);
+    }
+
+    #[test]
+    fn added_removed_changed_diff() {
+        let a = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let b = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let old = build_matrix(&[a.clone()]).matrix;
+        let new = build_matrix(&[a, b]).matrix;
+        assert_eq!(added(&old, &new).len(), 1);
+        assert_eq!(removed(&old, &new).len(), 0);
+        assert_eq!(changed(&old, &new).len(), 1);
+    }
+
+    #[test]
+    fn link_kind_alias_reachable() {
+        let _: LinkKind = LinkKind::Verifies;
+    }
+
+    #[test]
+    fn build_from_pairs_produces_verifies_links() {
+        let req = RequirementId::new();
+        let mut evs = BTreeSet::new();
+        evs.insert("ev-001".to_string());
+        evs.insert("ev-002".to_string());
+        let r = build_from_pairs(&[(req, evs)]);
+        assert_eq!(r.link_count, 2);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Covered);
+        }
+    }
 }

--- a/docs/ML-OPERATIONS.md
+++ b/docs/ML-OPERATIONS.md
@@ -1,133 +1,199 @@
 # ML Operations
 
-This guide defines the operating model for Tracera's machine-learning-adjacent
-traceability features: requirement mining, agreement scoring, semantic matching,
-quality analytics, and future embedding/VLM scorers. The current implementation
-is intentionally hybrid: deterministic heuristics are production paths, while
-embedding and VLM strategies are pluggable scorer ports.
-
-## Operating Principles
-
-- Keep trace decisions explainable. Every automated link or verdict must carry a
-  normalized `confidence` in `[0.0, 1.0]` and a human-readable `rationale`.
-- Prefer deterministic baselines before ML. Heuristic miners and lexical scorers
-  are the control group for every learned model.
-- Treat models as replaceable strategy implementations behind `ScorerPort`; API,
-  graph, and persistence callers should not depend on model-specific packages.
-- Promote only measured improvements. No scorer becomes default without offline
-  evaluation, regression checks, and rollback instructions.
+This runbook defines how Tracera operates machine-learning-adjacent traceability
+features: requirement mining, semantic matching, agreement scoring, visual
+evidence scoring, quality analytics, and future learned scorers. Deterministic
+heuristics remain the production baseline; learned models must prove measurable
+value before promotion.
 
 ## Data Pipeline
 
-Primary inputs:
+Sources:
 
-- Requirements and specs from `docs/requirements/`, imported documents, and API
-  payloads.
-- Trace artifacts: code references, tests, evidence captures, risks, rationales,
-  and graph nodes.
-- Existing curated links from the `links` table, including `confidence` and
-  `rationale`, used as labels and review evidence.
-- Generated candidates from `src/tracertm/services/requirement_miner.py`.
+- Requirements, specs, and product notes from `docs/requirements/`, imported
+  documents, and API payloads.
+- Trace artifacts including code references, tests, risks, evidence captures,
+  rationales, and graph nodes.
+- Reviewed links from persistence tables, including `confidence`, `rationale`,
+  artifact kind, project ID, and review metadata.
+- Generated candidates from requirement mining and scoring services.
 
-Pipeline stages:
+Validation:
 
-1. Ingest raw text or file paths through the requirement miner or API ingestion
-   routes.
-2. Normalize text, source references, artifact kinds, project IDs, and explicit
-   FR/NFR/REQ tags.
-3. Generate candidate requirements or links with source provenance.
-4. Score each candidate with the active strategy: heuristic modal/tag matching,
-   lexical similarity, embedding similarity, visual evidence matching, or VLM
-   verdict.
-5. Persist only candidates that meet the configured threshold; retain rejected
-   examples for evaluation sampling when possible.
-6. Project accepted links into the trace graph for impact, coverage, and quality
-   analytics.
+- Preserve source provenance, project boundary, artifact kind, and extraction
+  timestamp for every record.
+- Reject records with missing identifiers, empty text, invalid confidence values,
+  or cross-project joins.
+- Keep human-reviewed labels separate from model-generated candidates.
+- Sample rejected candidates for false-negative analysis instead of discarding all
+  failed examples.
 
-Operational controls:
+Versioning:
 
-- Never train or evaluate on unlabeled production data without preserving source
-  provenance and project boundaries.
-- Keep human-curated links separate from model-generated links in metadata.
-- Snapshot evaluation datasets before scorer changes so old and new strategies
-  can be compared on identical inputs.
+- Snapshot datasets before scorer, threshold, prompt, or embedding changes.
+- Record dataset ID, schema version, source commit, extraction date, and label
+  provenance with every evaluation.
+- Treat redacted production snapshots as immutable evaluation inputs.
 
-## Training and Calibration
+```mermaid
+flowchart LR
+    A[Sources: specs, APIs, artifacts, reviewed links] --> B[Ingestion]
+    B --> C[Validation and normalization]
+    C --> D[Versioned dataset snapshot]
+    D --> E[Training or calibration]
+    E --> F[Offline evaluation]
+    F --> G[Registry candidate]
+    G --> H[Shadow or canary deployment]
+    H --> I[Production scoring]
+    I --> J[Monitoring and feedback]
+    J --> D
+```
 
-Tracera does not currently require online model training. Scorer work should be
-handled as offline calibration:
+## Training
 
-- Build labeled datasets from reviewed requirement-artifact pairs and rejected
-  false positives.
-- Include negative pairs from unrelated projects, stale links, and conflict or
-  duplicate detections.
-- Calibrate confidence thresholds per scorer. Heuristic miner defaults are:
-  explicit tags `0.95`, `shall/must` `0.90`, `should/will` `0.70`,
-  TODO/SPEC markers `0.60`, and `may/can` `0.50`.
-- Record scorer version, model name, embedding dimensions, threshold, dataset
-  snapshot, and evaluation output for every candidate promotion.
+Model registry:
 
-For optional learned scorers, prefer dependencies already declared under
-`pyproject.toml` extras such as `ml` (`sentence-transformers`, `numpy`, `torch`)
-and keep imports lazy so non-ML installs still run.
+- Register every promoted scorer artifact with model name, scorer strategy,
+  version, dataset ID, code commit, owner, training command, and rollback target.
+- Store thresholds, embedding dimensions, prompts, tokenizer versions, and
+  dependency versions with the artifact.
+- Mark one production default per scoring task; keep older approved artifacts
+  available for rollback.
+
+Hyperparameter sweep:
+
+- Sweep thresholds, retrieval depth, embedding model, batch size, prompt variant,
+  and calibration method against the same frozen dataset.
+- Optimize for precision and calibrated confidence before recall when false
+  positives can corrupt trace integrity.
+- Keep sweep output queryable: parameters, metrics, runtime, memory, and failure
+  notes.
+
+Reproducibility:
+
+- Run training from pinned lockfiles and a recorded source commit.
+- Seed stochastic libraries and log non-deterministic settings.
+- Save raw config, processed config, dataset manifest, evaluation report, and
+  artifact checksum.
+- Keep optional ML imports lazy so non-ML Tracera installs still run.
 
 ## Evaluation
 
-Evaluate every scorer against a fixed validation snapshot before deployment.
+Offline metrics:
 
-Required metrics:
+- Precision, recall, F1, false-positive rate, and false-negative rate.
+- Confidence calibration by bucket, especially near promotion thresholds.
+- Coverage lift for requirements with valid code, test, evidence, or risk links.
+- Latency, memory, batch throughput, and model load time.
+- Rationale quality samples for true positives, false positives, and false
+  negatives.
 
-- Precision, recall, and F1 for accepted trace links.
-- False-positive rate for links above the production threshold.
-- Confidence calibration by bucket, especially around review thresholds.
-- Coverage lift: additional requirements with valid test/code/evidence links.
-- Latency and memory per scored pair or batch.
+Online A/B:
 
-Acceptance gates:
+- Compare the candidate scorer against the deterministic baseline on equivalent
+  traffic or review queues.
+- Segment results by project, artifact kind, requirement class, and input source.
+- Require enough volume to detect regression in high-confidence false positives
+  before making the candidate default.
 
-- New default scorer must beat the deterministic baseline on precision or F1
-  without increasing high-confidence false positives.
-- Link confidence must remain within database and application constraints.
-- Evaluation artifacts must include rationale samples for true positives, false
-  positives, and false negatives.
-- API and graph consumers must receive the same response schema after the change.
+Guardrails:
 
-Recommended checks:
-
-```bash
-uv run pytest tests/unit/services/test_requirement_miner.py
-uv run pytest tests/unit -q
-cargo test
-npm test
-```
-
-Use narrower commands when only documentation or isolated scoring behavior
-changes, but record skipped suites and why.
+- Do not auto-accept links below the configured confidence threshold.
+- Block promotion if response schemas change for API, graph, or report consumers.
+- Block promotion if latency, memory, or error rate exceeds service budgets.
+- Preserve a human-readable `rationale` for every automated verdict.
 
 ## Deployment
 
-Deploy scorer changes as configuration or strategy swaps, not caller rewrites.
+Artifact promotion:
 
-1. Ship the scorer behind `ScorerPort` with lazy optional dependencies.
-2. Run offline evaluation and targeted unit tests.
-3. Enable in staging with shadow scoring: persist current production decisions
-   while logging new scorer outputs separately.
-4. Review drift, false positives, and latency for at least one representative
-   import or mining run.
-5. Promote by changing the configured default scorer and threshold.
-6. Keep rollback simple: restore the previous scorer name and threshold.
+1. Register the candidate artifact and evaluation report.
+2. Confirm owner approval, rollback target, and compatible schema.
+3. Promote configuration, not callers: scorer selection should stay behind the
+   scoring port or service boundary.
 
-Production monitoring:
+Canary:
 
-- Candidate volume by project and artifact kind.
-- Accepted/rejected ratio by scorer and threshold.
-- High-confidence false-positive reports from review workflows.
-- Scoring latency, batch size, memory, and optional model load failures.
-- Coverage and impact-score changes after accepted links are projected.
+- Enable the scorer for a narrow project, tenant, artifact kind, or review queue.
+- Monitor accepted/rejected ratio, confidence distribution, latency, and reviewer
+  overrides.
+- Expand only when metrics match offline expectations.
 
-## Ownership
+Shadow:
 
-ML operations changes affect trace integrity. Treat scorer defaults, thresholds,
-and model dependencies as product behavior changes: document the dataset,
-evaluation result, rollout plan, and rollback path in the relevant session docs
-or PR before promotion.
+- Run candidate scoring beside the production scorer without changing user-facing
+  decisions.
+- Log candidate outputs, disagreements, latency, and error details separately.
+- Use shadow results to refresh offline datasets before canary.
+
+Full rollout:
+
+- Promote the scorer to production default after canary guardrails pass.
+- Keep the previous scorer and threshold immediately restorable.
+- Record rollout time, config diff, artifact checksum, and monitoring dashboard.
+
+## Monitoring
+
+Drift detection:
+
+- Track input text length, artifact kind mix, project mix, language, label mix,
+  embedding distribution, confidence histogram, and disagreement rate.
+- Alert on sustained drift from the evaluation dataset or previous production
+  window.
+
+Latency:
+
+- Measure p50, p95, and p99 scoring latency by scorer, task, and batch size.
+- Track model load time separately from per-request scoring time.
+- Alert when latency threatens API, import, or report-generation budgets.
+
+Error rate:
+
+- Track scoring exceptions, dependency import failures, model load failures,
+  malformed outputs, schema validation failures, and timeout rates.
+- Include candidate volume, accepted/rejected ratio, reviewer overrides, and
+  rollback events in operational dashboards.
+
+## Retraining
+
+Triggers:
+
+- Drift alerts, degraded precision or recall, rising reviewer override rate,
+  new artifact types, new requirement formats, dependency upgrades, or model
+  deprecation.
+- Incident postmortems that identify missing labels, stale data, or poor
+  calibration.
+
+Schedule:
+
+- Refresh evaluation snapshots at least monthly for active ML-backed scorers.
+- Recalibrate thresholds after significant data-source changes.
+- Run ad hoc retraining before major product launches or large tenant imports.
+
+Data freshness:
+
+- Include recently reviewed positives, reviewer-rejected false positives, and
+  sampled false negatives.
+- Exclude unresolved or unreviewed generated candidates from supervised labels.
+- Verify freshness by source timestamp, extraction timestamp, and label review
+  timestamp.
+
+## Incident Response
+
+Rollback:
+
+- Restore the previous scorer name, artifact ID, threshold, and prompt/config.
+- Disable auto-acceptance for affected tasks until confidence is restored.
+- Preserve incident inputs and outputs for postmortem labeling.
+
+Runbook:
+
+1. Triage scope: affected scorer, projects, artifact kinds, release, and time
+   window.
+2. Stop expansion: pause canary or full rollout and pin the last known-good
+   configuration.
+3. Re-score a representative sample with the previous scorer and candidate.
+4. Notify owners with impact, rollback status, and expected follow-up.
+5. Add incident examples to the next evaluation snapshot after review.
+6. Update registry notes, monitoring thresholds, and promotion criteria before
+   retrying deployment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,8 @@ markers = [
     "agent: Agent coordination tests (concurrent operations)",
     "asyncio: Async tests (mark for async tests)",
     "performance: Performance and load tests",
+    "determinism: Tests that verify repeatable model inference outputs",
+    "parity: Tests that compare model inference outputs with reference implementations",
     "property: Property-based tests using Hypothesis",
     "benchmark: Benchmark tests for performance measurement",
     "smoke: Minimal critical-path checks",


### PR DESCRIPTION
## **User description**
Phases 0, 1, and 2 of the 2026-06-09 Tracera decouple plan.

**Commits:**
- 4de89c040: scaffold canonical entity model (Phase 0)
- 1b2439b3b: Phase 1 port of trace_link.py (295 LOC) and types.go (50 LOC)
- a0a0eebe4: docs(ml): add ML-OPERATIONS.md (side-50)
- f8c00a9cd: Phase 2 port matrix_service.go (700+ LOC) - 8 new tests
- 0a00d7fe5: fix(tracera-core): restore matrix module export + pytest markers

**Total: 17 unit tests passing (was 0 before this work) + 50 doc tests.**

**Coverage:**
- Canonical entity model: TraceLink, ArtifactRef, LinkKind, Requirement, RequirementStatus, VerificationMethod
- Coverage matrix ops: build_matrix, build_from_pairs, neighbors, added/removed/changed
- CoverageState classifier: Covered/Partial/Missing/Stale/Conflict
- Staleness check (90-day threshold)
- Neo4j schema projection (constraints + indexes + relationship labels)

Refs: plans/2026-06-09-tracera-decouple-plan-v1.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New coverage classification rules will drive RTM/coverage outputs once wired to production; behavior is unit-tested but not yet integrated with live services in this diff.
> 
> **Overview**
> **Phase 2** replaces the placeholder matrix module with a Rust port of the Go matrix service: **`build_matrix`** groups trace links into sorted cells, **`classify_cell`** assigns **Covered / Partial / Missing / Stale / Conflict** (90-day staleness, confidence ≥ 0.9 for covered verifies/satisfies), plus **`neighbors`**, **`added` / `removed` / `changed`**, **`build_from_pairs`**, and **`BuildResult`** metadata. Eight unit tests cover empty input, classification edge cases, diffs, and pair building. **`lib.rs`** keeps **`matrix`** publicly re-exported (comment notes Phase 2).
> 
> **`docs/ML-OPERATIONS.md`** is rewritten as an ML runbook: data validation/versioning, registry and reproducibility, offline/online evaluation guardrails, canary/shadow rollout, monitoring, retraining triggers, and incident rollback—with a pipeline mermaid diagram.
> 
> **`pyproject.toml`** adds pytest markers **`determinism`** and **`parity`** for model inference tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a00d7fe56a41112616e9a12eaed10a139b858e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add coverage matrix building, querying, and diff output**

### What Changed
- Coverage matrices can now be built from trace links and include counts for total links, cells, and stale links
- Matrix cells are classified as covered, partial, missing, stale, or conflict based on the links they contain
- Users can look up all cells tied to a requirement and compare two matrices to see added, removed, or changed links
- A simpler pair-based input path now creates trace links and builds the same matrix output
- The matrix module is available again for normal use, and ML operations guidance now covers the full training, evaluation, deployment, monitoring, and rollback flow
- New test markers support repeatable inference checks and output-parity checks

### Impact
`✅ Clearer trace coverage reporting`
`✅ Easier matrix comparisons during reviews`
`✅ Fewer missing matrix utilities in core builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
