### PR TITLE
chore(gitignore): add /worktrees/ and /*-wtrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ __pycache__/
 .claudeignore
 .llmignore
 .hypothesis/
+/worktrees/
+/*-wtrees/


### PR DESCRIPTION
L1.4 governance keystone per L1 audit 2026-06-11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore rules with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds two **`.gitignore`** entries so local Git worktree checkouts are not tracked: **`/worktrees/`** at the repo root and **`/*-wtrees/`** for sibling directories whose names end in **`-wtrees`**.
> 
> This is a repo hygiene / L1 governance change only; nothing in application or CI behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c59c9e10b7504970fcabc781704939b6a05a6561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->