### PR TITLE
chore(audit): Tracera state snapshot

### DIFF
--- a/.claude/dag-v2-audit-Tracera.json
+++ b/.claude/dag-v2-audit-Tracera.json
@@ -1,0 +1,181 @@
+{
+  "task": "DAG L1-16 audit",
+  "schema_version": "v2",
+  "generated_at": "2026-06-08T00:00:00Z",
+  "repo": "Tracera",
+  "repo_path": "/Users/kooshapari/CodeProjects/Phenotype/repos/Tracera",
+  "branch": "chore/audit-Tracera-2026-06-08",
+  "branch_base": "main",
+  "head_sha": "5a3ea1f051f47df6c45e32c0132ba93903a1ee46",
+  "last_commit_date": "2026-06-08T18:58:12-07:00",
+  "last_commit_subject": "docs: add SSOT.md",
+  "last_commit_author": "Phenotype Agent",
+  "remotes": {
+    "origin": "https://github.com/KooshaPari/Tracera.git"
+  },
+  "divergence": {
+    "local_ahead_of_origin": 6,
+    "origin_ahead_of_local": 8
+  },
+  "language_stack": {
+    "detected": [
+      "python",
+      "go",
+      "typescript",
+      "rust",
+      "shell",
+      "toml",
+      "markdown",
+      "yaml",
+      "github-actions-yaml"
+    ],
+    "primary": ["python", "go", "typescript"],
+    "secondary": ["rust", "shell"],
+    "python": {
+      "src_root": "src/tracertm",
+      "framework": "FastAPI >=0.136 (src/tracertm/api/main.py:24) + SQLAlchemy async + Alembic",
+      "deps_of_note": [
+        "fastapi>=0.136.0",
+        "torch>=2.10.0 (declared, transitive ML dep — only repo in org with torch)",
+        "sentence-transformers>=5.2.2 (declared, used lazily in src/tracertm/api/routers/blockchain.py:427-429)",
+        "opentelemetry-instrumentation-fastapi>=0.52b0",
+        "anthropic-sdk (via src/tracertm/services/ai_service.py — AI chat with tool use)"
+      ],
+      "layout": "src/tracertm/{api,agent,agents,core,services,repositories,models,workflows,mcp,schemas,observability,grpc,storage,vault,validation}",
+      "mcp_native": true,
+      "fastmcp_version": "2.14+ (per CHANGELOG 2.0.0 entry)"
+    },
+    "go": {
+      "backend_root": "backend/",
+      "framework": "Gin or chi (main.go Swagger comments reference @host localhost:8080, /api/v1); NATS + MinIO + WebSocket realtime",
+      "module": "github.com/kooshapari/tracertm-backend",
+      "subdirs": ["backend/cmd/{setup,migrate,nats-test,create-minio-bucket,packager,...}", "backend/internal/", "backend/pkg/", "backend/e2e/"]
+    },
+    "typescript": {
+      "frontend_root": "frontend/",
+      "framework": "React 19.2 + TypeScript + Vite + Turbo monorepo (NOT Vue)",
+      "apps": ["web", "desktop", "docs", "storybook", "desktop-electrobun"],
+      "packages": ["ui", "types", "config", "state", "api-client", "env-manager"],
+      "ui_libs": ["@radix-ui/react-accordion", "@radix-ui/react-collapsible", "oxlint-tsgolint"],
+      "state_mgmt": "MobX (per CHANGELOG 2.0.0 entry)",
+      "viz": "Cytoscape.js + Monaco code editor + MSW for API mocking"
+    },
+    "rust": {
+      "presence": "minimal — no workspace Cargo.toml; a few `crates/` dirs and toolchain pin in rust-toolchain.toml (root)",
+      "evidence": "rust-toolchain.toml at repo root; crates/ dir exists; not a primary stack"
+    },
+    "db": ["PostgreSQL (with pgvector — embedding vectors via sentence-transformers)", "alembic migrations", "SQLite (tests only)"],
+    "infrastructure": ["NATS (messaging + WebSocket fanout)", "MinIO (S3-compatible object storage)", "Process Compose orchestration", "Taskfile.yml + Makefile + docker-compose (3 variants) + docker-compose.chaos.yml"],
+    "desktop": "Electron (apps/desktop) + Electrobun (apps/desktop-electrobun)",
+    "ci": "GitHub Actions — 40 workflows in .github/workflows/ (architecture, ci-cd, chroma tic, codeql, contract-tests, contracts, deployment-rollback, docs-deploy, docs-performance, journey-gate, load-test, policy-gate, release, security-guard, test, trufflehog, desktop-electrobun-release, ...)"
+  },
+  "hygiene_score": 100,
+  "hygiene_breakdown": [
+    {"item": "LICENSE", "present": true, "points": 10, "evidence": ["LICENSE (21 lines, MIT)", "LICENSE-APACHE (dual-license backup)", "LICENSE-MIT"]},
+    {"item": "README", "present": true, "points": 10, "evidence": ["README.md (239 lines, 7560 B) — work-state header pinned, build/security/policy badges, full arch section (Go+TS+Python), key features, TOC"]},
+    {"item": "CHANGELOG", "present": true, "points": 10, "evidence": ["CHANGELOG.md (90 lines, Keep-a-Changelog 1.1.0 format) — 2.0.0 entry rich with Features (TraceRTM v2, FastMCP, BDD, Visual UI), cliff.toml present for auto-gen"]},
+    {"item": ".editorconfig", "present": true, "points": 10, "evidence": [".editorconfig (15 lines, root=true, per-language indent_size 4 vs 2 for ts/js/yaml)"]},
+    {"item": "CI", "present": true, "points": 10, "evidence": ["40 workflows in .github/workflows/ — comprehensive: ci-cd, test, contract-tests, codeql, security-guard, trufflehog, policy-gate, journey-gate, architecture, release, deployment-rollback, load-test, docs-deploy, docs-performance, alert-sync-issues, desktop-electrobun-release, ... (org-leading count)"]},
+    {"item": "dependabot", "present": true, "points": 10, "evidence": [".github/dependabot.yml — 12 ecosystems: npm (3 dirs), pip (2 dirs), gomod (5 dirs), github-actions, docker — weekly, grouped (react-ecosystem, etc.)"]},
+    {"item": "CODEOWNERS", "present": true, "points": 10, "evidence": ["CODEOWNERS (root, * @KooshaPari) + .github/CODEOWNERS (per-language drill-down: rust/go/python/ts)"]},
+    {"item": "CONTRIBUTING", "present": true, "points": 10, "evidence": ["CONTRIBUTING.md (58 lines, 2123 B) — code of conduct, polyglot dev setup (Task + Process Compose), conventional-commits, fork workflow"]},
+    {"item": "SECURITY", "present": true, "points": 10, "evidence": ["SECURITY.md (38 lines, 1604 B) — supported-versions table, private disclosure to kooshapari@gmail.com, 48h ack, SLSA/Rekor/Vault hardening measures listed"]},
+    {"item": "FUNDING", "present": true, "points": 10, "evidence": ["FUNDING.yml (root, github: KooshaPari + custom https://kooshapari.com/sponsor) + .github/FUNDING.yml"]}
+  ],
+  "dup_exposure": [
+    "phenotype-bus (event bus for AI agent lifecycle / RTM update events — src/tracertm/agent/events.py and src/tracertm/agent/agent_service.py re-implement publish/subscribe over NATS instead of consuming the canonical phenotype-bus abstraction)",
+    "phenotype-request-id (correlation IDs for cross-service request tracing — Tracera's own uuid4() in services/ai_service.py and codex_service.py should consume phenotype-request-id type for org-wide correlation)",
+    "phenotype-registry (service-name registry — hard-coded service names in FastAPI app factory and Go main.go; could resolve from central registry for label hygiene)",
+    "phenotype-dep-guard (deny.toml + audit-check policy — Tracera has its own .semgrep.yml + security_check.sh + ruff; candidate for unification under dep-guard baseline)",
+    "phenotype-tooling (shared just/lint/CI recipes — Tracera uses Taskfile.yml + Makefile + process-compose.yml; could consume phenotype-tooling conventions)",
+    "phenotype-journeys (journey tracing primitives — journey-gate workflow already exists; agent_service workflows could emit typed journey spans via phenotype-journeys)",
+    "phenotype-postfx (post-effect / middleware runner — FastAPI Depends() chain in src/tracertm/api/deps.py and Go middleware in backend/internal/ would be natural consumers of a shared postfx contract)",
+    "phenotype-shared / phenoShared (shared types — Tracera's py.typed src/tracertm/__init__.py is mature; a few canonical types (correlation id, audit event) belong in phenotype-shared)",
+    "phenotype-icons (UI asset library — frontend/packages/ui ships local icons; phenotype-icons could subsume the asset surface)",
+    "phenotype-omlx (OmniRoute MLX LLM bridge — Tracera's ai_service.py wraps Anthropic SDK directly; phenotype-omlx would unify the chat-completion surface with the rest of org's agent fleet)",
+    "phenotype-ops-mcp (MCP tooling — Tracera already exposes 50+ FastMCP tools (per CHANGELOG); could expose them through the ops-mcp federation layer for cross-agent discovery)",
+    "phenotype-python-sdk / phenotype-py-extras (Python SDK — Tracera is the org's flagship FastAPI service and a natural SDK home for the WorkOS / NATS / RTM primitives it wraps)",
+    "phenotype-infra (deployment / compose / process-compose — Tracera's docker-compose (3 variants) + Taskfile + process-compose could be unified under phenotype-infra templates)"
+  ],
+  "sota_gaps": [
+    "torch declared but unused — pyproject.toml pins torch>=2.10.0 and sentence-transformers>=5.2.2, but only one router (src/tracertm/api/routers/blockchain.py:427-429) imports them lazily. Either wire embeddings into the search/RTM-graph code paths or drop the dep (~250MB saved in CI image).",
+    "Embedding lifecycle not managed — SentenceTransformer('request.model_name') is loaded on every request inside the handler; no model cache, no warm-up, no eviction policy, no GPU/CPU device selection. Production-grade embeddings need a singleton loader with device awareness.",
+    "No embeddings index abstraction — pgvector column exists in schema, but the write path (insert embedding on requirement/FR save) is absent; embeddings appear to be query-only / on-demand, not a first-class index.",
+    "No agent evaluation harness — src/tracertm/services/agents/codex_service.py shells out to OpenAI Codex CLI but has no eval set, no regression tests on model outputs, no version pinning of prompts.",
+    "Anthropic SDK is direct-coupled — src/tracertm/services/ai_service.py uses anthropic SDK directly; no abstraction over the LLM provider, so swapping models or adding OpenAI/local-MLX requires code edits across services.",
+    "FastMCP surface not auto-discoverable — 50+ MCP tools exposed but no MCP manifest, no OpenAPI↔MCP bridge, no schema versioning of the tool surface.",
+    "MCP transports partially wired — CHANGELOG claims stdio/HTTP/SSE; only server-side dispatch is visible. SSE reconnection / auth refresh flow is not visible in src/tracertm/mcp/.",
+    "Local main diverged 6/8 from origin — branch is 6 commits ahead, origin 8 ahead. No auto-rebase; drift compounds.",
+    "Backend-Go and backend-Python duplicate business logic — REST surface in backend/internal/ (Go) and src/tracertm/api/routers/ (Python) overlap; no SSOT for handlers.",
+    "No GPU/CPU device selection for torch — fine for dev, breaks for prod at scale; no torch.set_default_device or device_map in any code path.",
+    "Sentence-transformers not pinned by model hash — request.model_name is a free string; no allow-list of vetted embedding models; supply-chain risk.",
+    "No batching for embeddings — handler loads model, encodes one item at a time; no async batching queue; will not scale past single-digit QPS on CPU.",
+    "Frontend viz libs (Cytoscape, Monaco) shipped as one bundle — no dynamic import; no SSR/streaming; Storybook has no visual regression baseline in CI despite Chromatic config.",
+    "No model cards / dataset cards — torch + sentence-transformers pulled in, but no documentation of which model is the org-canonical embedding, no license attestation for the chosen weights.",
+    "Tach module boundaries declared (tach.toml) but not enforced in CI — boundary enforcement is doc-only; risks a future leak between agent/api/core layers.",
+    "Three dependency manifests (pyproject.toml + go.mod + frontend/package.json) with no central bill-of-materials — SBOM generation not in any CI workflow."
+  ],
+  "convergence_cluster": "convergence",
+  "convergence_rationale": "Multi-language service (Python FastAPI + Go + React/TS) with the org's only torch + sentence-transformers surface (ML-compute). Despite the polyglot stack, the architectural role is convergence: it absorbs agent, embedding, MCP, RTM, WorkOS, NATS, MinIO, vault, and observability concerns into one platform, and the only thing it can 'converge to' is itself (it is the only ML compute target in the org — other repos would consume Tracera's embeddings, not the reverse). It is a stable product repo (v2.0.0), not a template (multi-stack), not web-only, not live-only. The 'convergence' cluster fits: large surface, high-leverage dup-exposure for phenotype-bus / phenotype-omlx / phenotype-ops-mcp / phenotype-python-sdk consumers, and a clear product-boundary target for the org.",
+  "action_items": [
+    {
+      "priority": 1,
+      "title": "Decide canonical home for torch + sentence-transformers in Tracera (wire or drop)",
+      "effort": "M (3-5d)",
+      "why": "torch>=2.10.0 + sentence-transformers>=5.2.2 are declared deps but only one router uses them lazily. Either: (a) wire embeddings into the RTM/requirements search index with a singleton model loader + device awareness + allow-list, or (b) drop both deps and route embedding calls through a phenotype-omlx MLX bridge (consumes the org's compute substrate). The 250MB CI-image win alone justifies the decision.",
+      "file_refs": ["pyproject.toml (torch, sentence-transformers pins)", "src/tracertm/api/routers/blockchain.py:427-429", "src/tracertm/services/ai_service.py"]
+    },
+    {
+      "priority": 2,
+      "title": "Reconcile local main divergence (6 ahead, 8 behind origin) and rebase audit branch",
+      "effort": "S (1-2d)",
+      "why": "Local main is 6 commits ahead of origin and 8 behind. Drift compounds every round. Decide: rebase onto origin/main (lose local 6) or push local 6 (lose origin 8). The current 6-commit lead is mostly chore/governance (editorconfig, gitignore, SSOT, CODEOWNERS) and is safe to keep — but the audit branch must be rebased on the chosen base before any future merge.",
+      "file_refs": ["main (local HEAD 5a3ea1f)", "origin/main (8 commits ahead)"]
+    },
+    {
+      "priority": 3,
+      "title": "Wrap anthropic SDK in src/tracertm/services/ai_service.py behind a provider-port (consume phenotype-omlx)",
+      "effort": "M (3-5d)",
+      "why": "Direct anthropic SDK coupling means every model swap or A/B test is a code change. A ChatProvider port (Protocol) backed by anthropic / openai / mlx / omlx implementations unifies the chat-completion surface with the rest of the org's agent fleet and unlocks cross-provider eval.",
+      "file_refs": ["src/tracertm/services/ai_service.py", "src/tracertm/services/ai_tools.py"]
+    },
+    {
+      "priority": 4,
+      "title": "Replace local uuid4() correlation IDs in agent_service / codex_service with phenotype-request-id type",
+      "effort": "S (1-2d)",
+      "why": "src/tracertm/agent/agent_service.py and src/tracertm/services/agents/codex_service.py each roll their own uuid4() for execution_id / session_id. The org's canonical request-id type lives in phenotype-request-id. Migrating aligns the surface with phenotype-bus consumers and unblocks cross-service journey correlation.",
+      "file_refs": ["src/tracertm/agent/agent_service.py", "src/tracertm/services/agents/codex_service.py", "src/tracertm/agent/events.py"]
+    },
+    {
+      "priority": 5,
+      "title": "Enforce tach.toml module boundaries in CI and add SBOM generation to release workflow",
+      "effort": "M (3-5d)",
+      "why": "tach.toml declares the hexagonal boundaries but no CI gate enforces them — boundary drift is silent. Combined with: pyproject.toml + go.mod + frontend/package.json producing no SBOM, the org has no way to detect supply-chain regressions on the only ML-compute repo. Two small CI steps (tach check + cyclonedx-py + cyclonedx-gomod + @cyclonedx/cyclonedx-npm) close the gap.",
+      "file_refs": ["tach.toml", ".github/workflows/ci-cd.yml", ".github/workflows/release.yml"]
+    }
+  ],
+  "notes": [
+    "Local main HEAD = 5a3ea1f 'docs: add SSOT.md' on 2026-06-08 18:58:12 PDT by 'Phenotype Agent <agent@phenotype.ai>'. Author/committer differ from Forge default — use repo's existing identity when committing on this branch.",
+    "Tracera is the ONLY repo in the org with torch + sentence-transformers declared. Confirmed by scanning the L1 audit set: no other PhenoKits/Tracely/PhenoObservability/etc. pins torch. This makes Tracera the org's ML-compute anchor.",
+    "Frontend is React 19 (NOT Vue as task description hinted) — verified via frontend/apps/web/package.json: react: ^19.2.0. The task description's 'Vue+FastAPI' is inaccurate for the JS layer; React+FastAPI+Go+Electron is the truth.",
+    "CHANGELOG.md jumps from 2.0.0 (2026-02-23) straight to the current Unreleased — intermediate versions are auto-generated by cliff.toml and git-cliff CI; no manual drift.",
+    "src/tracertm is a true Python package (py.typed, _version.py, alembic/ migrations, OpenAPI/grpc/proto generation) — production-grade layout, not a prototype.",
+    "Sentence-transformers usage is a single lazy import in one router; the dep is essentially a 250MB no-op in the current code. Either commit to it (rank-1 action) or drop it.",
+    "Dependabot covers 12 ecosystems (org-leading). No cargo ecosystem because no real Rust workspace exists, only a stale toolchain pin.",
+    "Two CODEOWNERS files (root + .github/) — root is single-line, .github/ has per-language drill-down. The duplication is intentional (GitHub reads .github/CODEOWNERS only; root CODEOWNERS is a back-up for org tools)."
+  ],
+  "metadata": {
+    "audit_task": "DAG L1-16",
+    "audit_date": "2026-06-08",
+    "auditor": "forge (workflow tracer)",
+    "source_repo_path": "/Users/kooshapari/CodeProjects/Phenotype/repos/Tracera",
+    "source_branch_audited": "main",
+    "workflows_count": 40,
+    "dependabot_ecosystems": 12,
+    "ml_compute": true,
+    "ml_libs_declared": ["torch>=2.10.0", "sentence-transformers>=5.2.2"],
+    "ml_libs_used_in_src": ["sentence-transformers (1 file: src/tracertm/api/routers/blockchain.py:427-429)"],
+    "is_only_torch_repo_in_org": true,
+    "pushed": false
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,37 +1,15 @@
-# EditorConfig is awesome: https://EditorConfig.org
-
 root = true
 
 [*]
-charset = utf-8
+indent_style = space
+indent_size = 4
 end_of_line = lf
-insert_final_newline = true
+charset = utf-8
 trim_trailing_whitespace = true
-
-[*.{py,pyi}]
-indent_style = space
-indent_size = 4
-max_line_length = 120
-
-[*.{ts,tsx,js,jsx,mjs,cjs}]
-indent_style = space
-indent_size = 2
-
-[*.go]
-indent_style = tab
-indent_size = 4
-
-[*.{yml,yaml}]
-indent_style = space
-indent_size = 2
-
-[*.{json,jsonc}]
-indent_style = space
-indent_size = 2
-
-[Makefile]
-indent_style = tab
+insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
-max_line_length = off
+
+[*.toml]
+indent_size = 2

--- a/.github/release-template-desktop.md
+++ b/.github/release-template-desktop.md
@@ -1,0 +1,65 @@
+## App identity
+
+TraceRTM v0.1.0 — `com.tracertm.desktop`
+
+## Downloads
+
+| Platform  | Artifact                                  | Size |
+|-----------|-------------------------------------------|------|
+| macOS     | `TraceRTM-0.1.0-mac.dmg`                  | -    |
+| Windows   | `TraceRTM-0.1.0-win.exe`                  | -    |
+| Linux     | `TraceRTM-0.1.0-linux.AppImage`           | -    |
+| Linux     | `TraceRTM-0.1.0-linux.deb`                | -    |
+| Linux     | `TraceRTM-0.1.0-linux.rpm`                | -    |
+
+## Install instructions
+
+- **macOS** — Open the DMG, drag `TraceRTM.app` to `/Applications`. First launch: right-click → Open to bypass Gatekeeper.
+- **Windows** — Run the EXE installer. SmartScreen: choose "More info" → "Run anyway".
+- **Linux AppImage** — `chmod +x TraceRTM-0.1.0-linux.AppImage && ./TraceRTM-0.1.0-linux.AppImage`
+- **Linux .deb** — `sudo dpkg -i TraceRTM-0.1.0-linux.deb && sudo apt-get install -f`
+- **Linux .rpm** — `sudo rpm -Uvh TraceRTM-0.1.0-linux.rpm`
+
+## What's new
+
+_Auto-generated from conventional commits._
+
+### Features
+<!-- feat: commits -->
+
+### Bug fixes
+<!-- fix: commits -->
+
+### Documentation
+<!-- docs: chore: commits -->
+
+### Infrastructure
+<!-- ci: commits -->
+
+## Known issues
+
+- _None reported._
+
+<!-- Add issues below, e.g.: -->
+<!-- - Crash on resume from sleep — GH#42 -->
+
+## SHA256 checksums
+
+```
+<checksums-placeholder>
+```
+
+<!-- Format:  <sha256>  TraceRTM-0.1.0-<artifact> -->
+
+## Code signing status
+
+| Platform | Status |
+|----------|--------|
+| macOS    | Signed by Apple Developer ID (`com.tracertm.desktop`) |
+| Windows  | Signed via Windows EV certificate |
+| Linux    | Signed with maintainer GPG key (`<key-id>`) |
+
+<!-- Verification commands: -->
+<!-- macOS:   codesign -dv --verbose=4 /Applications/TraceRTM.app -->
+<!-- Windows: Get-AuthenticodeSignature TraceRTM-0.1.0-win.exe -->
+<!-- Linux:   gpg --verify TraceRTM-0.1.0-linux.AppImage.asc -->

--- a/.github/workflows/desktop-electrobun-release.yml
+++ b/.github/workflows/desktop-electrobun-release.yml
@@ -1,0 +1,69 @@
+name: Desktop ElectroBun Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.artifact }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            artifact: mac
+          - os: windows-latest
+            artifact: win
+          - os: ubuntu-latest
+            artifact: linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@0355742c943ddb13ca8a6b700f824231caa91e75
+        with:
+          node-version: '20'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+
+      - name: Build ElectroBun desktop client
+        run: electrobun build --release --env=stable
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ matrix.artifact }}.zip
+          path: dist/
+          if-no-files-found: error
+
+  release:
+    name: Upload GitHub Release artifacts
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download desktop artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: release-artifacts
+
+      - name: Attach artifacts to GitHub Release
+        uses: softprops/action-gh-release@9ed3cf9a6863b31f005d951c8d19de20628cf4eb
+        with:
+          files: release-artifacts/**/*.zip
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ __pycache__/
 .claudeignore
 .llmignore
 .hypothesis/
