### PR TITLE
chore(Tracera): add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,104 @@
+# justfile for Tracera
+# Polyglot workspace: TypeScript/Bun (frontend + TUI) and Python/uv (backend).
+# The repo's `make` and `bun` scripts remain canonical; this is a thin
+# convenience layer on top. Use `just` (or `just <recipe>`) to run recipes.
+# `just` is the casey/just command runner: https://just.systems
+
+set shell := ["bash", "-uc"]
+set dotenv-load
+
+# ---- Detected features (eval once, exported as env vars) ----
+
+export HAS_ROOT_PACKAGE := `test -f package.json && echo 1 || echo 0`
+export HAS_PYPROJECT := `test -f pyproject.toml && echo 1 || echo 0`
+export HAS_UV := `command -v uv >/dev/null 2>&1 && echo 1 || echo 0`
+export HAS_MAKE := `command -v make >/dev/null 2>&1 && echo 1 || echo 0`
+export JS_RUNNER := `command -v bun >/dev/null 2>&1 && echo bun || (command -v pnpm >/dev/null 2>&1 && echo pnpm || echo npm)`
+
+# ---- Default recipe: list available recipes ----
+
+default: list
+
+# Show all available recipes
+list:
+    @just --list
+
+# ---- Dev: start the TUI dev environment (delegates to the project's Makefile) ----
+
+dev:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_MAKE}" = "1" ]; then
+      make dev
+    else
+      ${JS_RUNNER} run dev
+    fi
+
+# ---- Build: produce release artifacts for both frontend and backend ----
+
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_MAKE}" = "1" ] && make -n build >/dev/null 2>&1; then
+      make build
+    elif [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+      ${JS_RUNNER} run build
+    fi
+
+# ---- Test: run the test suite (frontend + python) ----
+
+test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_MAKE}" = "1" ]; then
+      make test
+    else
+      if [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+        ${JS_RUNNER} test
+      fi
+      if [ "${HAS_PYPROJECT}" = "1" ] && [ "${HAS_UV}" = "1" ]; then
+        uv run pytest
+      fi
+    fi
+
+# ---- Lint: ruff for Python, eslint/biome for the frontend ----
+
+lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_PYPROJECT}" = "1" ] && [ "${HAS_UV}" = "1" ]; then
+      uv run ruff check .
+    fi
+
+    if [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+      ${JS_RUNNER} run lint || true
+    fi
+
+# ---- Fmt: apply formatter ----
+
+fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "${HAS_PYPROJECT}" = "1" ] && [ "${HAS_UV}" = "1" ]; then
+      uv run ruff format .
+    fi
+
+    if [ "${HAS_ROOT_PACKAGE}" = "1" ]; then
+      ${JS_RUNNER} run format || ${JS_RUNNER} run fix || true
+    fi
+
+# ---- Clean: remove generated artifacts ----
+
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    rm -rf node_modules dist .turbo .next build
+    rm -rf .venv __pycache__ .pytest_cache .mypy_cache .ruff_cache
+    rm -rf frontend/node_modules frontend/dist frontend/.turbo frontend/.next
+    find . -type d -name '__pycache__' -prune -exec rm -rf {} +


### PR DESCRIPTION
## **User description**
L1.4 governance keystone per L1 audit 2026-06-11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only addition with no runtime or application logic changes; the only operational note is that `just clean` aggressively deletes local caches and dependencies.
> 
> **Overview**
> Adds a root **`justfile`** so contributors can run common workspace tasks via **`just`** without replacing existing **`make`** or **`bun`** scripts.
> 
> It **detects** the environment (`package.json`, `pyproject.toml`, **`uv`**, **`make`**, and **`bun`/`pnpm`/`npm`**) and exposes recipes for **`dev`**, **`build`**, **`test`**, **`lint`**, **`fmt`**, and **`clean`**. **`dev`**, **`build`**, and **`test`** prefer **`make`** when available; otherwise they fall back to the JS package runner and, for Python, **`uv run pytest`**. **`lint`**/**`fmt`** run **`ruff`** when Python is present and attempt frontend **`lint`**/**`format`**/**`fix`** with failures tolerated via **`|| true`**. **`clean`** removes common JS/Python build and cache directories (including **`frontend/`** artifacts).
> 
> The default recipe lists available commands via **`just --list`**, and **`.env`** loading is enabled for recipes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25378289ae3ab2d36035e3f55cfc47c621361849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a justfile for common project commands**

### What Changed
- Adds a `just` command list for running dev, build, test, lint, format, and clean tasks from one place
- Uses existing project tools when they are available, so the same commands work across the frontend and backend
- Makes `just` show the available recipes by default

### Impact
`✅ Easier local development`
`✅ Faster access to test and lint commands`
`✅ Simpler cleanup of generated files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