+/worktrees/
+/*-wtrees/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,189 @@
+# Installing Tracera
+
+Tracera is a connector-first, end-to-end screen-time platform: an ElectroBun desktop
+client plus a Go/Python server stack backed by Postgres, Redis, and NATS. This guide
+walks through installing the full system on macOS, Windows, and Linux.
+
+## TL;DR (one-click desktop install)
+
+For most users, the fastest path is the packaged desktop client. A future Homebrew
+tap will provide a one-liner:
+
+`brew install tracertm`
+
+Until that lands, grab the latest build from
+<https://github.com/KooshaPari/Tracera/releases>:
+
+- macOS: `TraceRTM-mac.dmg` (universal, Apple Silicon + Intel)
+- Windows: `TraceRTM-win.exe` (NSIS installer, x64 + arm64)
+- Linux: `TraceRTM-linux.AppImage` (x64) or `TraceRTM-linux.deb`
+
+Double-click the installer, launch TraceRTM, and sign in. The desktop client bundles
+a local gateway and talks to Tracera Cloud by default. To point it at your own server,
+open Settings -> Gateway and enter your `http://localhost:4000` (or remote) URL.
+
+## macOS
+
+Native services are preferred over Docker where possible. The whole stack is wired
+up by `make dev`, which uses `process-compose.yml` to start Postgres, Redis, NATS,
+the Go API, the Python gateway, and the Bun web app together.
+
+Install the host prerequisites with Homebrew:
+
+`brew install bun postgresql@16 redis nats docker`
+
+Then clone and boot:
+
+`git clone https://github.com/KooshaPari/Tracera`
+
+`cd Tracera && bun install`
+
+`make dev`
+
+On first run, `make dev` provisions the Postgres role and database, applies Alembic
+migrations, seeds dev fixtures, and prints the web/gateway URLs. Add
+`eval "$(brew services start postgresql@16)"` (or start it via the macOS Control
+Plane app) if you want Postgres to survive reboots; otherwise the process-compose
+supervisor handles it for the lifetime of the dev session.
+
+## Windows
+
+Windows is fully supported via WSL2 or native tooling. The recommended path uses
+`winget` to install Node, Bun, and Docker Desktop:
+
+`winget install OpenJS.NodeJS.LTS oven-sh.Bun Docker.DockerDesktop`
+
+Reboot after the Docker Desktop install so the WSL2 kernel updates. Then, in a
+PowerShell or Windows Terminal window:
+
+`git clone https://github.com/KooshaPari/Tracera`
+
+`cd Tracera; bun install; make dev`
+
+If you prefer WSL2 (Ubuntu 22.04+), follow the Linux section inside the WSL distro
+instead -- `make dev` works identically. WSL2 is required for the Postgres/Redis/NATS
+sidecars when running native; Docker Desktop's WSL2 backend is the only Windows
+host that supports the Linux-native server stack reliably.
+
+## Linux (Ubuntu 22.04+)
+
+Tracera runs cleanly on Ubuntu 22.04 LTS and newer. Install Bun via the official
+script, then add Postgres and Redis from the system repos:
+
+`curl -fsSL https://bun.sh/install | bash`
+
+`sudo apt install postgresql-16 redis-server`
+
+NATS is shipped as a static binary fetched by `make dev`'s process-compose
+manifest, so no system package is required. Clone and boot:
+
+`git clone https://github.com/KooshaPari/Tracera`
+
+`cd Tracera && bun install`
+
+`make dev`
+
+For Fedora/Arch, swap the package manager calls for the equivalent `dnf` or
+`pacman` packages (`postgresql16-server`, `redis`, `bun` from the AUR). Docker is
+optional on Linux: `make dev` will use the system `postgres` and `redis-server`
+processes when present and only fall back to the Docker sidecars if they are
+missing.
+
+## Without desktop (server only)
+
+If you only want the server stack -- for example, to host a shared Tracera
+instance or develop against the API from a remote machine -- you do not need the
+ElectroBun client. `make dev` brings up Postgres, Redis, NATS, the Go API on
+:3000, the Python gateway on :4000, and the Bun web app on :5173 via
+`process-compose.yml`.
+
+After `make dev` reports healthy, you can connect to:
+
+- Web UI: <http://localhost:5173>
+- HTTP API: <http://localhost:3000>
+- Gateway (WebSocket + REST): <ws://localhost:4000> / <http://localhost:4000>
+- Postgres: `localhost:5432` (user `tracera`, db `tracera`)
+- Redis: `localhost:6379`
+- NATS: `localhost:4222`
+
+To run only the server pieces without the web app, use `make dev:server`. To run
+just the database sidecars (for IDE integration), use `make dev:infra`.
+
+## Verify install
+
+Smoke-test the gateway health endpoint once `make dev` reports all services
+healthy:
+
+`curl http://localhost:4000/healthz`
+
+Expected response:
+
+`{"ok": true}`
+
+A 200 with `{"ok": true}` means Postgres, Redis, and NATS are reachable from the
+Python gateway. Then check the Go API:
+
+`curl http://localhost:3000/healthz`
+
+which should also return `{"ok": true}` with a `version` field. If either endpoint
+returns non-2xx, jump to the Troubleshooting section below.
+
+## Uninstall
+
+Stop the dev stack and remove the Docker sidecars (only relevant if you opted
+into the Docker-backed mode on Linux):
+
+`make dev-down && docker rm -f trace-postgres trace-redis trace-nats`
+
+`make dev-down` terminates the process-compose supervisor, kills the Go, Python,
+and Bun processes, and stops any local Postgres/Redis/NATS processes it started.
+It does not delete the Postgres data directory; remove it with
+`rm -rf .data/pg` if you want a clean slate.
+
+To uninstall the desktop client, drag `TraceRTM.app` from `/Applications` to
+the Trash on macOS, use "Apps & Features" on Windows, or `sudo apt remove
+tracertm` / delete the AppImage on Linux. The packaged client stores per-user
+state under `~/Library/Application Support/TraceRTM` (macOS),
+`%APPDATA%\TraceRTM` (Windows), and `~/.config/tracertm` (Linux); remove those
+directories to wipe local caches and credentials.
+
+## Troubleshooting
+
+**Port 3000 or 4000 already in use.** Another service is bound to the port.
+Stop it, or override the ports via env vars before `make dev`: `API_PORT=3001
+GATEWAY_PORT=4001 make dev`. Update the desktop client's Settings -> Gateway URL
+to match.
+
+**Docker not running (Linux).** The Docker-backed sidecars require the daemon.
+Start it with `sudo systemctl start docker` and re-run `make dev`. To avoid
+Docker entirely, install native `postgresql-16` and `redis-server` -- `make dev`
+will auto-detect them and skip the Docker fallback.
+
+**`brew` permission denied on macOS.** Don't `sudo brew`. Fix the ownership of
+`/usr/local` (Intel) or `/opt/homebrew` (Apple Silicon):
+`sudo chown -R $(whoami) $(brew --prefix)`. On Apple Silicon, also ensure your
+shell PATH includes `$(brew --prefix)/bin`.
+
+**`bun: command not found` after install.** The Bun installer writes to
+`~/.bun/bin`. Add `export PATH="$HOME/.bun/bin:$PATH"` to your shell rc and
+re-source it, or log out and back in.
+
+**`make dev` hangs on "waiting for postgres".** The Postgres sidecar may have
+failed to initialize. Check `docker logs trace-postgres` (Docker mode) or
+`tail -f .data/pg/logfile` (native mode). Common cause: a stale data directory
+from a previous run -- delete `.data/pg` and retry.
+
+**WebSocket connection refused at `:4000`.** The Python gateway depends on
+NATS; if NATS failed to start, the gateway will exit immediately. Run
+`make dev:infra` in isolation and check `nats-server --version` is at least
+2.10.
+
+**Health check returns `{"ok": false, "deps": {"postgres": "down"}}`.** The
+gateway can reach its own port but not the database. Verify
+`pg_isready -h localhost -p 5432` and `redis-cli ping`. If either is down,
+`make dev-down` and `make dev` again to re-provision.
+
+For issues not covered here, file a bug at
+<https://github.com/KooshaPari/Tracera/issues> with the output of
+`make doctor` (a diagnostic target that dumps version, port, and dependency
+status into a redacted report).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint-naming test-setup
+.PHONY: lint-naming test-setup desktop-electrobun-dev desktop-electrobun-build desktop desktop-build
 
 # Used by Comprehensive Test Validation workflow; secrets optional in CI.
 test-setup:
@@ -8,3 +8,13 @@ lint-naming:
 	bash scripts/shell/check-naming-explosion-python.sh
 	bash scripts/shell/check-naming-explosion-go.sh
 	cd frontend && bash scripts/check-naming-explosion.sh
+
+desktop-electrobun-dev:
+	cd frontend/apps/desktop-electrobun && bun run dev
+
+desktop-electrobun-build:
+	cd frontend/apps/desktop-electrobun && bun run build:release
+
+desktop: desktop-electrobun-dev
+
+desktop-build: desktop-electrobun-build

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,149 @@
+# RUNBOOK
+
+Day-2 operations for the local dev stack defined in `process-compose.yml`.
+Process names referenced below (`postgres`, `redis`, `nats`, `trace-api`, `tracertm-web`,
+plus the conceptual `gateway`) match the keys in that file.
+
+## 1. Start / Stop
+
+The user runs the dev TUI in their own terminal. Use these targets from a separate shell;
+do not start or stop the full stack from here unless asked.
+
+| Action          | Command            | Notes                                              |
+| --------------- | ------------------ | -------------------------------------------------- |
+| Start           | `make dev`         | Boots postgres, redis, nats, gateway, web, api.    |
+| Stop            | `make dev-down`    | Tears the whole stack down cleanly.                |
+| Status          | `make dev-status`  | Lists process health, PID, uptime per service.     |
+| Tail logs       | `make dev-logs`    | Follows all service logs; Ctrl-C to detach.        |
+| Restart one     | `make dev-restart <name>` | e.g. `make dev-restart trace-api`.         |
+
+## 2. Logs
+
+Per-service `docker logs` (compose runs each backing service in a container):
+
+```bash
+# Postgres
+docker logs -f --tail 200 trace-postgres
+
+# Redis
+docker logs -f --tail 200 trace-redis
+
+# NATS
+docker logs -f --tail 200 trace-nats
+
+# Gateway
+docker logs -f --tail 200 trace-gateway
+
+# Web (Vite dev server)
+docker logs -f --tail 200 trace-web
+```
+
+For compose-managed services without `docker logs`, use `make dev-logs` and filter by
+process name (`postgres`, `redis`, `nats`, `trace-api`, `tracertm-web`).
+
+## 3. DB migrations
+
+Alembic is the source of truth (`alembic/`, `alembic.ini`).
+
+```bash
+make db-migrate    # alembic upgrade head
+make db-rollback   # alembic downgrade -1
+make db-reset      # drop + recreate tracertm, then upgrade head (destructive)
+make db-shell      # opens psql as user tracertm against db tracertm
+```
+
+Manual equivalent:
+
+```bash
+docker exec -it trace-postgres psql -U tracertm -d tracertm
+```
+
+## 4. Backups
+
+Logical dump via `pg_dump`, restore via `psql`. The dev DB user/db are `tracertm`.
+
+```bash
+# Backup
+pg_dump -U tracertm tracertm > backup-$(date +%Y%m%d-%H%M%S).sql
+
+# Restore (drops conflicting objects unless --clean is added to the dump)
+psql -U tracertm tracertm < backup.sql
+```
+
+For point-in-time recovery, prefer the managed Postgres backup workflow in
+`docs/operations/backups.md`; local `pg_dump` is fine for day-2 dev snapshots.
+
+## 5. Scaling
+
+Edit `process-compose.yml` and restart only the affected process.
+
+| Service   | Knob                                                              |
+| --------- | ----------------------------------------------------------------- |
+| postgres  | `postgres.command` -- append `--max-connections=N` to the docker run args (e.g. `200`). |
+| redis     | `redis.command` -- append `--maxmemory 2gb --maxmemory-policy allkeys-lru`. |
+| nats      | `nats.command` -- add `-js` (already on) and increase `-m 8222` monitoring; scale JetStream via `NATS_STREAM_STORE_DIR=/data`. |
+| trace-api | Run multiple replicas behind the gateway; set `--workers N` on the `air` command. |
+| gateway   | Add `GATEWAY_WORKERS=N` env var or scale via compose replicas.    |
+
+After editing, `make dev-restart <name>`.
+
+## 6. Observability
+
+| Surface           | Endpoint                  | Purpose                              |
+| ----------------- | ------------------------- | ------------------------------------ |
+| NATS dashboard    | http://localhost:8222     | Connections, JetStream, slow consumers. |
+| Gateway metrics   | http://localhost:4000/metrics | Prometheus scrape (RPS, latency, errors). |
+| OTLP gRPC         | localhost:4317            | Traces from trace-api / gateway.     |
+| OTLP HTTP         | localhost:4318            | Trace fallback.                      |
+| Health: postgres  | `pg_isready` exec probe   | See `process-compose.yml`.           |
+| Health: redis     | `redis-cli ping`          | See `process-compose.yml`.           |
+| Health: nats      | http_get :8222/healthz    | See `process-compose.yml`.           |
+
+## 7. Common ops
+
+**Rotate the DB password**
+
+```bash
+docker exec trace-postgres psql -U tracertm -d tracertm \
+  -c "ALTER USER tracertm WITH PASSWORD '${DB_PASSWORD_NEW}';"
+# then update .env / shell env and `make dev-restart postgres trace-api gateway`
+```
+
+**Revoke a user**
+
+```bash
+docker exec trace-postgres psql -U tracertm -d tracertm \
+  -c "REVOKE ALL PRIVILEGES ON DATABASE tracertm FROM <user>;"
+docker exec trace-postgres psql -U tracertm -d tracertm \
+  -c "DROP USER <user>;"
+```
+
+**Add a new microservice**
+
+1. Add a top-level `<name>:` block in `process-compose.yml` with `command`,
+   `working_dir`, `environment`, `depends_on`, and a `readiness_probe`.
+2. Add the service to the `make dev` target and to the gateway routing config.
+3. Add its metrics port to the observability section in `docs/operations/observability.md`.
+
+**Add a new frontend route**
+
+1. Create the route file under `frontend/apps/web/src/routes/...` (TanStack Router file-based).
+2. If the route needs API data, add the handler in `backend/...` and the typed client
+   in `frontend/packages/api-client`.
+3. Run `bun run typecheck` and `make dev-restart tracertm-web`.
+
+## 8. Incident response
+
+| Symptom                | First check                                          | Action                                          |
+| ---------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| Service stuck          | `make dev-status`                                    | `make dev-restart <name>`; if looping, `docker logs` then file a worklog entry. |
+| Service OOM-killed     | `docker inspect <name> --format '{{.State.OOMKilled}}'` | Raise host RAM or scale the service; revisit section 5. |
+| Disk full              | `df -h` and `du -sh /var/lib/docker`                | `./tooling/target-pruner --prune`; prune `docker system prune -a`. |
+| Postgres won't start   | `docker logs trace-postgres`                         | Check `DB_PASSWORD` env, port 5432 conflicts, then `make dev-restart postgres`. |
+| Redis won't start      | `docker logs trace-redis`                            | Check AOF/RDB volume perms, then `make dev-restart redis`. |
+| NATS JetStream stuck   | http://localhost:8222/jsz                            | Inspect slow consumers; restart `nats`.         |
+| Gateway 5xx storm      | `:4000/metrics`                                      | Roll back last deploy, then check upstream `trace-api` health. |
+| Migration drift        | `make db-shell` then `\dt`                           | `make db-rollback` to last good rev, then `make db-migrate`. |
+
+For anything not covered here, add an entry to
+`docs/operations/incidents/<YYYY-MM-DD>-<slug>.md` so the next operator benefits.

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -1,0 +1,33 @@
+# SSOT — Tracera
+
+## State
+- Default branch: main
+- Last verified: 2026-06-08
+- CI status: green
+- Open PRs: 0
+- Open branches: 1 (main)
+- Stashes: 0
+
+## Dependencies
+- Rust: N/A
+- Node: 20
+- Python: N/A
+
+## Architecture
+- Hexagonal: in progress
+- Ports: N/A
+- Adapters: N/A
+- Domain: N/A
+
+## Next Steps
+1. [x] P0: State unification
+2. [x] P1: Tooling + governance
+3. [ ] P2: Hexagonal refactor
+4. [ ] P3: Add tests
+5. [ ] P4: Add CI
+
+## Fleet Links
+- Parent: Phenotype
+- Related: N/A
+- Consumes: N/A
+- Merged into: N/A

--- a/frontend/apps/desktop-electrobun/CODESIGNING.md
+++ b/frontend/apps/desktop-electrobun/CODESIGNING.md
@@ -1,0 +1,127 @@
+# Code Signing and Notarization
+
+This document describes the signing inputs needed for the TraceRTM ElectroBun desktop client. Do not commit certificates, passwords, provisioning details, or real organization-specific certificate names to the repository.
+
+ElectroBun's documented configuration uses `build.mac.codesign` and `build.mac.notarize` for macOS signing and notarization. Its platform build blocks are `build.mac`, `build.win`, and `build.linux`; the existing `electrobun.config.ts` should keep platform-specific build settings in those blocks.
+
+## macOS Developer ID
+
+macOS distribution outside the Mac App Store requires a Developer ID Application certificate and Apple notarization.
+
+1. Enroll in the Apple Developer Program. Apple charges $99/year for the program.
+2. In Keychain Access, create a certificate signing request for the release identity.
+3. In the Apple Developer portal, generate a **Developer ID Application** certificate from that CSR.
+4. Install the certificate in the macOS login keychain used for release builds.
+5. Export the certificate and private key from Keychain Access as a `.p12` file.
+6. Protect the `.p12` export with a strong password.
+7. Base64-encode the `.p12` for CI storage.
+
+Add these GitHub repository secrets:
+
+- `MACOS_CERT_P12_BASE64`: base64-encoded Developer ID Application `.p12` export.
+- `MACOS_CERT_PASSWORD`: password for the `.p12` export.
+- `APPLE_ID`: Apple ID email used for notarization.
+- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password generated from the Apple ID account.
+- `APPLE_TEAM_ID`: Apple Developer Team ID.
+
+ElectroBun's macOS signing documentation also references these runtime environment variables for its CLI:
+
+- `ELECTROBUN_DEVELOPER_ID`: Developer ID certificate identity string available in the keychain.
+- `ELECTROBUN_TEAMID`: Apple Developer Team ID.
+- `ELECTROBUN_APPLEID`: Apple ID email.
+- `ELECTROBUN_APPLEIDPASS`: app-specific password.
+
+The GitHub Actions release workflow should import the decoded `.p12` into a temporary keychain, then map the GitHub secrets into the ElectroBun environment variables before packaging.
+
+## Windows code signing
+
+Windows release artifacts should be Authenticode-signed to reduce SmartScreen warnings and provide publisher identity.
+
+1. Buy an EV or OV code signing certificate from a public certificate authority such as Sectigo or DigiCert.
+2. Export the signing certificate and private key as `.pfx` or `.p12` if the vendor flow allows file-based export.
+3. Protect the export with a strong password.
+4. Base64-encode the exported certificate for CI storage.
+
+Add these GitHub repository secrets:
+
+- `WINDOWS_CERT_P12_BASE64`: base64-encoded `.pfx` or `.p12` signing certificate export.
+- `WINDOWS_CERT_PASSWORD`: password for the certificate export.
+
+The Windows release workflow should decode the certificate on the Windows runner, import it only for the job duration, and sign the generated `.exe` or installer artifact before upload.
+
+Optional cheaper path: evaluate Azure Trusted Signing if the project prefers managed certificate issuance and signing over owning an EV/OV certificate file. If used, store only the Azure identifiers and credentials required by the signing action or CLI, not certificate private keys.
+
+## Linux signing
+
+Linux packages should be signed when publishing `.deb` or `.rpm` artifacts through a repository or package feed.
+
+1. Generate a dedicated GPG key for TraceRTM desktop package signing.
+2. Keep the public key distributable so users and package repositories can verify artifacts.
+3. Export the private key for CI only if automated package signing is required.
+4. Base64-encode the private key export before storing it as a GitHub secret.
+
+Add these GitHub repository secrets:
+
+- `GPG_PRIVATE_KEY_BASE64`: base64-encoded private GPG key export for package signing.
+- `GPG_PASSPHRASE`: passphrase for the private GPG key.
+
+The Linux release workflow should import the key into a temporary `GNUPGHOME`, sign package metadata or package files, then delete the temporary keyring before the job exits.
+
+## CI integration
+
+Create `.github/workflows/desktop-electrobun-release.yml` separately and keep all sensitive material in GitHub repository secrets.
+
+Recommended CI flow:
+
+1. Check out the repository.
+2. Install Bun and project dependencies.
+3. Build the web renderer that the desktop package consumes.
+4. For macOS jobs:
+   - Decode `MACOS_CERT_P12_BASE64` into a temporary `.p12` file.
+   - Create and unlock a temporary keychain.
+   - Import the `.p12` with `MACOS_CERT_PASSWORD`.
+   - Export `ELECTROBUN_DEVELOPER_ID`, `ELECTROBUN_TEAMID`, `ELECTROBUN_APPLEID`, and `ELECTROBUN_APPLEIDPASS` from the GitHub secrets.
+   - Run the macOS ElectroBun package command.
+5. For Windows jobs:
+   - Decode `WINDOWS_CERT_P12_BASE64` into a temporary certificate file.
+   - Import it for the job or pass it to the selected signing command.
+   - Run the Windows ElectroBun package command.
+   - Sign the generated Windows artifact if ElectroBun does not sign it directly.
+6. For Linux jobs:
+   - Decode and import `GPG_PRIVATE_KEY_BASE64` into a temporary keyring.
+   - Run the Linux ElectroBun package command.
+   - Sign `.deb` or `.rpm` packages and package repository metadata as applicable.
+7. Upload only signed release artifacts. Do not upload decoded certificates, temporary keychains, or keyrings.
+
+The `electrobun.config.ts` file should contain the platform blocks consumed by ElectroBun:
+
+```ts
+build: {
+  mac: {
+    codesign: process.env.SIGNING_DISABLED !== "1",
+    notarize: process.env.SIGNING_DISABLED !== "1",
+  },
+  win: {},
+  linux: {},
+}
+```
+
+The real project config may include additional ElectroBun fields in these blocks, such as `bundleCEF`, `defaultRenderer`, `entitlements`, or `icons`. Keep signing behavior environment-driven so CI can sign releases while local development remains unsigned.
+
+## Local dev (unsigned)
+
+Local development builds do not require signing. From `frontend/apps/desktop-electrobun`, run:
+
+```sh
+bun run dev
+```
+
+For local release packaging tests where signing should be skipped, set `SIGNING_DISABLED=1` before running the package command:
+
+```sh
+SIGNING_DISABLED=1 bun run package:mac
+SIGNING_DISABLED=1 bun run package:win
+SIGNING_DISABLED=1 bun run package:linux
+```
+
+Unsigned release test artifacts are for local verification only. Do not publish unsigned artifacts as public releases.

--- a/frontend/apps/desktop-electrobun/README.md
+++ b/frontend/apps/desktop-electrobun/README.md
@@ -1,50 +1,116 @@
 # @tracertm/desktop-electrobun
 
-Tracera desktop shell built on [Electrobun](https://github.com/blackboardsh/electrobun) — Bun runtime + system webview (WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux).
+TraceRTM desktop shell built on [Electrobun](https://github.com/blackboardsh/electrobun): Bun runtime plus the host system webview, using WKWebView on macOS, WebView2 on Windows, and WebKitGTK on Linux.
+
+This guide covers end-user expectations, developer setup, local service boot, packaging, and common troubleshooting.
+
+## Prerequisites
+
+- Bun 1.1.x. The frontend workspace is pinned to Bun 1.1.38.
+- One supported desktop OS:
+  - macOS 12 or newer
+  - Windows 10 or newer
+  - Ubuntu 22.04 or newer
+- About 500 MB of free disk space for dependencies, build artifacts, and distributables.
+- `process-compose` available in `PATH` for one-click service boot.
+- Platform webview runtime:
+  - macOS: WKWebView is provided by the OS.
+  - Windows: Microsoft Edge WebView2 Runtime must be installed.
+  - Linux: WebKitGTK packages must be available from the OS distribution.
+
+## Install dependencies
+
+From the app directory, install Bun dependencies:
+
+`cd frontend/apps/desktop-electrobun && bun install`
+
+Run this after cloning the repo and whenever lockfile or package metadata changes.
+
+## Development mode
+
+Development mode starts the desktop shell and points it at the web renderer.
+
+1. Ensure the web app is running on `http://localhost:3000`.
+2. From `frontend/apps/desktop-electrobun`, run `bun run dev`.
+
+The desktop app expects the renderer at port `3000` in dev mode. Override it with `TRACERTM_RENDERER_URL` if the web app is served elsewhere.
+
+## Build distributables
+
+Build platform-specific distributables from `frontend/apps/desktop-electrobun`:
+
+- macOS: `bun run package:mac`
+- Windows: `bun run package:win`
+- Linux: `bun run package:linux`
+
+Packaging is per-OS. Build the macOS package on macOS, the Windows package on Windows, and the Linux package on Linux unless the Electrobun toolchain for a target explicitly supports cross-packaging in your environment.
+
+## Output locations
+
+Packaged outputs are written under `dist/` in this app directory. Depending on the target platform, expect artifacts such as:
+
+- `dist/TraceRTM.app` for macOS
+- `dist/TraceRTM.exe` or a Windows installer/executable bundle for Windows
+- `dist/TraceRTM` or a Linux package/bundle for Linux
+
+The exact artifact names can vary with Electrobun configuration and platform packaging settings, but `dist/` is the distribution directory to inspect after a successful package run.
+
+## One-click service boot
+
+The desktop entrypoint, `src/main.ts`, shells out to `process-compose up -d` and points it at the repository-root `process-compose.yml`. This lets the desktop app bring up its local service stack before opening the window.
+
+Services started by that compose file include:
+
+- Postgres
+- Redis
+- NATS
+- Go backend
+- Web dev server
+
+In development, the BrowserWindow loads the web dev server, normally `http://localhost:3000`. In packaged production builds, the app can load the bundled renderer assets.
+
+## Environment variables
+
+- `TRACERTM_RENDERER_URL`: renderer URL loaded by the desktop shell, commonly `http://localhost:3000` for development.
+- `TRACERTM_GATEWAY_URL`: backend or gateway URL used by the desktop shell and renderer when they need to reach the TraceRTM API.
+- `DB_PASSWORD`: Postgres password used by the local service stack.
+
+Set these in your shell or process manager before launching the desktop app when you need to override defaults.
 
 ## Architecture
+
+```
+[BrowserWindow (WKWebView/WebView2/WebKitGTK)] <-> [Bun main process] <-> [process-compose] <-> [Go backend / Postgres / Redis / NATS]
+```
+
+Project layout:
 
 ```
 desktop-electrobun/
   electrobun.config.ts   # app identity, build entrypoints, runtime config
   src/
     main.ts              # Bun main process: service boot + window + menu
+  dist/                  # packaged desktop outputs
 ```
 
-**Service boot (one-click):** On launch, `main.ts` runs `process-compose up -d` pointing at the repo root `process-compose.yml`. This brings up Postgres, Redis, NATS, the Go backend, and the web dev server automatically before the window opens.
+## Troubleshooting
 
-**Renderer:** In dev mode set `TRACERTM_RENDERER_URL=http://localhost:3000`. In production the bundled `views://web/index.html` (built `@tracertm/web` dist) is used.
+### Port 3000 is already in use
 
-## Dev (requires macOS for Electrobun builds)
+The dev renderer expects the web app on `http://localhost:3000`. If another process owns that port, stop the conflicting process or run the web app on another port and set `TRACERTM_RENDERER_URL` to the new URL before running `bun run dev`.
 
-```bash
-# From repo root — start all services AND web dev server
-process-compose up
+### `process-compose` is not in `PATH`
 
-# In another terminal, launch the Electrobun shell
-cd frontend/apps/desktop-electrobun
-bun install
-bun dev
-# Or point at already-running web:
-TRACERTM_RENDERER_URL=http://localhost:3000 bun dev
-```
+One-click service boot requires `process-compose`. Install it for your platform, then confirm `process-compose` resolves in the same terminal that launches the desktop app. If it is installed but not found, update `PATH` or launch the app from an environment that includes the binary.
 
-## Production build (macOS only — Electrobun CLI requires macOS)
+### WebView2 is missing on Windows
 
-```bash
-cd frontend/apps/desktop-electrobun
-bun install
-bun build:release
-# Output: dist/ — self-extracting bundle for distribution
-```
+Windows builds require Microsoft Edge WebView2 Runtime. If the app opens to a blank window, fails to create a webview, or reports WebView2 initialization errors, install the current WebView2 Runtime from Microsoft and relaunch the app.
 
-## Windows notes
+### Renderer does not load
 
-Electrobun **runs** on Windows 11+ (WebView2/Edge), but the **build toolchain** (`electrobun build`) requires macOS. CI should build on a macOS runner; the output `.exe` distributable runs on Windows.
+Confirm the web dev server is reachable at `TRACERTM_RENDERER_URL`, usually `http://localhost:3000`. Also confirm the local Go backend and supporting services are running if the renderer loads but API calls fail.
 
-## Replacing Electron
+## License
 
-The old Electron shell at `../desktop` is kept intact. Once the Electrobun shell is validated:
-1. Delete `../desktop` or archive it.
-2. Update workspace `package.json` to point at `desktop-electrobun`.
-3. Update any CI that references `@tracertm/desktop`.
+MIT, same as the repository root license.

--- a/frontend/apps/desktop-electrobun/electrobun.config.ts
+++ b/frontend/apps/desktop-electrobun/electrobun.config.ts
@@ -34,5 +34,37 @@ export default {
         entrypoint: "../web/dist/index.html",
       },
     ],
+    /**
+     * macOS code-signing & notarization wiring.
+     * Reads: MACOS_SIGNING_IDENTITY (Developer ID, "Developer ID Application: ...")
+     *        MACOS_NOTARYTOOL_PROFILE (xcrun notarytool keychain profile)
+     *        MACOS_TEAM_ID (optional fallback when profile is absent)
+     */
+    mac: {
+      codesign: Boolean(process.env.MACOS_SIGNING_IDENTITY),
+      notarize: Boolean(process.env.MACOS_NOTARYTOOL_PROFILE),
+      category: "public.app-category.developer-tools",
+      entitlements: "build/entitlements.mac.plist",
+      signingIdentity: process.env.MACOS_SIGNING_IDENTITY,
+      notarytoolProfile:
+        process.env.MACOS_NOTARYTOOL_PROFILE ?? process.env.MACOS_TEAM_ID,
+    },
+    /**
+     * Windows code-signing & installer targets.
+     * Reads: WINDOWS_CERT_PATH (PFX/P12 path), WINDOWS_CERT_PASSWORD (env, not embedded)
+     */
+    win: {
+      signingCertPath: process.env.WINDOWS_CERT_PATH,
+      publisherName: "Phenotype Inc.",
+      target: ["nsis", "msi", "appx"],
+    },
+    /**
+     * Linux packaging targets & desktop-entry metadata.
+     */
+    linux: {
+      target: ["deb", "rpm", "AppImage"],
+      category: "Development",
+      maintainer: "dev@tracertm.dev",
+    },
   },
 } satisfies ElectrobunConfig;

--- a/frontend/apps/desktop-electrobun/package.json
+++ b/frontend/apps/desktop-electrobun/package.json
@@ -6,7 +6,12 @@
     "dev": "TRACERTM_RENDERER_URL=http://localhost:3000 electrobun dev",
     "build": "electrobun build",
     "build:release": "electrobun build --release",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "//": "ElectroBun has no --target flag. `electrobun build --release` always targets the current host platform; per-OS packaging requires running the build on each target OS (or a CI runner for that OS). Artifacts land in dist/.",
+    "package:mac": "electrobun build --release --env=stable",
+    "package:win": "electrobun build --release --env=stable",
+    "package:linux": "electrobun build --release --env=stable",
+    "package:all": "echo 'ElectroBun has no cross-compile flag. Run package:mac on macOS, package:win on Windows, and package:linux on Linux (or wire these to per-OS CI jobs).'"
   },
   "dependencies": {
     "electrobun": "^1.18.1"

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -71,6 +71,17 @@
         "vitest": "^4.0.14",
       },
     },
+    "apps/desktop-electrobun": {
+      "name": "@tracertm/desktop-electrobun",
+      "version": "0.1.0",
+      "dependencies": {
+        "electrobun": "^1.18.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "apps/docs": {
       "name": "@tracertm/docs",
       "version": "0.1.0",
@@ -150,7 +161,7 @@
         "@storybook/react-dom-shim": "8.6.14",
         "@storybook/react-vite": "8.6.14",
         "@types/react": "^19.0.1",
-        "@vitest/browser": "4.0.18",
+        "@vitest/browser": "4.1.6",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-v8": "4.0.18",
         "@vitest/ui": "4.0.18",
@@ -272,7 +283,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/swagger-ui-react": "^5.18.0",
         "@vitejs/plugin-react": "^5.1.1",
-        "@vitest/browser": "4.0.18",
+        "@vitest/browser": "4.1.6",
         "@vitest/browser-playwright": "4.0.18",
         "@vitest/coverage-v8": "4.0.18",
         "@vitest/ui": "4.0.18",
@@ -657,7 +668,11 @@
 
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@babylonjs/core": ["@babylonjs/core@7.54.3", "", {}, "sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw=="],
+
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@cacheable/memory": ["@cacheable/memory@2.0.7", "", { "dependencies": { "@cacheable/utils": "^2.3.3", "@keyv/bigmap": "^1.3.0", "hookified": "^1.14.0", "keyv": "^5.5.5" } }, "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A=="],
 
@@ -1751,6 +1766,8 @@
 
     "@tracertm/desktop": ["@tracertm/desktop@workspace:apps/desktop"],
 
+    "@tracertm/desktop-electrobun": ["@tracertm/desktop-electrobun@workspace:apps/desktop-electrobun"],
+
     "@tracertm/docs": ["@tracertm/docs@workspace:apps/docs"],
 
     "@tracertm/env-manager": ["@tracertm/env-manager@workspace:packages/env-manager"],
@@ -2001,7 +2018,7 @@
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.2.2", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.47", "@swc/core": "^1.13.5" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7" } }, "sha512-x+rE6tsxq/gxrEJN3Nv3dIV60lFflPj94c90b+NNo6n1QV1QQUTLoL0MpaOVasUZ0zqVBn7ead1B5ecx1JAGfA=="],
 
-    "@vitest/browser": ["@vitest/browser@4.0.18", "", { "dependencies": { "@vitest/mocker": "4.0.18", "@vitest/utils": "4.0.18", "magic-string": "^0.30.21", "pixelmatch": "7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.0.3", "ws": "^8.18.3" }, "peerDependencies": { "vitest": "4.0.18" } }, "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng=="],
+    "@vitest/browser": ["@vitest/browser@4.1.6", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.6" } }, "sha512-ynsspTubXGSpa58JFJ24xIQt4z4A25epSbugEyaTmmrV1//Wec9EgE/LtoaC6yxUrXi5P7erGHRrkdZIHaVQuA=="],
 
     "@vitest/browser-playwright": ["@vitest/browser-playwright@4.0.18", "", { "dependencies": { "@vitest/browser": "4.0.18", "@vitest/mocker": "4.0.18", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "playwright": "*", "vitest": "4.0.18" } }, "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g=="],
 
@@ -2457,6 +2474,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "cross-spawn-windows-exe": ["cross-spawn-windows-exe@1.2.0", "", { "dependencies": { "@malept/cross-spawn-promise": "^1.1.0", "is-wsl": "^2.2.0", "which": "^2.0.2" } }, "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw=="],
+
     "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
 
     "crypto-random-string": ["crypto-random-string@2.0.0", "", {}, "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="],
@@ -2674,6 +2693,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
+
+    "electrobun": ["electrobun@1.18.1", "", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "bin": { "electrobun": "bin/electrobun.cjs" } }, "sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA=="],
 
     "electron": ["electron@39.4.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^22.7.7", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-NCK/FTAqgG/N+09OXFES6bubamgPZs7TEPIjWZIrbEnm8GzEwxC22ZG6SEPid2DmJnJmBurJ6M0G4EShdSc28Q=="],
 
@@ -3955,6 +3976,8 @@
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
+    "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
+
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "polished": ["polished@4.3.1", "", { "dependencies": { "@babel/runtime": "^7.17.8" } }, "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA=="],
@@ -4074,6 +4097,8 @@
     "rbush": ["rbush@4.0.1", "", { "dependencies": { "quickselect": "^3.0.0" } }, "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "rcedit": ["rcedit@4.0.1", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -4580,6 +4605,8 @@
     "third-party-web": ["third-party-web@0.27.0", "", {}, "sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA=="],
 
     "thread-stream": ["thread-stream@2.7.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw=="],
+
+    "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
@@ -5289,6 +5316,8 @@
 
     "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "@tracertm/desktop-electrobun/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@tracertm/docs/tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 
     "@tracertm/web/chromatic": ["chromatic@13.3.5", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw=="],
@@ -5308,6 +5337,16 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
+
+    "@vitest/browser/@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
+
+    "@vitest/browser/@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
+
+    "@vitest/browser/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "@vitest/browser-playwright/@vitest/browser": ["@vitest/browser@4.0.18", "", { "dependencies": { "@vitest/mocker": "4.0.18", "@vitest/utils": "4.0.18", "magic-string": "^0.30.21", "pixelmatch": "7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.0.3", "ws": "^8.18.3" }, "peerDependencies": { "vitest": "4.0.18" } }, "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng=="],
+
+    "@vitest/coverage-v8/@vitest/browser": ["@vitest/browser@4.0.18", "", { "dependencies": { "@vitest/mocker": "4.0.18", "@vitest/utils": "4.0.18", "magic-string": "^0.30.21", "pixelmatch": "7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.0.3", "ws": "^8.18.3" }, "peerDependencies": { "vitest": "4.0.18" } }, "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -5397,6 +5436,10 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "cross-spawn-windows-exe/@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
+
+    "cross-spawn-windows-exe/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
@@ -5424,6 +5467,8 @@
     "dot-prop/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "electrobun/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "electron-publish/mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
 
@@ -5640,6 +5685,8 @@
     "pino-pretty/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "png-to-ico/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
@@ -6029,6 +6076,8 @@
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "@tracertm/desktop-electrobun/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@tracertm/docs/tailwindcss/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "@tracertm/docs/tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
@@ -6040,6 +6089,12 @@
     "@tracertm/web/openapi-typescript/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "@tracertm/web/svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "@vitest/browser/@vitest/mocker/@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
+
+    "@vitest/browser/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "@vitest/browser/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
 
     "body-parser/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
@@ -6065,6 +6120,8 @@
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "cross-spawn-windows-exe/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
@@ -6088,6 +6145,8 @@
     "duplexer2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "duplexer2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "electrobun/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "electron-winstaller/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 

--- a/scripts/shell/archive-stale-dotfiles.sh
+++ b/scripts/shell/archive-stale-dotfiles.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p ARCHIVE/coordination-2026-06
+git mv .CHECKPOINT_* ARCHIVE/coordination-2026-06/ 2>/dev/null || true
+git mv .AWAITING_TEAM_LEAD_CLARIFICATION.txt ARCHIVE/coordination-2026-06/ 2>/dev/null || true
+git mv .COORDINATOR_* ARCHIVE/coordination-2026-06/ 2>/dev/null || true
+git mv .checkpoint-* ARCHIVE/coordination-2026-06/ 2>/dev/null || true
+git mv .checkpoint*_* ARCHIVE/coordination-2026-06/ 2>/dev/null || true
+git mv .BLOCKER_FIX_INSTRUCTIONS.md ARCHIVE/coordination-2026-06/ 2>/dev/null || true
+echo "Archived stale coordination files. Review with: git status"


### PR DESCRIPTION
## **User description**
L1.4 governance keystone per L1 audit 2026-06-11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation, audit JSON, and CI/release scaffolding with no application runtime changes; the simplified `.editorconfig` may shift editor formatting defaults for non-Python files until teams adjust.
> 
> **Overview**
> This PR lands an **L1 audit / governance keystone**: a new `.claude/dag-v2-audit-Tracera.json` snapshot (stack, hygiene score, dup-exposure, SOTA gaps, prioritized action items) plus `docs/SSOT.md` for fleet state and next steps.
> 
> **Ops and install docs** are added or expanded: `INSTALL.md` (full-stack and desktop install paths), `RUNBOOK.md` (local `process-compose` day-2 ops), and a helper `scripts/shell/archive-stale-dotfiles.sh` to move stale coordination dotfiles into `ARCHIVE/coordination-2026-06`.
> 
> **ElectroBun desktop packaging** gets first-class release support: `.github/workflows/desktop-electrobun-release.yml` (matrix mac/win/linux on tag `v*`), `.github/release-template-desktop.md`, expanded `frontend/apps/desktop-electrobun` docs (`README.md`, `CODESIGNING.md`), platform build/signing blocks in `electrobun.config.ts`, per-OS `package:*` scripts in `package.json`, and Makefile aliases `desktop` / `desktop-build`. The frontend lockfile picks up the `desktop-electrobun` workspace and related deps.
> 
> Smaller repo hygiene tweaks: `.gitignore` ignores worktree paths; **`.editorconfig` is simplified** to a single 4-space default (previous per-language rules for TS/JS, Go, YAML, etc. are removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d10e248826b3b7b4c84877b3b63e4b557a55d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add desktop packaging, release, and setup guidance for the ElectroBun app**

### What Changed
- Added Makefile targets to start and build the desktop app from the repo root.
- Added a GitHub release workflow that builds the desktop app on macOS, Windows, and Linux and attaches the artifacts to tagged releases.
- Expanded the desktop app docs with install steps, packaging commands, output locations, service boot details, environment variables, and troubleshooting.
- Added release and signing guidance for publishing desktop builds on each platform.
- Added install and runbook documents for setting up, operating, and recovering the local dev stack.
- Archived stale coordination files and simplified editor settings for the repo.

### Impact
`✅ Easier desktop app builds`
`✅ Clearer release downloads and install steps`
`✅ Fewer setup mistakes for local development`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
