### PR TITLE
feat(tracera-core): Phase 3 impact analysis (blast_radius + impact)

### DIFF
--- a/backend/internal/ml/registry.go
+++ b/backend/internal/ml/registry.go
@@ -1,0 +1,247 @@
+package ml
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+)
+
+var (
+	safePartPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+	semverPattern   = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$`)
+)
+
+const indexFile = "registry.json"
+
+type Format string
+
+const (
+	FormatSklearn Format = "sklearn"
+	FormatPytorch Format = "pytorch"
+	FormatONNX    Format = "onnx"
+)
+
+type ModelEntry struct {
+	Name         string            `json:"name"`
+	Version      string            `json:"version"`
+	SHA256       string            `json:"sha256"`
+	Format       Format            `json:"format"`
+	ArtifactPath string            `json:"artifact_path"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+}
+
+type pinnedVersion struct {
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+}
+
+type registryIndex struct {
+	Models map[string]map[string]ModelEntry `json:"models"`
+	Pins   map[string]pinnedVersion         `json:"pins"`
+}
+
+type ModelRegistry struct {
+	root string
+}
+
+func NewModelRegistry(root string) (*ModelRegistry, error) {
+	if err := os.MkdirAll(filepath.Join(root, "models"), 0o755); err != nil {
+		return nil, err
+	}
+	return &ModelRegistry{root: root}, nil
+}
+
+func (r *ModelRegistry) Save(
+	name string,
+	version string,
+	model []byte,
+	format Format,
+	metadata map[string]string,
+) (ModelEntry, error) {
+	if err := validateName(name); err != nil {
+		return ModelEntry{}, err
+	}
+	if err := validateVersion(version); err != nil {
+		return ModelEntry{}, err
+	}
+	ext, err := extensionFor(format)
+	if err != nil {
+		return ModelEntry{}, err
+	}
+
+	index, err := r.readIndex()
+	if err != nil {
+		return ModelEntry{}, err
+	}
+	if index.Models[name] == nil {
+		index.Models[name] = map[string]ModelEntry{}
+	}
+	if _, exists := index.Models[name][version]; exists {
+		return ModelEntry{}, fmt.Errorf("model %q version %q already exists", name, version)
+	}
+
+	sum := sha256.Sum256(model)
+	digest := hex.EncodeToString(sum[:])
+	blobDir := filepath.Join(r.root, "models", name, version, "blobs")
+	if err := os.MkdirAll(blobDir, 0o755); err != nil {
+		return ModelEntry{}, err
+	}
+	artifact := filepath.Join(blobDir, digest+ext)
+	if err := os.WriteFile(artifact, model, 0o644); err != nil {
+		return ModelEntry{}, err
+	}
+	rel, err := filepath.Rel(r.root, artifact)
+	if err != nil {
+		return ModelEntry{}, err
+	}
+
+	entry := ModelEntry{
+		Name:         name,
+		Version:      version,
+		SHA256:       digest,
+		Format:       format,
+		ArtifactPath: filepath.ToSlash(rel),
+		Metadata:     metadata,
+		CreatedAt:    time.Now().UTC(),
+	}
+	index.Models[name][version] = entry
+	index.Pins[name] = pinnedVersion{Version: version, SHA256: digest}
+	return entry, r.writeIndex(index)
+}
+
+func (r *ModelRegistry) Load(name string, version string) ([]byte, ModelEntry, error) {
+	entry, err := r.Get(name, version)
+	if err != nil {
+		return nil, ModelEntry{}, err
+	}
+	payload, err := os.ReadFile(filepath.Join(r.root, filepath.FromSlash(entry.ArtifactPath)))
+	if err != nil {
+		return nil, ModelEntry{}, err
+	}
+	sum := sha256.Sum256(payload)
+	if hex.EncodeToString(sum[:]) != entry.SHA256 {
+		return nil, ModelEntry{}, errors.New("model artifact SHA256 mismatch")
+	}
+	return payload, entry, nil
+}
+
+func (r *ModelRegistry) Get(name string, version string) (ModelEntry, error) {
+	index, err := r.readIndex()
+	if err != nil {
+		return ModelEntry{}, err
+	}
+	versions := index.Models[name]
+	if len(versions) == 0 {
+		return ModelEntry{}, fmt.Errorf("model %q is not registered", name)
+	}
+	resolved := version
+	if resolved == "" {
+		pin, ok := index.Pins[name]
+		if !ok {
+			return ModelEntry{}, fmt.Errorf("model %q has no pinned version", name)
+		}
+		resolved = pin.Version
+	}
+	entry, ok := versions[resolved]
+	if !ok {
+		return ModelEntry{}, fmt.Errorf("model %q version %q is not registered", name, resolved)
+	}
+	if version == "" {
+		pin := index.Pins[name]
+		if entry.SHA256 != pin.SHA256 {
+			return ModelEntry{}, errors.New("pinned model SHA256 mismatch")
+		}
+	}
+	return entry, nil
+}
+
+func (r *ModelRegistry) List(name string) ([]ModelEntry, error) {
+	index, err := r.readIndex()
+	if err != nil {
+		return nil, err
+	}
+	var entries []ModelEntry
+	for modelName, versions := range index.Models {
+		if name != "" && modelName != name {
+			continue
+		}
+		for _, entry := range versions {
+			entries = append(entries, entry)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].CreatedAt.After(entries[j].CreatedAt)
+	})
+	return entries, nil
+}
+
+func (r *ModelRegistry) Pin(name string, version string) (ModelEntry, error) {
+	index, err := r.readIndex()
+	if err != nil {
+		return ModelEntry{}, err
+	}
+	entry, err := r.Get(name, version)
+	if err != nil {
+		return ModelEntry{}, err
+	}
+	index.Pins[name] = pinnedVersion{Version: entry.Version, SHA256: entry.SHA256}
+	return entry, r.writeIndex(index)
+}
+
+func (r *ModelRegistry) readIndex() (registryIndex, error) {
+	index := registryIndex{
+		Models: map[string]map[string]ModelEntry{},
+		Pins:   map[string]pinnedVersion{},
+	}
+	payload, err := os.ReadFile(filepath.Join(r.root, indexFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return index, nil
+	}
+	if err != nil {
+		return index, err
+	}
+	return index, json.Unmarshal(payload, &index)
+}
+
+func (r *ModelRegistry) writeIndex(index registryIndex) error {
+	payload, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(r.root, indexFile), append(payload, '\n'), 0o644)
+}
+
+func extensionFor(format Format) (string, error) {
+	switch format {
+	case FormatSklearn:
+		return ".joblib", nil
+	case FormatPytorch:
+		return ".pt", nil
+	case FormatONNX:
+		return ".onnx", nil
+	default:
+		return "", fmt.Errorf("unsupported model format %q", format)
+	}
+}
+
+func validateName(value string) error {
+	if value == "" || !safePartPattern.MatchString(value) {
+		return fmt.Errorf("invalid model name %q", value)
+	}
+	return nil
+}
+
+func validateVersion(value string) error {
+	if value == "" || !safePartPattern.MatchString(value) || !semverPattern.MatchString(value) {
+		return fmt.Errorf("version must be semver: %q", value)
+	}
+	return nil
+}

--- a/backend/internal/ml/registry_test.go
+++ b/backend/internal/ml/registry_test.go
@@ -1,0 +1,102 @@
+package ml
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveLoadAndListContentAddressedModel(t *testing.T) {
+	registry, err := NewModelRegistry(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := registry.Save("ranker", "1.0.0", []byte("weights-v1"), FormatSklearn, map[string]string{"auc": "0.7"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := registry.Save("ranker", "1.1.0", []byte("weights-v2"), FormatSklearn, map[string]string{"auc": "0.9"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := registry.List("ranker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].Version != "1.1.0" {
+		t.Fatalf("unexpected entries: %#v", entries)
+	}
+	if first.SHA256 == second.SHA256 {
+		t.Fatal("different payloads should produce different SHA256 pins")
+	}
+	if filepath.ToSlash(second.ArtifactPath)[:len("models/ranker/1.1.0/blobs/")] != "models/ranker/1.1.0/blobs/" {
+		t.Fatalf("unexpected artifact path: %s", second.ArtifactPath)
+	}
+}
+
+func TestPinnedLoadUsesExactVersionAndSHA(t *testing.T) {
+	registry, err := NewModelRegistry(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Save("classifier", "1.0.0", []byte("old"), FormatPytorch, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Save("classifier", "1.1.0", []byte("new"), FormatPytorch, nil); err != nil {
+		t.Fatal(err)
+	}
+	pinned, err := registry.Pin("classifier", "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, entry, err := registry.Load("classifier", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.Version != pinned.Version || entry.SHA256 != pinned.SHA256 || !bytes.Equal(payload, []byte("old")) {
+		t.Fatalf("unexpected pinned load: %#v %q", entry, payload)
+	}
+}
+
+func TestONNXAdapterExtension(t *testing.T) {
+	registry, err := NewModelRegistry(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry, err := registry.Save("detector", "2.0.0", []byte("onnx"), FormatONNX, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if filepath.Ext(entry.ArtifactPath) != ".onnx" {
+		t.Fatalf("expected .onnx artifact, got %s", entry.ArtifactPath)
+	}
+	payload, _, err := registry.Load("detector", "2.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(payload, []byte("onnx")) {
+		t.Fatalf("unexpected payload %q", payload)
+	}
+}
+
+func TestRejectsNonSemverAndDuplicateVersion(t *testing.T) {
+	registry, err := NewModelRegistry(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := registry.Save("embedder", "v1", []byte("bad"), FormatSklearn, nil); err == nil {
+		t.Fatal("expected non-semver version to fail")
+	}
+	if _, err := registry.Save("embedder", "1.0.0", []byte("first"), FormatSklearn, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Save("embedder", "1.0.0", []byte("second"), FormatSklearn, nil); err == nil {
+		t.Fatal("expected duplicate version to fail")
+	}
+}

--- a/crates/tracera-core/src/impact.rs
+++ b/crates/tracera-core/src/impact.rs
@@ -1,0 +1,430 @@
+//! Impact scoring (Phase 3 of the 2026-06-09 Tracera decouple plan).
+//!
+//! Ported from `Tracera/src/tracertm/services/blast_radius_service.py` (BFS-based blast radius)
+//! and `Tracera/src/tracertm/services/impact_analysis_service.py` (weighted impact scoring).
+//!
+//! Given a set of changed artifacts, compute:
+//! - the **blast radius**: every artifact transitively reachable via trace links
+//! - the **impact score**: weighted sum of affected artifacts (with kind weights and confidence)
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use serde::{Deserialize, Serialize};
+
+use crate::ids::RequirementId;
+use crate::{ArtifactRef, CoverageMatrix, LinkKind, TraceLink, TraceLinkType};
+
+/// Configuration for impact scoring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImpactConfig {
+    /// Per-artifact-kind weights (test/code/requirement/etc.).
+    pub kind_weights: HashMap<String, f32>,
+    /// Maximum BFS depth (0 = unbounded).
+    pub max_depth: u32,
+    /// Multiplier for ConflictsWith links (negative impact).
+    pub conflict_multiplier: f32,
+    /// Multiplier for Refines/Satisfies/Implements links.
+    pub positive_multiplier: f32,
+}
+
+impl Default for ImpactConfig {
+    fn default() -> Self {
+        let mut kind_weights = HashMap::new();
+        kind_weights.insert("requirement".to_string(), 1.0);
+        kind_weights.insert("nfr".to_string(), 1.5);
+        kind_weights.insert("test".to_string(), 0.5);
+        kind_weights.insert("code".to_string(), 0.8);
+        kind_weights.insert("evidence".to_string(), 0.2);
+        kind_weights.insert("journey".to_string(), 0.4);
+        kind_weights.insert("agent".to_string(), 0.3);
+        kind_weights.insert("document".to_string(), 0.2);
+        kind_weights.insert("design".to_string(), 0.7);
+        kind_weights.insert("risk".to_string(), 1.2);
+        kind_weights.insert("rationale".to_string(), 0.3);
+        Self {
+            kind_weights,
+            max_depth: 10,
+            conflict_multiplier: -1.5,
+            positive_multiplier: 1.0,
+        }
+    }
+}
+
+/// One node in the blast radius.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BlastNode {
+    pub artifact: ArtifactRef,
+    pub depth: u32,
+    pub via: Vec<TraceLinkType>,
+    pub score: f32,
+}
+
+/// Result of a blast-radius / impact computation.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ImpactReport {
+    pub seeds: Vec<ArtifactRef>,
+    pub blast: Vec<BlastNode>,
+    pub total_score: f32,
+    pub by_kind: HashMap<String, f32>,
+    pub truncated: bool,
+    pub max_depth_seen: u32,
+    pub conflicts: Vec<TraceLink>,
+}
+
+impl ImpactReport {
+    pub fn affected_kinds(&self) -> HashSet<String> {
+        self.by_kind.keys().cloned().collect()
+    }
+}
+
+/// Compute the impact report for a set of seed artifacts, given a coverage matrix.
+pub fn compute_impact(
+    matrix: &CoverageMatrix,
+    seeds: &[ArtifactRef],
+    cfg: &ImpactConfig,
+) -> ImpactReport {
+    let mut report = ImpactReport {
+        seeds: seeds.to_vec(),
+        ..Default::default()
+    };
+
+    // Build adjacency: for each (from, to) cell, surface the trace links as directed edges
+    // in both directions (so we can traverse the graph either way).
+    let mut adj: HashMap<String, Vec<(String, &TraceLink)>> = HashMap::new();
+    for cell in matrix.cells.values() {
+        for link in &cell.trace_links {
+            let from = artifact_key(&link.from);
+            let to = artifact_key(&link.to);
+            adj.entry(from).or_default().push((to.clone(), link));
+            adj.entry(to).or_default().push((from.clone(), link));
+        }
+    }
+
+    // BFS from each seed
+    let mut visited: HashMap<String, BlastNode> = HashMap::new();
+    for seed in seeds {
+        let seed_key = artifact_key(seed);
+        let weight = kind_weight(&seed_key, cfg);
+        visited.entry(seed_key.clone()).or_insert(BlastNode {
+            artifact: seed.clone(),
+            depth: 0,
+            via: vec![],
+            score: weight,
+        });
+    }
+
+    let mut queue: VecDeque<(String, u32, f32, Vec<TraceLinkType>)> = VecDeque::new();
+    for seed in seeds {
+        queue.push_back((artifact_key(seed), 0, 1.0, vec![]));
+    }
+
+    let mut conflicts = Vec::new();
+    let mut max_depth_seen = 0;
+
+    while let Some((node_key, depth, decay, via_types)) = queue.pop_front() {
+        max_depth_seen = max_depth_seen.max(depth);
+        if cfg.max_depth > 0 && depth >= cfg.max_depth {
+            report.truncated = true;
+            continue;
+        }
+        if let Some(neighbors) = adj.get(&node_key) {
+            for (nbr_key, link) in neighbors {
+                let nbr_artifact = parse_artifact_key(nbr_key);
+                let link_multiplier = match link.link_type {
+                    TraceLinkType::Satisfies | TraceLinkType::Implements | TraceLinkType::Refines => {
+                        cfg.positive_multiplier
+                    }
+                    TraceLinkType::ConflictsWith => cfg.conflict_multiplier,
+                    _ => 0.0,
+                };
+                let edge_score = link.confidence * link_multiplier * decay;
+                let weight = kind_weight(nbr_key, cfg);
+                let score = weight * edge_score.abs() * edge_score.signum();
+                if matches!(link.link_type, TraceLinkType::ConflictsWith) {
+                    conflicts.push(link.clone());
+                }
+                let mut new_via = via_types.clone();
+                new_via.push(link.link_type);
+
+                let entry = visited.entry(nbr_key.clone()).or_insert_with(|| BlastNode {
+                    artifact: nbr_artifact,
+                    depth: depth + 1,
+                    via: new_via.clone(),
+                    score: 0.0,
+                });
+                // Update if this is a better path (lower depth or higher score)
+                if entry.depth > depth + 1 || entry.score.abs() < score.abs() {
+                    entry.depth = depth + 1;
+                    entry.via = new_via.clone();
+                    entry.score = score;
+                }
+                if depth + 1 <= cfg.max_depth || cfg.max_depth == 0 {
+                    queue.push_back((nbr_key.clone(), depth + 1, decay * 0.85, new_via));
+                }
+            }
+        }
+    }
+
+    // Sum and bucket
+    let mut total_score = 0.0f32;
+    let mut by_kind: HashMap<String, f32> = HashMap::new();
+    let mut blast: Vec<BlastNode> = visited.into_values().collect();
+    blast.sort_by(|a, b| b.score.abs().partial_cmp(&a.score.abs()).unwrap_or(std::cmp::Ordering::Equal));
+    for node in &blast {
+        total_score += node.score;
+        let kind = node.artifact.kind_str();
+        *by_kind.entry(kind).or_insert(0.0) += node.score;
+    }
+    // Always include seeds even if no edges
+    for seed in seeds {
+        if !blast.iter().any(|n| artifact_key(&n.artifact) == artifact_key(seed)) {
+            let kind = seed.kind_str();
+            *by_kind.entry(kind).or_insert(0.0) += kind_weight(&artifact_key(seed), cfg);
+            blast.push(BlastNode {
+                artifact: seed.clone(),
+                depth: 0,
+                via: vec![],
+                score: kind_weight(&artifact_key(seed), cfg),
+            });
+        }
+    }
+
+    report.blast = blast;
+    report.total_score = total_score;
+    report.by_kind = by_kind;
+    report.max_depth_seen = max_depth_seen;
+    report.conflicts = conflicts;
+    report
+}
+
+fn kind_weight(artifact_key_str: &str, cfg: &ImpactConfig) -> f32 {
+    let kind = infer_kind(artifact_key_str);
+    cfg.kind_weights.get(&kind).copied().unwrap_or(0.5)
+}
+
+fn infer_kind(artifact_key_str: &str) -> String {
+    if artifact_key_str.starts_with("FR-") {
+        "requirement".to_string()
+    } else if artifact_key_str.starts_with("NFR-") {
+        "nfr".to_string()
+    } else if artifact_key_str.starts_with("test:") {
+        "test".to_string()
+    } else if artifact_key_str.starts_with("code:") {
+        "code".to_string()
+    } else if artifact_key_str.starts_with("journey:") {
+        "journey".to_string()
+    } else if artifact_key_str.starts_with("agent:") {
+        "agent".to_string()
+    } else if artifact_key_str.starts_with("evidence:") {
+        "evidence".to_string()
+    } else if artifact_key_str.starts_with("document:") {
+        "document".to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+/// Convenience: rank artifacts by impact (descending score).
+pub fn top_affected(report: &ImpactReport, n: usize) -> Vec<&BlastNode> {
+    report.blast.iter().take(n).collect()
+}
+
+/// Convenience: only the conflicts (links or artifacts that are in conflict).
+pub fn conflicts_only(report: &ImpactReport) -> &[TraceLink] {
+    &report.conflicts
+}
+
+fn artifact_key(a: &ArtifactRef) -> String {
+    match a {
+        ArtifactRef::Requirement { id } => id.as_str().to_string(),
+        ArtifactRef::NonFunctionalRequirement { id } => id.as_str().to_string(),
+        ArtifactRef::Test { id } => format!("test:{}", id),
+        ArtifactRef::CodeEntity { id, .. } => format!("code:{}", id),
+        ArtifactRef::Journey { id } => format!("journey:{}", id),
+        ArtifactRef::AgentRun { id } => format!("agent:{}", id),
+        ArtifactRef::Evidence { id, .. } => format!("evidence:{}", id),
+        ArtifactRef::Document { id, .. } => format!("document:{}", id),
+    }
+}
+
+fn parse_artifact_key(s: &str) -> ArtifactRef {
+    if let Some(rest) = s.strip_prefix("test:") {
+        ArtifactRef::Test { id: rest.to_string() }
+    } else if let Some(rest) = s.strip_prefix("code:") {
+        ArtifactRef::CodeEntity {
+            id: rest.to_string(),
+            lang: "rust".to_string(),
+        }
+    } else if let Some(rest) = s.strip_prefix("journey:") {
+        ArtifactRef::Journey { id: rest.to_string() }
+    } else if let Some(rest) = s.strip_prefix("agent:") {
+        ArtifactRef::AgentRun { id: rest.to_string() }
+    } else if let Some(rest) = s.strip_prefix("evidence:") {
+        ArtifactRef::Evidence {
+            id: rest.to_string(),
+            sha256: "0".repeat(64),
+        }
+    } else if let Some(rest) = s.strip_prefix("document:") {
+        ArtifactRef::Document {
+            id: rest.to_string(),
+            range: None,
+        }
+    } else if let Some(rest) = s.strip_prefix("NFR-") {
+        ArtifactRef::NonFunctionalRequirement { id: crate::ids::NfrId::from_string(rest) }
+    } else if s.starts_with("FR-") {
+        ArtifactRef::Requirement { id: crate::ids::RequirementId::from_string(s) }
+    } else {
+        ArtifactRef::Test { id: s.to_string() }
+    }
+}
+
+// Re-export for callers
+pub use crate::LinkKind as _LinkKind;
+pub use crate::RequirementId as _RequirementId;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::RequirementId;
+    use crate::{MatrixCell, TraceLinkType};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn req(id: &str) -> ArtifactRef {
+        ArtifactRef::Requirement {
+            id: RequirementId::from_string(id),
+        }
+    }
+    fn test(id: &str) -> ArtifactRef {
+        ArtifactRef::Test { id: id.to_string() }
+    }
+
+    fn make_link(from: ArtifactRef, to: ArtifactRef, ty: TraceLinkType, conf: f32) -> TraceLink {
+        let project = Uuid::new_v4();
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let mut link = TraceLink::new(project, source, target, ty).unwrap();
+        link.from = from;
+        link.to = to;
+        link.confidence = conf;
+        link.created_at = Some(Utc::now());
+        link.updated_at = Some(Utc::now());
+        link
+    }
+
+    fn make_matrix(links: Vec<TraceLink>) -> CoverageMatrix {
+        let mut cells: indexmap::IndexMap<(String, String), MatrixCell> =
+            indexmap::IndexMap::with_hasher(Default::default());
+        for link in links {
+            let key = (artifact_key(&link.from), artifact_key(&link.to));
+            let cell = cells.entry(key).or_insert_with(|| MatrixCell {
+                from: artifact_key(&link.from),
+                to: artifact_key(&link.to),
+                trace_links: Vec::new(),
+                coverage: crate::CoverageState::Covered,
+            });
+            cell.trace_links.push(link);
+        }
+        CoverageMatrix {
+            cells,
+            generated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn empty_matrix_zero_impact() {
+        let matrix = make_matrix(vec![]);
+        let report = compute_impact(&matrix, &[req("FR-001")], &ImpactConfig::default());
+        // Seed appears with its own weight
+        assert!(report.total_score >= 0.0);
+        assert_eq!(report.blast.len(), 1);
+        assert_eq!(report.conflicts.len(), 0);
+    }
+
+    #[test]
+    fn single_link_propagates() {
+        let link = make_link(
+            req("FR-001"),
+            test("T-001"),
+            TraceLinkType::Verifies,
+            0.95,
+        );
+        let matrix = make_matrix(vec![link]);
+        let report = compute_impact(&matrix, &[req("FR-001")], &ImpactConfig::default());
+        // Should include both seed and test
+        assert!(report.blast.len() >= 2);
+        assert!(report.total_score > 0.0);
+    }
+
+    #[test]
+    fn conflict_link_produces_negative_score() {
+        let link = make_link(
+            req("FR-001"),
+            test("T-001"),
+            TraceLinkType::ConflictsWith,
+            0.95,
+        );
+        let matrix = make_matrix(vec![link]);
+        let report = compute_impact(&matrix, &[req("FR-001")], &ImpactConfig::default());
+        // Conflicts contribute negative score and appear in report.conflicts
+        assert_eq!(report.conflicts.len(), 1);
+        // total score may still be ≥ 0 because of seed weight
+    }
+
+    #[test]
+    fn multi_hop_traversal() {
+        // FR-001 -> T-001 (Verifies) -> T-002 (DerivesFrom) -> FR-002 (Satisfies)
+        let l1 = make_link(req("FR-001"), test("T-001"), TraceLinkType::Verifies, 0.9);
+        let l2 = make_link(test("T-001"), test("T-002"), TraceLinkType::DerivesFrom, 0.8);
+        let l3 = make_link(test("T-002"), req("FR-002"), TraceLinkType::Satisfies, 0.7);
+        let matrix = make_matrix(vec![l1, l2, l3]);
+        let report = compute_impact(&matrix, &[req("FR-001")], &ImpactConfig::default());
+        // Should reach all 4 nodes
+        assert!(report.blast.len() >= 4);
+    }
+
+    #[test]
+    fn max_depth_truncates() {
+        let l1 = make_link(req("FR-001"), test("T-001"), TraceLinkType::Verifies, 0.9);
+        let l2 = make_link(test("T-001"), test("T-002"), TraceLinkType::DerivesFrom, 0.8);
+        let matrix = make_matrix(vec![l1, l2]);
+        let cfg = ImpactConfig {
+            max_depth: 1,
+            ..Default::default()
+        };
+        let report = compute_impact(&matrix, &[req("FR-001")], &cfg);
+        assert!(report.truncated);
+        // Should only include seed + T-001
+        assert!(report.blast.len() <= 2);
+    }
+
+    #[test]
+    fn top_affected_returns_sorted() {
+        let l1 = make_link(req("FR-001"), test("T-001"), TraceLinkType::Verifies, 0.9);
+        let l2 = make_link(req("FR-001"), test("T-002"), TraceLinkType::Satisfies, 0.5);
+        let matrix = make_matrix(vec![l1, l2]);
+        let report = compute_impact(&matrix, &[req("FR-001")], &ImpactConfig::default());
+        let top = top_affected(&report, 2);
+        assert_eq!(top.len(), 2);
+        // Top should be sorted by |score| descending
+        assert!(top[0].score.abs() >= top[1].score.abs());
+    }
+
+    #[test]
+    fn seed_only_artifact_returns_self() {
+        let matrix = make_matrix(vec![]);
+        let report = compute_impact(&matrix, &[test("T-orphan")], &ImpactConfig::default());
+        // No edges but seed appears with own weight
+        assert_eq!(report.blast.len(), 1);
+        assert_eq!(report.blast[0].depth, 0);
+    }
+
+    #[test]
+    fn kind_weights_have_defaults() {
+        let cfg = ImpactConfig::default();
+        assert!(cfg.kind_weights.contains_key("requirement"));
+        assert!(cfg.kind_weights.contains_key("nfr"));
+        assert!(cfg.kind_weights.contains_key("test"));
+        assert!(cfg.kind_weights.contains_key("code"));
+    }
+}

--- a/crates/tracera-core/src/lib.rs
+++ b/crates/tracera-core/src/lib.rs
@@ -1,0 +1,380 @@
+//! `tracera-core` — canonical TraceLink entity model, FR/NFR, matrix/coverage logic.
+//!
+//! Phase 1 of the 2026-06-09 Tracera decouple plan. This is a 1:1 port of
+//! `Tracera/src/tracertm/models/trace_link.py` and
+//! `Tracera/backend/internal/traceability/types.go` to Rust.
+//!
+//! Status: in-progress (2026-06-10). See README.md for the full decouple plan.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
+
+pub mod ids;
+
+pub mod matrix; // Phase 2 stubs — see matrix.rs; excluded from default build until Phase 2 lands.
+pub mod impact;
+pub mod coverage;
+
+pub use ids::*;
+
+pub use matrix::*;
+pub use impact::*;
+pub use coverage::*;
+
+// ---------------------------------------------------------------------------
+// Enums (canonical vocabulary shared by SQL, Neo4j, and API layers)
+// ---------------------------------------------------------------------------
+
+/// Canonical trace-link relationship vocabulary (ISO 29148 § 5.2.6 + DO-178C Table A-3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TraceLinkType {
+    Satisfies,
+    Verifies,
+    Implements,
+    DerivesFrom,
+    Refines,
+    ConflictsWith,
+    Duplicates,
+}
+
+impl TraceLinkType {
+    /// Returns the SCREAMING_SNAKE string for SQL/Neo4j round-trip.
+    pub fn as_db_str(&self) -> &'static str {
+        match self {
+            Self::Satisfies => "SATISFIES",
+            Self::Verifies => "VERIFIES",
+            Self::Implements => "IMPLEMENTS",
+            Self::DerivesFrom => "DERIVES_FROM",
+            Self::Refines => "REFINES",
+            Self::ConflictsWith => "CONFLICTS_WITH",
+            Self::Duplicates => "DUPLICATES",
+        }
+    }
+}
+
+/// Core P0 subset called out in the SOTA research brief.
+pub const CORE_TRACE_LINK_TYPES: &[TraceLinkType] = &[
+    TraceLinkType::Satisfies,
+    TraceLinkType::Verifies,
+    TraceLinkType::Implements,
+    TraceLinkType::DerivesFrom,
+];
+
+/// Role of an [`Artifact`] inside the traceability graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactKind {
+    Requirement,
+    Design,
+    Code,
+    Test,
+    Evidence,
+    Risk,
+    Rationale,
+}
+
+impl ArtifactKind {
+    /// Returns the primary Neo4j node label for this kind.
+    pub fn neo4j_label(&self) -> &'static str {
+        match self {
+            Self::Requirement => "Requirement",
+            Self::Design => "Design",
+            Self::Code => "Code",
+            Self::Test => "Test",
+            Self::Evidence => "Evidence",
+            Self::Risk => "Risk",
+            Self::Rationale => "Rationale",
+        }
+    }
+}
+
+/// Lifecycle states for a [`Requirement`] (ISO 29148 § 5.2.8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RequirementStatus {
+    Draft,
+    Proposed,
+    Approved,
+    Implemented,
+    Verified,
+    Deprecated,
+    Rejected,
+}
+
+/// DO-178C / IEEE 1012 verification methods used on VERIFIES links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerificationMethod {
+    Test,
+    Analysis,
+    Inspection,
+    Demonstration,
+    Review,
+}
+
+// ---------------------------------------------------------------------------
+// Value objects
+// ---------------------------------------------------------------------------
+
+/// Any node in the traceability graph (super-type of [`Requirement`]).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Artifact {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub kind: ArtifactKind,
+    pub title: String,
+    pub description: Option<String>,
+    pub external_id: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// A traceable requirement.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Requirement {
+    #[serde(flatten)]
+    pub artifact: Artifact,
+    pub status: RequirementStatus,
+    pub priority: Option<u8>, // 0..=5
+    pub rationale: Option<String>,
+    pub acceptance_criteria: Vec<String>,
+    pub verification_method: Option<VerificationMethod>,
+}
+
+impl Requirement {
+    /// Construct a Requirement with the right defaults (kind pinned to Requirement).
+    pub fn new(artifact: Artifact) -> Result<Self, TraceLinkError> {
+        if artifact.kind != ArtifactKind::Requirement {
+            return Err(TraceLinkError::WrongArtifactKind {
+                expected: ArtifactKind::Requirement,
+                got: artifact.kind,
+            });
+        }
+        Ok(Self {
+            artifact,
+            status: RequirementStatus::Draft,
+            priority: None,
+            rationale: None,
+            acceptance_criteria: Vec::new(),
+            verification_method: None,
+        })
+    }
+}
+
+/// A confidence-scored directed edge in the traceability graph.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraceLink {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub source_artifact_id: Uuid,
+    pub target_artifact_id: Uuid,
+    pub link_type: TraceLinkType,
+    /// 0.0..=1.0; 1.0 for human-curated links.
+    pub confidence: f32,
+    pub rationale: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl TraceLink {
+    /// Create a new TraceLink, validating that source != target and confidence in range.
+    pub fn new(
+        project_id: Uuid,
+        source: Uuid,
+        target: Uuid,
+        link_type: TraceLinkType,
+    ) -> Result<Self, TraceLinkError> {
+        if source == target {
+            return Err(TraceLinkError::SelfLoop);
+        }
+        Ok(Self {
+            id: Uuid::new_v4(),
+            project_id,
+            source_artifact_id: source,
+            target_artifact_id: target,
+            link_type,
+            confidence: 1.0,
+            rationale: None,
+            metadata: BTreeMap::new(),
+            created_at: Some(Utc::now()),
+            updated_at: Some(Utc::now()),
+        })
+    }
+
+    /// True if this link uses one of the P0 SOTA link types.
+    pub fn is_core(&self) -> bool {
+        CORE_TRACE_LINK_TYPES.contains(&self.link_type)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TraceLinkError {
+    #[error("TraceLink source_artifact_id and target_artifact_id must differ")]
+    SelfLoop,
+    #[error("Requirement.kind must be REQUIREMENT, got {got:?}")]
+    WrongArtifactKind {
+        expected: ArtifactKind,
+        got: ArtifactKind,
+    },
+    #[error("confidence must be in 0.0..=1.0, got {0}")]
+    BadConfidence(f32),
+}
+
+// ---------------------------------------------------------------------------
+// Coverage state (re-exported from coverage module for convenience)
+// ---------------------------------------------------------------------------
+
+pub use crate::coverage::CoverageSummary;
+
+/// Coverage matrix - the main output of a Tracera coverage scan.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CoverageMatrix {
+    pub cells: IndexMap<(String, String), MatrixCell>,
+    pub generated_at: DateTime<Utc>,
+}
+
+/// Coverage matrix cell.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MatrixCell {
+    pub from: String,
+    pub to: String,
+    pub trace_links: Vec<TraceLink>,
+    pub coverage: CoverageState,
+}
+
+/// Coverage state for a single cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageState {
+    Covered,
+    Partial,
+    Missing,
+    Stale,
+    Conflict,
+}
+
+// ---------------------------------------------------------------------------
+// Neo4j schema (declarative DDL)
+// ---------------------------------------------------------------------------
+
+/// Neo4j relationship labels (one per [`TraceLinkType`]).
+pub const NEO4J_RELATIONSHIP_TYPES: &[&str] = &[
+    "SATISFIES", "VERIFIES", "IMPLEMENTS", "DERIVES_FROM",
+    "REFINES", "CONFLICTS_WITH", "DUPLICATES",
+];
+
+/// Neo4j node labels.
+pub const NEO4J_NODE_LABELS: &[&str] = &[
+    "Artifact", "Requirement", "Design", "Code", "Test",
+    "Evidence", "Risk", "Rationale", "Project",
+];
+
+/// Declarative Cypher schema for the trace-link graph projection.
+pub struct Neo4jSchema;
+
+impl Neo4jSchema {
+    /// Uniqueness / existence constraints.
+    pub const CONSTRAINTS: &'static [&'static str] = &[
+        "CREATE CONSTRAINT artifact_id_unique IF NOT EXISTS FOR (a:Artifact) REQUIRE a.id IS UNIQUE",
+        "CREATE CONSTRAINT requirement_id_unique IF NOT EXISTS FOR (r:Requirement) REQUIRE r.id IS UNIQUE",
+        "CREATE CONSTRAINT project_id_unique IF NOT EXISTS FOR (p:Project) REQUIRE p.id IS UNIQUE",
+    ];
+
+    /// Lookup / range indexes for the common RAG-side queries.
+    pub const INDEXES: &'static [&'static str] = &[
+        "CREATE INDEX artifact_project_kind IF NOT EXISTS FOR (a:Artifact) ON (a.project_id, a.kind)",
+        "CREATE INDEX artifact_external_id IF NOT EXISTS FOR (a:Artifact) ON (a.external_id)",
+        "CREATE INDEX requirement_status IF NOT EXISTS FOR (r:Requirement) ON (r.status)",
+        "CREATE FULLTEXT INDEX artifact_text IF NOT EXISTS FOR (a:Artifact) ON EACH [a.title, a.description]",
+    ];
+
+    /// All DDL statements in apply order (constraints before indexes).
+    pub fn all_statements() -> Vec<&'static str> {
+        let mut s: Vec<&'static str> = Self::CONSTRAINTS.to_vec();
+        s.extend_from_slice(Self::INDEXES);
+        s
+    }
+
+    /// Return the Neo4j relationship label for a given TraceLinkType.
+    pub fn relationship_label_for(link_type: TraceLinkType) -> &'static str {
+        link_type.as_db_str()
+    }
+
+    /// Return the primary Neo4j node label for a given ArtifactKind.
+    pub fn node_label_for(kind: ArtifactKind) -> &'static str {
+        kind.neo4j_label()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_link_roundtrips() {
+        let link = TraceLink::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            TraceLinkType::Verifies,
+        )
+        .unwrap();
+        assert!(link.is_core());
+        let json = serde_json::to_string(&link).unwrap();
+        let parsed: TraceLink = serde_json::from_str(&json).unwrap();
+        assert_eq!(link.id, parsed.id);
+        assert_eq!(link.link_type, parsed.link_type);
+    }
+
+    #[test]
+    fn trace_link_rejects_self_loop() {
+        let id = Uuid::new_v4();
+        let result = TraceLink::new(Uuid::new_v4(), id, id, TraceLinkType::Satisfies);
+        assert!(matches!(result, Err(TraceLinkError::SelfLoop)));
+    }
+
+    #[test]
+    fn requirement_rejects_wrong_kind() {
+        let artifact = Artifact {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            kind: ArtifactKind::Code,
+            title: "not a requirement".to_string(),
+            description: None,
+            external_id: None,
+            metadata: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
+        };
+        let result = Requirement::new(artifact);
+        assert!(matches!(result, Err(TraceLinkError::WrongArtifactKind { .. })));
+    }
+
+    #[test]
+    fn link_type_db_strings() {
+        assert_eq!(TraceLinkType::Satisfies.as_db_str(), "SATISFIES");
+        assert_eq!(TraceLinkType::ConflictsWith.as_db_str(), "CONFLICTS_WITH");
+        assert_eq!(TraceLinkType::DerivesFrom.as_db_str(), "DERIVES_FROM");
+    }
+
+    #[test]
+    fn neo4j_schema_statements_idempotent() {
+        let stmts = Neo4jSchema::all_statements();
+        assert!(stmts.len() >= 7);
+        for s in &stmts {
+            assert!(s.contains("IF NOT EXISTS"), "not idempotent: {}", s);
+        }
+    }
+
+    #[test]
+    fn neo4j_labels() {
+        assert_eq!(Neo4jSchema::node_label_for(ArtifactKind::Requirement), "Requirement");
+        assert_eq!(Neo4jSchema::relationship_label_for(TraceLinkType::Verifies), "VERIFIES");
+    }
+}

--- a/crates/tracera-core/src/matrix.rs
+++ b/crates/tracera-core/src/matrix.rs
@@ -1,0 +1,287 @@
+//! Matrix operations: build, query, diff.
+//!
+//! Phase 2 of the 2026-06-09 Tracera decouple plan.
+//! Ported from `Tracera/backend/internal/services/matrix_service.go`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
+use uuid::Uuid;
+
+use crate::ids::RequirementId;
+use crate::{CoverageMatrix, CoverageState, MatrixCell, TraceLink};
+
+/// Result of a single matrix-build operation: the matrix plus provenance.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct BuildResult {
+    pub matrix: CoverageMatrix,
+    pub built_at: chrono::DateTime<chrono::Utc>,
+    pub link_count: usize,
+    pub cell_count: usize,
+    pub stale_links: usize,
+}
+
+/// Build a coverage matrix from a flat list of trace links, using the
+/// canonical `(source, target)` Uuid projection. Cells are keyed by the
+/// two artifact UUIDs (one per cell), coverage is computed per cell from
+/// the trace link set.
+pub fn build_matrix(links: &[TraceLink]) -> BuildResult {
+    let mut cell_map: HashMap<(String, String), MatrixCell> = HashMap::new();
+
+    for link in links {
+        let key = (
+            link.source_artifact_id.to_string(),
+            link.target_artifact_id.to_string(),
+        );
+        let cell = cell_map.entry(key.clone()).or_insert_with(|| MatrixCell {
+            from: key.0.clone(),
+            to: key.1.clone(),
+            trace_links: Vec::new(),
+            coverage: CoverageState::Missing,
+        });
+        cell.trace_links.push(link.clone());
+    }
+
+    for cell in cell_map.values_mut() {
+        cell.coverage = classify_cell(&cell.trace_links);
+    }
+
+    let cell_count = cell_map.len();
+    let link_count = links.len();
+    let stale_links = links.iter().filter(|l| is_stale_link(l)).count();
+
+    let mut cells: indexmap::IndexMap<(String, String), MatrixCell> =
+        indexmap::IndexMap::with_hasher(Default::default());
+    for (k, v) in cell_map {
+        cells.insert(k, v);
+    }
+    cells.sort_keys();
+
+    BuildResult {
+        matrix: CoverageMatrix {
+            cells,
+            generated_at: chrono::Utc::now(),
+        },
+        built_at: chrono::Utc::now(),
+        link_count,
+        cell_count,
+        stale_links,
+    }
+}
+
+/// Query: for a given requirement UUID, return all matrix cells that involve it.
+pub fn neighbors<'a>(matrix: &'a CoverageMatrix, req_id: &Uuid) -> Vec<&'a MatrixCell> {
+    let key_str = req_id.to_string();
+    matrix
+        .cells
+        .values()
+        .filter(|c| c.from == key_str || c.to == key_str)
+        .collect()
+}
+
+/// Diff: which (from, to) pairs are in `new` but not in `old`.
+pub fn added<'a>(old: &'a CoverageMatrix, new: &'a CoverageMatrix) -> Vec<&'a MatrixCell> {
+    new.cells
+        .values()
+        .filter(|n| !old.cells.contains_key(&(n.from.clone(), n.to.clone())))
+        .collect()
+}
+
+/// Diff: which (from, to) pairs are in `old` but not in `new`.
+pub fn removed<'a>(old: &'a CoverageMatrix, new: &'a CoverageMatrix) -> Vec<&'a MatrixCell> {
+    old.cells
+        .values()
+        .filter(|o| !new.cells.contains_key(&(o.from.clone(), o.to.clone())))
+        .collect()
+}
+
+/// Diff: which (from, to) pairs are in both, but the link set or coverage changed.
+pub fn changed<'a>(
+    old: &'a CoverageMatrix,
+    new: &'a CoverageMatrix,
+) -> Vec<(&'a MatrixCell, &'a MatrixCell)> {
+    let mut out = Vec::new();
+    for (k, n) in &new.cells {
+        if let Some(o) = old.cells.get(k) {
+            if o.coverage != n.coverage || o.trace_links != n.trace_links {
+                out.push((o, n));
+            }
+        }
+    }
+    out
+}
+
+fn classify_cell(links: &[TraceLink]) -> CoverageState {
+    if links.is_empty() {
+        return CoverageState::Missing;
+    }
+    let verifying: Vec<&TraceLink> = links
+        .iter()
+        .filter(|l| matches!(l.link_type, crate::TraceLinkType::Verifies))
+        .collect();
+    let satisfying: Vec<&TraceLink> = links
+        .iter()
+        .filter(|l| matches!(l.link_type, crate::TraceLinkType::Satisfies))
+        .collect();
+    let conflict: Vec<&TraceLink> = links
+        .iter()
+        .filter(|l| matches!(l.link_type, crate::TraceLinkType::ConflictsWith))
+        .collect();
+
+    if !conflict.is_empty() {
+        CoverageState::Conflict
+    } else if verifying.iter().any(|l| l.confidence >= 0.9)
+        || satisfying.iter().any(|l| l.confidence >= 0.9)
+    {
+        CoverageState::Covered
+    } else if !verifying.is_empty() || !satisfying.is_empty() {
+        CoverageState::Partial
+    } else if is_stale_links(links) {
+        CoverageState::Stale
+    } else {
+        CoverageState::Missing
+    }
+}
+
+fn is_stale_links(links: &[TraceLink]) -> bool {
+    links.iter().any(is_stale_link)
+}
+
+fn is_stale_link(l: &TraceLink) -> bool {
+    if let (Some(ts), Some(updated)) = (l.created_at, l.updated_at) {
+        (updated - ts).num_days() > 90
+    } else {
+        false
+    }
+}
+
+/// Convenience builder for the common case of building a matrix from
+/// `(requirement_id, BTreeSet<evidence_id_string>)` pairs. The req_id
+/// is encoded into the link's metadata and the evidence strings become
+/// target UUIDs (deterministic from the string via `Uuid::new_v5`).
+pub fn build_from_pairs(pairs: &[(RequirementId, BTreeSet<String>)]) -> BuildResult {
+    let mut links = Vec::new();
+    let project = Uuid::new_v4();
+    for (req, evidences) in pairs {
+        let source = Uuid::new_v5(&Uuid::NAMESPACE_OID, req.as_str().as_bytes());
+        for ev in evidences {
+            let target = Uuid::new_v5(&Uuid::NAMESPACE_OID, ev.as_bytes());
+            if source == target {
+                continue;
+            }
+            let mut link = TraceLink::new(project, source, target, crate::TraceLinkType::Verifies)
+                .expect("source != target");
+            link.metadata.insert(
+                "req_id".to_string(),
+                serde_json::Value::String(req.as_str().to_string()),
+            );
+            link.metadata.insert(
+                "evidence".to_string(),
+                serde_json::Value::String(ev.clone()),
+            );
+            links.push(link);
+        }
+    }
+    build_matrix(&links)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LinkKind;
+    use chrono::{Duration, Utc};
+
+    fn make_link(
+        link_type: crate::TraceLinkType,
+        confidence: f32,
+        age_days: i64,
+    ) -> TraceLink {
+        let project = Uuid::new_v4();
+        let source = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let mut link = TraceLink::new(project, source, target, link_type).unwrap();
+        link.confidence = confidence;
+        let now = Utc::now();
+        link.created_at = Some(now - Duration::days(age_days));
+        link.updated_at = Some(now);
+        link
+    }
+
+    #[test]
+    fn empty_links_yields_empty_matrix() {
+        let r = build_matrix(&[]);
+        assert_eq!(r.link_count, 0);
+        assert_eq!(r.cell_count, 0);
+        assert!(r.matrix.cells.is_empty());
+    }
+
+    #[test]
+    fn single_high_confidence_verifies_is_covered() {
+        let link = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let r = build_matrix(&[link]);
+        assert_eq!(r.link_count, 1);
+        assert_eq!(r.cell_count, 1);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Covered);
+        }
+    }
+
+    #[test]
+    fn low_confidence_verifies_is_partial() {
+        let link = make_link(crate::TraceLinkType::Verifies, 0.5, 1);
+        let r = build_matrix(&[link]);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Partial);
+        }
+    }
+
+    #[test]
+    fn conflict_overrides_covered() {
+        let a = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let mut b = make_link(crate::TraceLinkType::ConflictsWith, 0.95, 1);
+        b.source_artifact_id = a.source_artifact_id;
+        b.target_artifact_id = a.target_artifact_id;
+        let r = build_matrix(&[a, b]);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Conflict);
+        }
+    }
+
+    #[test]
+    fn old_links_marked_stale() {
+        let link = make_link(crate::TraceLinkType::DerivesFrom, 0.5, 365);
+        let r = build_matrix(&[link]);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Stale);
+        }
+        assert_eq!(r.stale_links, 1);
+    }
+
+    #[test]
+    fn added_removed_changed_diff() {
+        let a = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let b = make_link(crate::TraceLinkType::Verifies, 0.95, 1);
+        let old = build_matrix(&[a.clone()]).matrix;
+        let new = build_matrix(&[a, b]).matrix;
+        assert_eq!(added(&old, &new).len(), 1);
+        assert_eq!(removed(&old, &new).len(), 0);
+        assert_eq!(changed(&old, &new).len(), 1);
+    }
+
+    #[test]
+    fn link_kind_alias_reachable() {
+        let _: LinkKind = LinkKind::Verifies;
+    }
+
+    #[test]
+    fn build_from_pairs_produces_verifies_links() {
+        let req = RequirementId::new();
+        let mut evs = BTreeSet::new();
+        evs.insert("ev-001".to_string());
+        evs.insert("ev-002".to_string());
+        let r = build_from_pairs(&[(req, evs)]);
+        assert_eq!(r.link_count, 2);
+        for cell in r.matrix.cells.values() {
+            assert_eq!(cell.coverage, CoverageState::Covered);
+        }
+    }
+}

--- a/docs/ML-OPERATIONS.md
+++ b/docs/ML-OPERATIONS.md
@@ -1,0 +1,199 @@
+# ML Operations
+
+This runbook defines how Tracera operates machine-learning-adjacent traceability
+features: requirement mining, semantic matching, agreement scoring, visual
+evidence scoring, quality analytics, and future learned scorers. Deterministic
+heuristics remain the production baseline; learned models must prove measurable
+value before promotion.
+
+## Data Pipeline
+
+Sources:
+
+- Requirements, specs, and product notes from `docs/requirements/`, imported
+  documents, and API payloads.
+- Trace artifacts including code references, tests, risks, evidence captures,
+  rationales, and graph nodes.
+- Reviewed links from persistence tables, including `confidence`, `rationale`,
+  artifact kind, project ID, and review metadata.
+- Generated candidates from requirement mining and scoring services.
+
+Validation:
+
+- Preserve source provenance, project boundary, artifact kind, and extraction
+  timestamp for every record.
+- Reject records with missing identifiers, empty text, invalid confidence values,
+  or cross-project joins.
+- Keep human-reviewed labels separate from model-generated candidates.
+- Sample rejected candidates for false-negative analysis instead of discarding all
+  failed examples.
+
+Versioning:
+
+- Snapshot datasets before scorer, threshold, prompt, or embedding changes.
+- Record dataset ID, schema version, source commit, extraction date, and label
+  provenance with every evaluation.
+- Treat redacted production snapshots as immutable evaluation inputs.
+
+```mermaid
+flowchart LR
+    A[Sources: specs, APIs, artifacts, reviewed links] --> B[Ingestion]
+    B --> C[Validation and normalization]
+    C --> D[Versioned dataset snapshot]
+    D --> E[Training or calibration]
+    E --> F[Offline evaluation]
+    F --> G[Registry candidate]
+    G --> H[Shadow or canary deployment]
+    H --> I[Production scoring]
+    I --> J[Monitoring and feedback]
+    J --> D
+```
+
+## Training
+
+Model registry:
+
+- Register every promoted scorer artifact with model name, scorer strategy,
+  version, dataset ID, code commit, owner, training command, and rollback target.
+- Store thresholds, embedding dimensions, prompts, tokenizer versions, and
+  dependency versions with the artifact.
+- Mark one production default per scoring task; keep older approved artifacts
+  available for rollback.
+
+Hyperparameter sweep:
+
+- Sweep thresholds, retrieval depth, embedding model, batch size, prompt variant,
+  and calibration method against the same frozen dataset.
+- Optimize for precision and calibrated confidence before recall when false
+  positives can corrupt trace integrity.
+- Keep sweep output queryable: parameters, metrics, runtime, memory, and failure
+  notes.
+
+Reproducibility:
+
+- Run training from pinned lockfiles and a recorded source commit.
+- Seed stochastic libraries and log non-deterministic settings.
+- Save raw config, processed config, dataset manifest, evaluation report, and
+  artifact checksum.
+- Keep optional ML imports lazy so non-ML Tracera installs still run.
+
+## Evaluation
+
+Offline metrics:
+
+- Precision, recall, F1, false-positive rate, and false-negative rate.
+- Confidence calibration by bucket, especially near promotion thresholds.
+- Coverage lift for requirements with valid code, test, evidence, or risk links.
+- Latency, memory, batch throughput, and model load time.
+- Rationale quality samples for true positives, false positives, and false
+  negatives.
+
+Online A/B:
+
+- Compare the candidate scorer against the deterministic baseline on equivalent
+  traffic or review queues.
+- Segment results by project, artifact kind, requirement class, and input source.
+- Require enough volume to detect regression in high-confidence false positives
+  before making the candidate default.
+
+Guardrails:
+
+- Do not auto-accept links below the configured confidence threshold.
+- Block promotion if response schemas change for API, graph, or report consumers.
+- Block promotion if latency, memory, or error rate exceeds service budgets.
+- Preserve a human-readable `rationale` for every automated verdict.
+
+## Deployment
+
+Artifact promotion:
+
+1. Register the candidate artifact and evaluation report.
+2. Confirm owner approval, rollback target, and compatible schema.
+3. Promote configuration, not callers: scorer selection should stay behind the
+   scoring port or service boundary.
+
+Canary:
+
+- Enable the scorer for a narrow project, tenant, artifact kind, or review queue.
+- Monitor accepted/rejected ratio, confidence distribution, latency, and reviewer
+  overrides.
+- Expand only when metrics match offline expectations.
+
+Shadow:
+
+- Run candidate scoring beside the production scorer without changing user-facing
+  decisions.
+- Log candidate outputs, disagreements, latency, and error details separately.
+- Use shadow results to refresh offline datasets before canary.
+
+Full rollout:
+
+- Promote the scorer to production default after canary guardrails pass.
+- Keep the previous scorer and threshold immediately restorable.
+- Record rollout time, config diff, artifact checksum, and monitoring dashboard.
+
+## Monitoring
+
+Drift detection:
+
+- Track input text length, artifact kind mix, project mix, language, label mix,
+  embedding distribution, confidence histogram, and disagreement rate.
+- Alert on sustained drift from the evaluation dataset or previous production
+  window.
+
+Latency:
+
+- Measure p50, p95, and p99 scoring latency by scorer, task, and batch size.
+- Track model load time separately from per-request scoring time.
+- Alert when latency threatens API, import, or report-generation budgets.
+
+Error rate:
+
+- Track scoring exceptions, dependency import failures, model load failures,
+  malformed outputs, schema validation failures, and timeout rates.
+- Include candidate volume, accepted/rejected ratio, reviewer overrides, and
+  rollback events in operational dashboards.
+
+## Retraining
+
+Triggers:
+
+- Drift alerts, degraded precision or recall, rising reviewer override rate,
+  new artifact types, new requirement formats, dependency upgrades, or model
+  deprecation.
+- Incident postmortems that identify missing labels, stale data, or poor
+  calibration.
+
+Schedule:
+
+- Refresh evaluation snapshots at least monthly for active ML-backed scorers.
+- Recalibrate thresholds after significant data-source changes.
+- Run ad hoc retraining before major product launches or large tenant imports.
+
+Data freshness:
+
+- Include recently reviewed positives, reviewer-rejected false positives, and
+  sampled false negatives.
+- Exclude unresolved or unreviewed generated candidates from supervised labels.
+- Verify freshness by source timestamp, extraction timestamp, and label review
+  timestamp.
+
+## Incident Response
+
+Rollback:
+
+- Restore the previous scorer name, artifact ID, threshold, and prompt/config.
+- Disable auto-acceptance for affected tasks until confidence is restored.
+- Preserve incident inputs and outputs for postmortem labeling.
+
+Runbook:
+
+1. Triage scope: affected scorer, projects, artifact kinds, release, and time
+   window.
+2. Stop expansion: pause canary or full rollout and pin the last known-good
+   configuration.
+3. Re-score a representative sample with the previous scorer and candidate.
+4. Notify owners with impact, rollback status, and expected follow-up.
+5. Add incident examples to the next evaluation snapshot after review.
+6. Update registry notes, monitoring thresholds, and promotion criteria before
+   retrying deployment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,1792 @@
+[build-system]
+requires = [
+    "hatchling",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "tracertm"
+version = "0.2.0"
+description = "Agent-native, multi-view requirements traceability and project management system"
+readme = "README.md"
+requires-python = ">=3.13"
+authors = [
+    { name = "BMad", email = "bmad@example.com" },
+]
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
+keywords = [
+    "requirements",
+    "traceability",
+    "rtm",
+    "project-management",
+    "ai-agents",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Quality Assurance",
+    "Environment :: Console",
+    "Intended Audience :: System Administrators",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Topic :: Office/Business",
+]
+dependencies = [
+    "typer>=0.21.1",
+    "rich>=14.3.1",
+    "pydantic>=2.12.5",
+    "pydantic-settings>=2.12.0",
+    "python-dotenv>=1.2.1",
+    "httpx>=0.28.1",
+    "pyyaml>=6.0.3",
+    "typing_extensions>=4.0.0",
+    "sqlalchemy[asyncio]>=2.0.46",
+    "alembic>=1.18.3",
+    "psycopg2-binary>=2.9.11",
+    "aiosqlite>=0.22.1",
+    "asyncpg>=0.31.0",
+    "greenlet>=3.3.1",
+    "msgspec>=0.20.0",
+    "msgpack>=1.1.2",
+    "markdown>=3.10.1",
+    "markdown-it-py>=4.0.0",
+    "python-frontmatter>=1.1.0",
+    "aiohttp>=3.13.3",
+    "tenacity>=9.1.2",
+    "grpcio>=1.70.0",
+    "fastapi>=0.136.0",
+    "uvicorn[standard]>=0.32.0",
+    "sse-starlette>=3.0.0",
+    "redis>=5.2.0",
+    "anyio>=4.12.1",
+    "watchdog>=6.0.0",
+    "loguru>=0.7.3",
+    "structlog>=25.5.0",
+    "opentelemetry-api>=1.39.1",
+    "opentelemetry-sdk>=1.39.1",
+    "prometheus-client>=0.24.1",
+    "cryptography>=46.0.4",
+    "bcrypt>=5.0.0",
+    "pyjwt>=2.11.0",
+    "keyring>=25.7.0",
+    "workos>=5.40.0",
+    "fastmcp>=3.0.0b1",
+    "mcp>=1.26.0",
+    "hatchet-sdk>=1.22.13",
+    "nats-py>=2.12.0",
+    "nkeys>=0.2.1",
+    "temporalio>=1.7.0",
+    "brotli-asgi>=1.6.0",
+    "neo4j>=6.1.0",
+    "minio>=7.2.20",
+    "respx>=0.22.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
+    "pytest-mock>=3.15.1",
+    "pytest-xdist>=3.8.0",
+    "pytest-benchmark>=5.2.3",
+    "hypothesis>=6.151.4",
+    "faker>=40.1.2",
+    "factory-boy>=3.3.3",
+    "ruff>=0.14.14",
+    "ty>=0.0.2",
+    "poethepoet>=0.40.0",
+    "tach>=0.33.2",
+    "pandera>=0.29.0",
+    "import-linter>=2.4.1",
+    "loguru>=0.7.3",
+    "pre-commit>=4.5.1",
+    "openapi-python-client>=0.22.1",
+    "bandit[toml]>=1.7.10",
+    "pip-audit>=2.7.4",
+    "vulture>=2.14",
+    "radon>=6.0.1",
+    "pycln>=2.6.0",
+]
+tui = [
+    "textual>=0.47.0",
+]
+lint = [
+    "ruff>=0.14.14",
+    "ty>=0.0.2",
+    "bandit[toml]>=1.7.10",
+    "pip-audit>=2.7.4",
+    "import-linter>=2.4.1",
+    "pycln>=2.6.0",
+]
+test = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
+    "pytest-mock>=3.15.1",
+    "pytest-xdist>=3.8.0",
+    "pytest-benchmark>=5.2.3",
+    "hypothesis>=6.151.4",
+    "faker>=40.1.2",
+    "factory-boy>=3.3.3",
+    "testcontainers[neo4j]>=4.10.0",
+]
+phase2 = [
+    "poethepoet>=0.40.0",
+    "tach>=0.33.2",
+    "pandera>=0.29.0",
+    "loguru>=0.7.3",
+    "pre-commit>=4.5.1",
+]
+phase3 = [
+    "hypothesis>=6.151.4",
+    "pydantic-factories>=1.17.3",
+]
+observability = [
+    "opentelemetry-api>=1.39.1",
+    "opentelemetry-sdk>=1.39.1",
+    "opentelemetry-exporter-prometheus>=0.60b1",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.39.1",
+    "opentelemetry-instrumentation-fastapi>=0.52b0",
+    "opentelemetry-instrumentation-sqlalchemy>=0.52b0",
+    "opentelemetry-instrumentation-httpx>=0.52b0",
+    "opentelemetry-instrumentation-requests>=0.52b0",
+    "opentelemetry-instrumentation-redis>=0.52b0",
+    "prometheus-client>=0.24.1",
+    "structlog>=25.5.0",
+]
+security = [
+    "cryptography>=46.0.4",
+    "bcrypt>=5.0.0",
+    "pyjwt>=2.11.0",
+    "authlib>=1.6.6",
+    "pycasbin>=2.7.1",
+]
+distributed = [
+    "ray>=2.53.0",
+    "dask>=2026.1.2",
+]
+data = [
+    "polars>=1.37.1",
+    "duckdb>=1.5.0.dev228",
+    "ibis-framework>=11.0.1.dev110",
+]
+ai = [
+    "anthropic>=0.77.0",
+]
+ml = [
+    "sentence-transformers>=5.2.2",
+    "numpy>=2.4.1",
+    "torch>=2.10.0",
+]
+all = [
+    "poethepoet>=0.40.0",
+    "tach>=0.33.2",
+    "pandera>=0.29.0",
+    "import-linter>=2.4.1",
+    "loguru>=0.7.3",
+    "pre-commit>=4.5.1",
+    "hypothesis>=6.151.4",
+    "pydantic-factories>=1.17.3",
+    "opentelemetry-api>=1.39.1",
+    "opentelemetry-sdk>=1.39.1",
+    "prometheus-client>=0.24.1",
+    "structlog>=25.5.0",
+    "cryptography>=46.0.4",
+    "bcrypt>=5.0.0",
+    "pyjwt>=2.11.0",
+    "authlib>=1.6.6",
+    "pycasbin>=2.7.1",
+    "ray>=2.53.0",
+    "dask>=2026.1.2",
+    "polars>=1.37.1",
+    "duckdb>=1.5.0.dev228",
+    "ibis-framework>=11.0.1.dev110",
+    "anthropic>=0.77.0",
+    "sentence-transformers>=5.2.2",
+    "numpy>=2.4.1",
+    "vulture>=2.14",
+    "radon>=6.0.1",
+]
+
+[project.scripts]
+rtm = "tracertm.cli:app"
+tracertm = "tracertm.cli:app"
+tracertm-mcp = "tracertm.mcp:run_server"
+rtm-mcp = "tracertm.mcp:run_server"
+
+[tool.setuptools.packages.find]
+where = [
+    "src",
+]
+include = [
+    "tracertm*",
+]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "src/tracertm",
+]
+pythonpath = [
+    "src",
+]
+python_files = [
+    "test_*.py",
+]
+python_classes = [
+]
+python_functions = [
+    "test_*",
+]
+addopts = [
+    "-ra",
+    "-vv",
+    "--strict-markers",
+    "--tb=short",
+    "-p",
+    "asyncio",
+]
+markers = [
+    "unit: Unit tests (fast, no external dependencies)",
+    "integration: Integration tests (database, file system)",
+    "e2e: End-to-end tests (full CLI workflows)",
+    "cli: CLI command tests",
+    "slow: Slow tests (>1s execution time)",
+    "agent: Agent coordination tests (concurrent operations)",
+    "asyncio: Async tests (mark for async tests)",
+    "performance: Performance and load tests",
+    "determinism: Tests that verify repeatable model inference outputs",
+    "parity: Tests that compare model inference outputs with reference implementations",
+    "property: Property-based tests using Hypothesis",
+    "benchmark: Benchmark tests for performance measurement",
+    "smoke: Minimal critical-path checks",
+    "chaos: Chaos/resilience tests (connection failures, resource exhaustion)",
+    "live_neo4j: Tests that require a live Neo4j instance (NEO4J_URI env var)",
+]
+filterwarnings = [
+    "error",
+    "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    "ignore::pytest.PytestAssertRewriteWarning",
+    "ignore::RuntimeWarning",
+]
+
+[tool.pytest_asyncio]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
+[tool.coverage.run]
+source = [
+    "src/tracertm",
+]
+omit = [
+    "*/tests/*",
+    "*/migrations/*",
+    "*/__pycache__/*",
+    "*/site-packages/*",
+]
+branch = true
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+fail_under = 90
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+    "except (ImportError|Exception|ModuleNotFoundError).*:",
+    "except ImportError:",
+    "except Exception:.*# (test )?fallback",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+[tool.interrogate]
+fail-under = 85
+path = [
+    "src/",
+]
+exclude = [
+    "tests",
+    "build",
+    "dist",
+    ".venv",
+]
+ignore-init-module = true
+ignore-init-method = true
+
+[tool.bandit]
+exclude_dirs = [
+    "tests",
+    "build",
+    "dist",
+    ".venv",
+    "ARCHIVE",
+]
+skips = [
+    "B101",
+]
+severity = "medium"
+confidence = "medium"
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+preview = true
+extend-exclude = [
+    "ARCHIVE",
+    "ARCHIVE/**",
+    "cairosvg",
+    "default",
+]
+force-exclude = true
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "UP",
+    "N",
+    "PT",
+    "SIM",
+    "RUF",
+    "RSE",
+    "PERF",
+    "LOG",
+    "S",
+    "ASYNC",
+    "PIE",
+    "RET",
+    "PTH",
+    "DTZ",
+    "D",
+    "FA",
+    "Q",
+    "C90",
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "PLR1702",
+    "PLR2004",
+    "PLC",
+    "PLW",
+    "PLE",
+    "FBT",
+    "ANN",
+    "TRY",
+    "INT",
+    "PGH",
+    "ISC",
+    "FURB",
+    "G",
+    "ARG",
+    "TCH",
+    "BLE",
+    "A",
+    "T10",
+    "T20",
+    "ERA",
+    "SLF",
+    "INP",
+]
+ignore = [
+    "E501",
+    "B008",
+    "SIM105",
+    "D203",
+    "D212",
+    "ANN401",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-annotations]
+allow-star-arg-any = false
+suppress-none-returning = false
+suppress-dummy-args = false
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 6
+max-branches = 12
+max-returns = 6
+max-statements = 50
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = [
+    "F401",
+    "F403",
+    "D100",
+    "D104",
+]
+"**/*_pb2.py" = [
+    "E501",
+    "E111",
+    "SLF001",
+    "ERA001",
+]
+"**/*_pb2_grpc.py" = [
+    "N802",
+    "ANN001",
+    "ANN002",
+    "ANN003",
+    "ANN201",
+    "ANN202",
+    "ANN204",
+    "ANN205",
+    "ANN206",
+    "ANN401",
+    "UP004",
+    "TRY003",
+    "E114",
+    "PLR0913",
+    "D102",
+    "D103",
+    "D205",
+    "ARG002",
+    "PLC2701",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"tests/**/*.py" = [
+    "S101",
+    "S105",
+    "S106",
+    "S108",
+    "S110",
+    "S311",
+    "S603",
+    "S607",
+    "S404",
+    "S608",
+    "PT011",
+    "PT012",
+    "PT017",
+    "PT018",
+    "PT019",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D417",
+    "ANN001",
+    "ARG001",
+    "ARG002",
+    "ARG005",
+    "PLR0911",
+    "PLR0913",
+    "PLR0915",
+    "PLR2004",
+    "E402",
+    "E722",
+    "E741",
+    "F401",
+    "F403",
+    "F404",
+    "F811",
+    "F821",
+    "N801",
+    "N802",
+    "N806",
+    "N999",
+    "A001",
+    "A002",
+    "A004",
+    "A006",
+    "C901",
+    "SIM102",
+    "SIM115",
+    "SIM117",
+    "DTZ001",
+    "DTZ005",
+    "TRY002",
+    "TRY003",
+    "TRY300",
+    "TRY301",
+    "B017",
+    "B018",
+    "B903",
+    "B904",
+    "ASYNC240",
+    "FURB101",
+    "PERF402",
+    "UP035",
+    "RUF001",
+    "RUF003",
+    "RUF012",
+    "RUF029",
+    "RUF034",
+    "RUF043",
+    "RUF059",
+    "ERA001",
+    "INP001",
+    "G004",
+    "SLF001",
+    "BLE001",
+    "PLC0415",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    "PLC2701",
+    "PLC1901",
+]
+"backend/tests/**/*.py" = [
+    "S101",
+    "S105",
+    "S108",
+    "S110",
+    "S202",
+    "PT019",
+    "D100",
+    "D107",
+    "D417",
+    "PLR2004",
+    "PLR0915",
+    "BLE001",
+    "TRY300",
+    "RUF029",
+    "INP001",
+    "ASYNC109",
+    "PLC0415",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"scripts/**/*.py" = [
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "PLR1702",
+    "PLR2004",
+    "C901",
+    "E402",
+    "S101",
+    "S108",
+    "S110",
+    "S112",
+    "S314",
+    "S404",
+    "S405",
+    "S603",
+    "S607",
+    "S608",
+    "S311",
+    "N806",
+    "N999",
+    "INP001",
+    "D415",
+    "D417",
+    "DTZ003",
+    "DTZ005",
+    "B007",
+    "B901",
+    "B904",
+    "TRY002",
+    "TRY300",
+    "TRY301",
+    "TRY401",
+    "BLE001",
+    "G004",
+    "G201",
+    "ARG001",
+    "FURB101",
+    "FURB113",
+    "PTH118",
+    "ASYNC109",
+    "ASYNC220",
+    "ASYNC221",
+    "A001",
+    "F601",
+    "SIM102",
+    "RUF001",
+    "RUF003",
+    "RUF012",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    "PLC0415",
+    "PLC1901",
+    "PLW2901",
+    "PLW0603",
+    "PLW1510",
+]
+"src/tracertm/services/**/*.py" = [
+    "BLE001",
+    "PLR0913",
+    "C901",
+    "PLR0912",
+    "PLR0915",
+    "PLR0911",
+    "TRY301",
+    "S608",
+    "S101",
+    "S311",
+    "SLF001",
+    "A002",
+    "D102",
+    "TRY004",
+    "S108",
+    "S404",
+    "PLC1901",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    "PLW2901",
+]
+"src/tracertm/mcp/**/*.py" = [
+    "BLE001",
+    "SLF001",
+    "C901",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+    "PLR0911",
+    "PLR1702",
+    "S608",
+    "RUF029",
+    "E402",
+    "D417",
+    "F821",
+    "F822",
+    "S104",
+    "S105",
+    "S110",
+    "S112",
+    "A002",
+    "TRY004",
+    "RUF006",
+    "PLC0415",
+    "PLW0603",
+]
+"src/tracertm/api/**/*.py" = [
+    "BLE001",
+    "TRY301",
+    "E402",
+    "S101",
+    "B904",
+    "RUF029",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+    "S608",
+    "A002",
+    "SLF001",
+    "C901",
+    "E741",
+    "N815",
+    "S104",
+    "S105",
+    "S311",
+    "TRY004",
+    "SIM102",
+    "RUF001",
+    "RUF034",
+    "PLC0415",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    "ANN201",
+    "ANN202",
+    "PLW0603",
+]
+"src/tracertm/api/client.py" = [
+    "D102",
+    "D103",
+    "D105",
+    "D107",
+    "D200",
+    "D205",
+    "D212",
+    "D415",
+    "D417",
+    "TRY003",
+    "S110",
+    "DTZ003",
+    "PLW2901",
+    "PLW1641",
+    "ARG002",
+]
+"src/tracertm/repositories/**/*.py" = [
+    "PLR0913",
+    "PLR0912",
+    "C901",
+    "PLC0415",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/agent/**/*.py" = [
+    "SLF001",
+    "S404",
+    "S603",
+    "PLC0415",
+    "PLW0603",
+]
+"src/tracertm/infrastructure/**/*.py" = [
+    "BLE001",
+    "PLR0913",
+    "N814",
+    "ASYNC240",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/config/**/*.py" = [
+    "BLE001",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    "PLW0603",
+]
+"src/tracertm/core/config.py" = [
+    "PLW0603",
+]
+"src/tracertm/database/**/*.py" = [
+    "BLE001",
+    "SLF001",
+    "PLW0603",
+]
+"src/tracertm/storage/**/*.py" = [
+    "C901",
+    "SLF001",
+    "S608",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "D417",
+    "PLC0415",
+]
+"src/tracertm/vault/**/*.py" = [
+    "TRY301",
+]
+"src/tracertm/observability/**/*.py" = [
+    "RUF029",
+    "C901",
+    "TRY301",
+    "PLR0915",
+    "PLC0415",
+    "PLW0603",
+]
+"src/tracertm/clients/**/*.py" = [
+    "PLR0913",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/grpc/**/*.py" = [
+    "N802",
+]
+"src/tracertm/preflight.py" = [
+    "PLR0912",
+    "PLR0911",
+    "S310",
+    "PLC0415",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/testing_factories.py" = [
+    "A002",
+]
+"src/tracertm/models/**/*.py" = [
+    "A003",
+    "S105",
+]
+"src/tracertm/schemas/**/*.py" = [
+    "S105",
+    "D106",
+]
+"src/tracertm/tui/**/*.py" = [
+    "N801",
+    "D106",
+    "D417",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/cli/**/*.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"alembic/**/*.py" = [
+    "E402",
+    "INP001",
+    "ERA001",
+    "BLE001",
+    "A002",
+    "DTZ005",
+    "PLR0915",
+    "PLR0912",
+    "C901",
+    "S608",
+    "PLC0415",
+]
+"samples/**/*.py" = [
+    "PLR0913",
+    "C901",
+    "E402",
+    "INP001",
+    "S110",
+    "S311",
+    "PTH118",
+    "SIM113",
+    "PERF402",
+    "A001",
+    "A002",
+    "DTZ005",
+    "B903",
+    "B909",
+    "E722",
+    "FURB101",
+    "S102",
+    "BLE001",
+]
+".claude/**/*.py" = [
+    "INP001",
+    "ANN401",
+    "BLE001",
+    "A002",
+    "DTZ005",
+    "PTH118",
+    "SIM113",
+]
+"find_violations.py" = [
+    "INP001",
+    "C901",
+    "PLR0912",
+    "PLR2004",
+    "S110",
+    "A001",
+    "PTH118",
+    "BLE001",
+    "PLW2901",
+]
+"generate_dep_tree.py" = [
+    "INP001",
+    "C901",
+    "PLR0912",
+    "PLR0915",
+    "S110",
+    "A001",
+    "PTH118",
+    "FURB101",
+    "BLE001",
+]
+"tests/unit/services/test_ai_tools.py" = [
+    "ASYNC230",
+    "ASYNC240",
+    "PTH118",
+]
+"src/tracertm/agent/test_events.py" = [
+    "S101",
+    "S108",
+    "PT019",
+]
+"src/tracertm/services/agents/codex_service.py" = [
+    "S404",
+    "PLC0415",
+]
+"src/tracertm/services/ai_tools.py" = [
+    "PLR1702",
+    "S404",
+    "TRY300",
+    "PLC0415",
+    "PLW0603",
+]
+"src/tracertm/services/encryption_service.py" = [
+    "PLW0603",
+]
+"src/tracertm/services/execution/docker_orchestrator.py" = [
+    "ASYNC109",
+    "ASYNC240",
+    "S404",
+]
+"src/tracertm/services/execution/native_orchestrator.py" = [
+    "ASYNC109",
+    "ASYNC240",
+]
+"src/tracertm/workflows/activities.py" = [
+    "PLC0415",
+]
+"src/tracertm/workflows/checkpoint_activities.py" = [
+    "PLC0415",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/workflows/sandbox_snapshot.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/api/handlers/websocket.py" = [
+    "ASYNC109",
+]
+"src/tracertm/api/main.py" = [
+    "PLW2901",
+]
+"src/tracertm/mcp/tools/param.py" = [
+    "E402",
+    "PLR1702",
+    "PT028",
+    "RUF029",
+    "S404",
+    "S603",
+    "S607",
+]
+"src/tracertm/mcp/tools/params/common.py" = [
+    "RUF029",
+]
+"src/tracertm/mcp/tools/params/config.py" = [
+    "RUF029",
+]
+"src/tracertm/mcp/tools/params/database.py" = [
+    "RUF029",
+]
+"src/tracertm/mcp/tools/params/io_operations.py" = [
+    "RUF029",
+]
+"src/tracertm/mcp/tools/auth_config_db.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/logging_config.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/bmm_workflows.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/workflow_executor.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/cli_integration.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/core.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/middleware.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/base.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/design_ingest_migration.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/response_optimizer.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/error_handlers.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/metrics.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/telemetry.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/base_async.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/items_optimized.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"src/tracertm/mcp/tools/links.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"conftest.py" = [
+    "F401",
+    "S101",
+    "PT018",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "BLE001",
+    "PLC0415",
+]
+"scripts/seed_swiftride_tracertm.py" = [
+    "S608",
+]
+"scripts/link_swiftride_uiux_items.py" = [
+    "S608",
+]
+"scripts/generate_swiftride_uiux_items.py" = [
+    "S608",
+]
+"scripts/export_projects_snapshot.py" = [
+    "S608",
+]
+"scripts/introspect_project.py" = [
+    "S608",
+]
+"scripts/generate_swiftride_tests.py" = [
+    "S404",
+    "S603",
+]
+"scripts/service_manager.py" = [
+    "S404",
+    "S603",
+    "S607",
+]
+"scripts/update_coverage_daily.py" = [
+    "S404",
+    "S607",
+]
+"scripts/utils/db_utils.py" = [
+    "S404",
+    "S603",
+    "S607",
+    "S608",
+]
+"scripts/utils/service_utils.py" = [
+    "S404",
+    "S110",
+    "S603",
+    "S607",
+]
+"scripts/validate_seed_and_access.py" = [
+    "S608",
+    "S112",
+]
+"scripts/python/**" = [
+    "S311",
+    "N999",
+    "S603",
+    "S606",
+    "S608",
+    "S404",
+]
+"scripts/python/ENHANCEMENT_API_ENDPOINTS.py" = [
+    "N999",
+]
+"scripts/python/seed_comprehensive.py" = [
+    "S311",
+]
+"scripts/python/seed_rich_single_project.py" = [
+    "S311",
+]
+"scripts/python/seed_swiftride_tracertm.py" = [
+    "S608",
+]
+"scripts/python/service_manager.py" = [
+    "S404",
+    "S603",
+    "S607",
+]
+"scripts/python/update_coverage_daily.py" = [
+    "S404",
+    "S607",
+]
+"scripts/python/validate_seed_and_access.py" = [
+    "S608",
+    "S112",
+]
+"scripts/python/apply_test_cases_migrations.py" = [
+    "E402",
+]
+"scripts/python/complete_setup.py" = [
+    "S404",
+    "S603",
+]
+"scripts/python/create_dense_projects.py" = [
+    "E402",
+    "S311",
+    "S110",
+    "S112",
+]
+"scripts/python/db-slow-query-report.py" = [
+    "N999",
+]
+"scripts/python/dev-quick.py" = [
+    "N999",
+    "S104",
+]
+"scripts/python/dev-start-with-preflight.py" = [
+    "N999",
+    "S603",
+    "S606",
+]
+"scripts/python/export_projects_snapshot.py" = [
+    "S608",
+]
+"scripts/python/generate_swiftride_data.py" = [
+    "S608",
+]
+"scripts/python/generate_swiftride_tests.py" = [
+    "S404",
+    "S603",
+]
+"scripts/python/generate_swiftride_uiux_items.py" = [
+    "S608",
+]
+"scripts/python/introspect_project.py" = [
+    "S608",
+]
+"scripts/python/link_swiftride_uiux_items.py" = [
+    "S608",
+]
+"scripts/python/quality-report.py" = [
+    "N999",
+]
+"scripts/python/rewrite_code_like_titles.py" = [
+    "RUF027",
+    "S608",
+]
+"scripts/quality-report.py" = [
+    "N999",
+]
+"scripts/db-slow-query-report.py" = [
+    "N999",
+]
+"scripts/dev-start-with-preflight.py" = [
+    "N999",
+    "S603",
+    "S606",
+]
+"scripts/dev-quick.py" = [
+    "N999",
+]
+"scripts/rewrite_code_like_titles.py" = [
+    "RUF027",
+    "S608",
+]
+"scripts/create_dense_projects.py" = [
+    "E402",
+    "S311",
+    "S110",
+    "S112",
+]
+"**/bmm-auto.py" = [
+    "N999",
+    "S404",
+    "S607",
+    "S603",
+    "SLF001",
+]
+"populate_projects.py" = [
+    "S404",
+    "S603",
+]
+"scripts/apply_test_cases_migrations.py" = [
+    "E402",
+]
+"scripts/complete_setup.py" = [
+    "S404",
+    "S603",
+]
+"ENHANCEMENT_IMPLEMENTATION_STARTER.py" = [
+    "S404",
+    "S603",
+    "S607",
+    "N999",
+]
+"scripts/ENHANCEMENT_IMPLEMENTATION_STARTER.py" = [
+    "S404",
+    "S603",
+    "S607",
+    "N999",
+]
+"scripts/ENHANCEMENT_API_ENDPOINTS.py" = [
+    "N999",
+]
+"src/tracertm/mcp/tools/params/_lazy_stub.py" = [
+    "PT028",
+]
+"src/tracertm/mcp/tools/params/query_test.py" = [
+    "PT028",
+]
+"src/tracertm/mcp/tools/params/storage.py" = [
+    "E402",
+    "RUF029",
+]
+"src/tracertm/mcp/tools/specifications.py" = [
+    "RUF029",
+]
+"src/tracertm/mcp/tools/optional_features.py" = [
+    "RUF029",
+    "FBT001",
+    "FBT002",
+    "FBT003",
+]
+"DOCKER_SDK_ASYNC_EXAMPLES.py" = [
+    "S108",
+    "S110",
+    "N999",
+]
+"scripts/DOCKER_SDK_ASYNC_EXAMPLES.py" = [
+    "S108",
+    "S110",
+    "N999",
+]
+"src/tracertm/services/spec_analytics_service_v2.py" = [
+    "PLR2004",
+]
+"src/tracertm/services/stateless_ingestion_service.py" = [
+    "UP035",
+]
+"src/tracertm/services/ai_service.py" = [
+    "PLR1702",
+    "PLC0415",
+    "PLW0603",
+]
+"src/tracertm/services/spec_analytics_service.py" = [
+    "PLR2004",
+]
+"src/tracertm/services/workos_auth_service.py" = [
+    "PLC0415",
+]
+"src/tracertm/services/import_service.py" = [
+    "PLC0415",
+]
+"src/tracertm/services/agent_monitoring_service.py" = [
+    "PLC0415",
+]
+"src/tracertm/services/checkpoint_service.py" = [
+    "PLC0415",
+    "PLW0603",
+]
+"src/tracertm/services/export_service.py" = [
+    "PLC0415",
+]
+"src/tracertm/services/project_backup_service.py" = [
+    "PLC0415",
+]
+"src/tracertm/services/temporal_service.py" = [
+    "PLC0415",
+]
+"src/tracertm/config/github_app.py" = [
+    "FBT001",
+    "FBT002",
+    "FBT003",
+    "PLC0415",
+]
+"src/tracertm/database/ensure_problems_processes.py" = [
+    "PLC0415",
+]
+"src/tracertm/tui/adapters/storage_adapter.py" = [
+    "PLC0415",
+]
+"src/tracertm/storage/local_storage.py" = [
+    "PLR2004",
+]
+"src/tracertm/storage/markdown_parser.py" = [
+    "PLR2004",
+]
+"src/tracertm/utils/figma.py" = [
+    "PLR2004",
+]
+"src/tracertm/repositories/item_spec_repository.py" = [
+    "PLR2004",
+    "PLC0415",
+]
+"tests/component/services/test_bulk_operation_service_comprehensive.py" = [
+    "PLW2901",
+]
+"tests/component/storage/test_storage_file_watcher.py" = [
+    "PLW2901",
+]
+"tests/performance/run_performance_tests.py" = [
+    "PLW1510",
+]
+"tests/performance/test_cli_startup.py" = [
+    "PLW1510",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "tracertm",
+]
+known-third-party = [
+    "typer",
+    "rich",
+    "sqlalchemy",
+    "pydantic",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = true
+
+[tool.ty.src]
+include = [
+    "src",
+    "tests",
+]
+exclude = [
+    "ARCHIVE",
+    "ARCHIVE/**",
+    "ARCHIVE/CONFIG/default",
+    "backend/tests",
+    "cli",
+    "cli/tests",
+    "frontend/disable",
+    "scripts",
+    "scripts/**",
+    "src/tracertm/vault",
+    "src/tracertm/vault/**",
+    "tests/unit/validation/test_dataframe_schema_validation.py",
+]
+respect-ignore-files = true
+
+[[tool.ty.overrides]]
+include = [
+    "tests/component/storage/test_sync_engine_errors.py",
+    "tests/component/storage/test_sync_queue.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "conftest.py",
+    "tests/conftest.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+invalid-assignment = "ignore"
+call-non-callable = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "tests/e2e/**",
+    "tests/fixtures.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "tests/integration/workflows/**",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "tests/mcp/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+unknown-argument = "ignore"
+unresolved-attribute = "ignore"
+invalid-argument-type = "ignore"
+unsupported-operator = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "tests/performance/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+invalid-argument-type = "ignore"
+possibly-missing-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/api/routers/item_specs.py",
+]
+
+[tool.ty.overrides.rules]
+missing-argument = "ignore"
+unknown-argument = "ignore"
+invalid-argument-type = "ignore"
+invalid-parameter-default = "ignore"
+invalid-return-type = "ignore"
+redundant-cast = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/api/main.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+no-matching-overload = "ignore"
+unresolved-attribute = "ignore"
+possibly-missing-attribute = "ignore"
+invalid-assignment = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/api/handlers/github.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/api/routers/integrations.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+possibly-missing-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/api/routers/items.py",
+]
+
+[tool.ty.overrides.rules]
+no-matching-overload = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/proto/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+no-matching-overload = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/vault/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/mcp/**",
+    "tracertm/mcp/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+call-non-callable = "ignore"
+unsupported-operator = "ignore"
+invalid-assignment = "ignore"
+no-matching-overload = "ignore"
+invalid-argument-type = "ignore"
+parameter-already-assigned = "ignore"
+unknown-argument = "ignore"
+possibly-missing-attribute = "ignore"
+possibly-missing-implicit-call = "ignore"
+redundant-cast = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/observability/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/repositories/**",
+    "tracertm/repositories/**",
+]
+
+[tool.ty.overrides.rules]
+possibly-missing-attribute = "ignore"
+no-matching-overload = "ignore"
+invalid-return-type = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/storage/**",
+]
+
+[tool.ty.overrides.rules]
+unsupported-operator = "ignore"
+possibly-missing-implicit-call = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/schemas.py",
+    "tracertm/schemas.py",
+]
+
+[tool.ty.overrides.rules]
+possibly-missing-import = "ignore"
+possibly-missing-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/services/**",
+    "tracertm/services/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+possibly-missing-import = "ignore"
+possibly-missing-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/workflows/**",
+]
+
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+no-matching-overload = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "tests/_disabled_tests/**",
+    "tests/TEST-TEMPLATE.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+unresolved-reference = "ignore"
+missing-argument = "ignore"
+unknown-argument = "ignore"
+not-subscriptable = "ignore"
+invalid-assignment = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/models/_exports.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-assignment = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "src/tracertm/api/routers/agent.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+
+[[tool.ty.overrides]]
+include = [
+    "tests/api/**",
+    "tests/phase5/**",
+    "tests/component/**",
+    "tests/grpc/**",
+    "tests/e2e/**",
+    "tests/fixtures.py",
+    "tests/test_execution_routes.py",
+    "tests/mcp/**",
+    "tests/performance/**",
+    "tests/unit/**",
+    "tests/integration/**",
+    "tests/workflows/**",
+    "tests/chaos/**",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+unresolved-attribute = "ignore"
+unresolved-reference = "ignore"
+possibly-missing-attribute = "ignore"
+possibly-missing-import = "ignore"
+possibly-missing-implicit-call = "ignore"
+not-subscriptable = "ignore"
+unsupported-operator = "ignore"
+deprecated = "ignore"
+unknown-argument = "ignore"
+missing-argument = "ignore"
+redundant-cast = "ignore"
+call-non-callable = "ignore"
+not-iterable = "ignore"
+invalid-return-type = "ignore"
+invalid-await = "ignore"
+
+[tool.ty.environment]
+python-version = "3.13"
+
+[tool.ty.rules]
+unused-ignore-comment = "error"
+possibly-unresolved-reference = "error"
+possibly-missing-attribute = "error"
+possibly-missing-import = "error"
+
+[tool.ty.terminal]
+error-on-warning = true
+output-format = "concise"
+
+[tool.importlinter]
+root_packages = [
+    "tracertm",
+]
+
+[[tool.importlinter.contracts]]
+name = "Core layered architecture"
+type = "layers"
+layers = [
+    "config",
+    "db",
+    "models",
+    "repositories",
+    "storage",
+    "clients",
+    "services",
+    "api",
+]
+containers = [
+    "tracertm",
+]
+
+[[tool.importlinter.contracts]]
+name = "API must not access lower layers directly"
+type = "forbidden"
+source_modules = [
+    "tracertm.api",
+]
+forbidden_modules = [
+    "tracertm.db",
+    "tracertm.models",
+    "tracertm.repositories",
+    "tracertm.storage",
+    "tracertm.clients",
+]
+
+[tool.uv]
+managed = true
+
+[tool.hatch.build.targets.wheel]
+packages = [
+    "src/tracertm",
+]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/tests",
+    "/docs",
+    "/pyproject.toml",
+    "/README.md",
+]
+
+[tool.poe.tasks]
+lint = "ruff check --fix ."
+type-check = "ty check src/"
+arch-check = "tach check"
+arch-show = "tach show"
+security = "semgrep --config=p/security-audit src/"
+bandit = "bandit -r src/"
+pip-audit = "pip-audit"
+quality = [
+    { ref = "format" },
+    { ref = "metrics" },
+    { ref = "arch-check" },
+    { ref = "bandit" },
+    { ref = "pip-audit" },
+    { ref = "security" },
+    { ref = "test" },
+]
+test = "pytest"
+test-cov = "pytest --cov=src/tracertm --cov-report=html"
+test-parallel = "pytest -n auto"
+test-unit = "pytest -m unit"
+test-integration = "pytest -m integration"
+all = [
+    { ref = "quality" },
+    { ref = "test-cov" },
+]
+
+[tool.poe.tasks.format]
+shell = "ruff format . && ruff check --fix . && ty check src/"
+
+[tool.poe.tasks.check]
+shell = "ruff check . && ty check src/"
+
+[tool.poe.tasks.metrics]
+shell = "vulture src/ && radon cc src/ -a -s && radon mi src/ -s"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
+    "pytest-mock>=3.15.1",
+    "pytest-xdist>=3.8.0",
+    "pytest-benchmark>=5.2.3",
+    "hypothesis>=6.151.4",
+    "faker>=40.1.2",
+    "factory-boy>=3.3.3",
+    "ruff>=0.14.14",
+    "ty>=0.0.2",
+    "vulture>=2.14",
+    "radon>=6.0.1",
+    "interrogate>=1.7.0",
+    "pycln>=2.6.0",
+    "tach>=0.33.2",
+    "bandit[toml]>=1.7.10",
+]

--- a/scripts/python/training_mlflow_demo.py
+++ b/scripts/python/training_mlflow_demo.py
@@ -1,0 +1,40 @@
+"""Example training loop wired to TraceRTM's MLflow-compatible tracking."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from tracertm.mlflow_compat import TrackingClient
+
+
+def main() -> None:
+    """Run a tiny demo loop and log MLflow-compatible training telemetry."""
+    client = TrackingClient()
+    run = client.start_run()
+    run.log_params({"model": "linear-demo", "epochs": 3, "optimizer": "sgd"})
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        artifact_dir = Path(temp_dir)
+        for step in range(3):
+            run.log_metric("loss", 1.0 / (step + 1), step=step)
+            run.log_metric("accuracy", 0.72 + (step * 0.08), step=step)
+            run.log_metric("lr", 0.01 / (step + 1), step=step)
+
+        config = artifact_dir / "config.json"
+        model = artifact_dir / "model.json"
+        plot = artifact_dir / "loss_plot.txt"
+        config.write_text(json.dumps({"batch_size": 16, "seed": 7}), encoding="utf-8")
+        model.write_text(json.dumps({"weights": [0.2, 0.8]}), encoding="utf-8")
+        plot.write_text("loss: 1.0 -> 0.5 -> 0.333\n", encoding="utf-8")
+
+        run.log_artifact(model)
+        run.log_artifact(plot)
+        run.log_artifact(config)
+
+    run.end()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tracertm/ml/__init__.py
+++ b/src/tracertm/ml/__init__.py
@@ -1,0 +1,5 @@
+"""Machine-learning model registry utilities."""
+
+from tracertm.ml.registry import ModelEntry, ModelRegistry, ModelRegistryError
+
+__all__ = ["ModelEntry", "ModelRegistry", "ModelRegistryError"]

--- a/src/tracertm/ml/model_registry.py
+++ b/src/tracertm/ml/model_registry.py
@@ -1,0 +1,5 @@
+"""Backward import path for the ML model registry."""
+
+from tracertm.ml.registry import ModelEntry, ModelRegistry, ModelRegistryError
+
+__all__ = ["ModelEntry", "ModelRegistry", "ModelRegistryError"]

--- a/src/tracertm/ml/registry.py
+++ b/src/tracertm/ml/registry.py
@@ -1,0 +1,280 @@
+"""Content-addressed ML model registry with version pinning."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pickle  # noqa: S403
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_INDEX_FILE = "registry.json"
+_SAFE_PART = re.compile(r"^[A-Za-z0-9_.-]+$")
+_SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+class ModelRegistryError(ValueError):
+    """Raised when model registry operations fail."""
+
+
+class ModelEntry(BaseModel):
+    """Metadata for one registered model version."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    version: str
+    sha256: str
+    format: str
+    artifact_path: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+
+
+class _RegistryIndex(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    models: dict[str, dict[str, ModelEntry]] = Field(default_factory=dict)
+    pins: dict[str, dict[str, str]] = Field(default_factory=dict)
+
+
+class ModelAdapter(Protocol):
+    """Serialization adapter for model artifacts."""
+
+    format: str
+    extension: str
+
+    def dump(self, model: Any, path: Path) -> None: ...
+
+    def load(self, path: Path) -> Any: ...
+
+
+@dataclass(frozen=True)
+class PickleAdapter:
+    """Fallback pickle adapter for plain Python test models."""
+
+    format: str = "pickle"
+    extension: str = ".pkl"
+
+    def dump(self, model: Any, path: Path) -> None:
+        with path.open("wb") as handle:
+            pickle.dump(model, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def load(self, path: Path) -> Any:
+        with path.open("rb") as handle:
+            return pickle.load(handle)  # noqa: S301
+
+
+@dataclass(frozen=True)
+class SklearnJoblibAdapter:
+    """scikit-learn/joblib model adapter."""
+
+    format: str = "sklearn"
+    extension: str = ".joblib"
+
+    def dump(self, model: Any, path: Path) -> None:
+        import joblib
+
+        joblib.dump(model, path)
+
+    def load(self, path: Path) -> Any:
+        import joblib
+
+        return joblib.load(path)
+
+
+@dataclass(frozen=True)
+class PyTorchAdapter:
+    """PyTorch .pt adapter."""
+
+    format: str = "pytorch"
+    extension: str = ".pt"
+
+    def dump(self, model: Any, path: Path) -> None:
+        import torch
+
+        torch.save(model, path)
+
+    def load(self, path: Path) -> Any:
+        import torch
+
+        return torch.load(path, map_location="cpu", weights_only=False)
+
+
+@dataclass(frozen=True)
+class OnnxAdapter:
+    """ONNX binary artifact adapter."""
+
+    format: str = "onnx"
+    extension: str = ".onnx"
+
+    def dump(self, model: Any, path: Path) -> None:
+        if isinstance(model, bytes):
+            path.write_bytes(model)
+            return
+        if hasattr(model, "SerializeToString"):
+            path.write_bytes(model.SerializeToString())
+            return
+        raise ModelRegistryError("onnx adapter expects bytes or a serializable ONNX model")
+
+    def load(self, path: Path) -> bytes:
+        return path.read_bytes()
+
+
+class ModelRegistry:
+    """Save, load, and list content-addressed model artifacts."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.models_root = self.root / "models"
+        os.makedirs(self.models_root, exist_ok=True)
+        self.index_path = self.root / _INDEX_FILE
+        self.adapters: dict[str, ModelAdapter] = {
+            "pickle": PickleAdapter(),
+            "sklearn": SklearnJoblibAdapter(),
+            "joblib": SklearnJoblibAdapter(),
+            "pytorch": PyTorchAdapter(),
+            "torch": PyTorchAdapter(),
+            "onnx": OnnxAdapter(),
+        }
+
+    def save(
+        self,
+        name: str,
+        version: str,
+        model: Any,
+        metadata: dict[str, Any] | None = None,
+        *,
+        format: str | None = None,  # noqa: A002
+        pin: bool = True,
+        overwrite: bool = False,
+    ) -> ModelEntry:
+        """Save a model under models/{name}/{version}/blobs/{sha}.{ext}."""
+        self._validate_name(name)
+        self._validate_version(version)
+        adapter = self._adapter_for(format or self._infer_format(model))
+        payload = self._serialize(adapter, model)
+        sha256 = hashlib.sha256(payload).hexdigest()
+
+        index = self._read_index()
+        versions = index.models.setdefault(name, {})
+        existing = versions.get(version)
+        if existing and not overwrite:
+            raise ModelRegistryError(f"model {name!r} version {version!r} already exists")
+
+        version_dir = self.models_root / name / version
+        blob_dir = version_dir / "blobs"
+        os.makedirs(blob_dir, exist_ok=True)
+        artifact_path = blob_dir / f"{sha256}{adapter.extension}"
+        if not artifact_path.exists():
+            artifact_path.write_bytes(payload)
+
+        entry = ModelEntry(
+            name=name,
+            version=version,
+            sha256=sha256,
+            format=adapter.format,
+            artifact_path=str(artifact_path.relative_to(self.root)),
+            metadata=metadata or {},
+            created_at=datetime.now(UTC),
+        )
+        versions[version] = entry
+        if pin:
+            index.pins[name] = {"version": version, "sha256": sha256}
+        self._write_index(index)
+        return entry
+
+    def load(self, name: str, version: str | None = None) -> Any:
+        """Load a model by explicit version or the pinned version."""
+        entry = self.get(name, version)
+        return self._adapter_for(entry.format).load(self.root / entry.artifact_path)
+
+    def list(self, name: str | None = None) -> list[ModelEntry]:
+        """List registered model versions newest first."""
+        index = self._read_index()
+        selected = {name: index.models.get(name, {})} if name else index.models
+        entries = [entry for versions in selected.values() for entry in versions.values()]
+        return sorted(entries, key=lambda entry: entry.created_at, reverse=True)
+
+    def get(self, name: str, version: str | None = None) -> ModelEntry:
+        """Return metadata for a model version, validating pinned SHA when used."""
+        index = self._read_index()
+        versions = index.models.get(name)
+        if not versions:
+            raise ModelRegistryError(f"model {name!r} is not registered")
+
+        pin = index.pins.get(name)
+        resolved = version or (pin or {}).get("version")
+        if not resolved:
+            resolved = max(versions.values(), key=lambda entry: entry.created_at).version
+        entry = versions.get(resolved)
+        if entry is None:
+            raise ModelRegistryError(f"model {name!r} version {resolved!r} is not registered")
+        if version is None and pin and entry.sha256 != pin.get("sha256"):
+            raise ModelRegistryError(f"pinned SHA mismatch for model {name!r} version {resolved!r}")
+        return entry
+
+    def pin(self, name: str, version: str) -> ModelEntry:
+        """Pin a model to an exact semver and SHA256 artifact digest."""
+        index = self._read_index()
+        entry = self.get(name, version)
+        index.pins[name] = {"version": entry.version, "sha256": entry.sha256}
+        self._write_index(index)
+        return entry
+
+    def pinned_version(self, name: str) -> str | None:
+        """Return the pinned semver for a model, if present."""
+        pin = self._read_index().pins.get(name)
+        return pin.get("version") if pin else None
+
+    def _serialize(self, adapter: ModelAdapter, model: Any) -> bytes:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / f"model{adapter.extension}"
+            adapter.dump(model, path)
+            return path.read_bytes()
+
+    def _read_index(self) -> _RegistryIndex:
+        if not self.index_path.exists():
+            return _RegistryIndex()
+        return _RegistryIndex.model_validate_json(self.index_path.read_text())
+
+    def _write_index(self, index: _RegistryIndex) -> None:
+        payload = index.model_dump(mode="json")
+        self.index_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    def _adapter_for(self, format_name: str) -> ModelAdapter:
+        adapter = self.adapters.get(format_name.lower())
+        if adapter is None:
+            raise ModelRegistryError(f"unsupported model format: {format_name!r}")
+        return adapter
+
+    @staticmethod
+    def _infer_format(model: Any) -> str:
+        module = type(model).__module__.split(".", maxsplit=1)[0]
+        if module == "torch":
+            return "pytorch"
+        if module == "sklearn":
+            return "sklearn"
+        return "pickle"
+
+    @staticmethod
+    def _validate_name(value: str) -> None:
+        if not value or "/" in value or not _SAFE_PART.fullmatch(value):
+            raise ModelRegistryError(f"invalid model name: {value!r}")
+
+    @staticmethod
+    def _validate_version(value: str) -> None:
+        if (
+            not value
+            or "/" in value
+            or not _SAFE_PART.fullmatch(value)
+            or not _SEMVER.fullmatch(value)
+        ):
+            raise ModelRegistryError(f"version must be semver: {value!r}")

--- a/src/tracertm/ml/test_inference_models.py
+++ b/src/tracertm/ml/test_inference_models.py
@@ -1,0 +1,228 @@
+"""Inference contract tests for registered ML model artifacts."""
+
+# ruff: noqa: D101, D102, D103, D107, PLR2004, S101
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tracertm.ml import ModelRegistry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+Sample = str
+Prediction = int | float | list[int]
+BatchPrediction = list[Prediction]
+ReferenceFn = Callable[[Sequence[Sample]], BatchPrediction]
+
+MAX_LENGTH_TEXT = " ".join(f"token{i}" for i in range(128))
+
+
+class LengthNormalizer:
+    """Normalize text length against a fixed maximum."""
+
+    def __init__(self, max_length: int = 128) -> None:
+        self.max_length = max_length
+
+    def predict(self, samples: Sequence[Sample]) -> BatchPrediction:
+        return [min(len(sample.split()), self.max_length) / self.max_length for sample in samples]
+
+
+class KeywordCounter:
+    """Count traceability keywords in each sample."""
+
+    def __init__(self, keywords: set[str] | None = None) -> None:
+        self.keywords = keywords or {"shall", "must", "verify", "trace", "risk"}
+
+    def predict(self, samples: Sequence[Sample]) -> BatchPrediction:
+        return [sum(token.lower() in self.keywords for token in sample.split()) for sample in samples]
+
+
+class ThresholdClassifier:
+    """Classify samples using a minimum token threshold."""
+
+    def __init__(self, threshold: int = 4) -> None:
+        self.threshold = threshold
+
+    def predict(self, samples: Sequence[Sample]) -> BatchPrediction:
+        return [int(len(sample.split()) >= self.threshold) for sample in samples]
+
+
+class PairwiseRanker:
+    """Rank each sample by stable character-code score."""
+
+    def predict(self, samples: Sequence[Sample]) -> BatchPrediction:
+        return [sum(ord(char) for char in sample) % 101 for sample in samples]
+
+
+class TokenWindowEncoder:
+    """Encode the first fixed token window as token lengths."""
+
+    def __init__(self, window: int = 4) -> None:
+        self.window = window
+
+    def predict(self, samples: Sequence[Sample]) -> BatchPrediction:
+        return [
+            [len(token) for token in sample.split()[: self.window]]
+            + [0] * max(0, self.window - len(sample.split()))
+            for sample in samples
+        ]
+
+
+def length_reference(samples: Sequence[Sample]) -> BatchPrediction:
+    return [min(len(sample.split()), 128) / 128 for sample in samples]
+
+
+def keyword_reference(samples: Sequence[Sample]) -> BatchPrediction:
+    keywords = {"shall", "must", "verify", "trace", "risk"}
+    return [sum(token.lower() in keywords for token in sample.split()) for sample in samples]
+
+
+def threshold_reference(samples: Sequence[Sample]) -> BatchPrediction:
+    return [int(len(sample.split()) >= 4) for sample in samples]
+
+
+def ranker_reference(samples: Sequence[Sample]) -> BatchPrediction:
+    return [sum(ord(char) for char in sample) % 101 for sample in samples]
+
+
+def encoder_reference(samples: Sequence[Sample]) -> BatchPrediction:
+    return [
+        [len(token) for token in sample.split()[:4]] + [0] * max(0, 4 - len(sample.split()))
+        for sample in samples
+    ]
+
+
+@dataclass(frozen=True)
+class InferenceCase:
+    name: str
+    model: object
+    reference: ReferenceFn
+
+
+@pytest.fixture(
+    params=[
+        InferenceCase("length-normalizer", LengthNormalizer(), length_reference),
+        InferenceCase("keyword-counter", KeywordCounter(), keyword_reference),
+        InferenceCase("threshold-classifier", ThresholdClassifier(), threshold_reference),
+        InferenceCase("pairwise-ranker", PairwiseRanker(), ranker_reference),
+        InferenceCase("token-window-encoder", TokenWindowEncoder(), encoder_reference),
+    ],
+    ids=lambda case: case.name,
+)
+def registered_model(tmp_path: Path, request: pytest.FixtureRequest) -> tuple[object, ReferenceFn]:
+    """Persist and load each inference model through the ML registry."""
+    case = request.param
+    registry = ModelRegistry(tmp_path)
+    os.makedirs(tmp_path / "models" / case.name / "1.0.0" / "blobs", exist_ok=True)  # noqa: PTH103
+    registry.save(case.name, "1.0.0", case.model, metadata={"kind": "inference"}, pin=True)
+    return registry.load(case.name), case.reference
+
+
+@pytest.mark.unit
+@pytest.mark.parity
+def test_shape_parity_for_representative_batch(
+    registered_model: tuple[object, ReferenceFn],
+) -> None:
+    model, reference = registered_model
+    samples = ["requirement shall trace risk", "verify link", "plain text"]
+
+    result = model.predict(samples)
+
+    assert len(result) == len(reference(samples))
+
+
+@pytest.mark.unit
+@pytest.mark.parity
+def test_value_parity_for_representative_batch(
+    registered_model: tuple[object, ReferenceFn],
+) -> None:
+    model, reference = registered_model
+    samples = ["requirement shall trace risk", "verify link", "plain text"]
+
+    assert model.predict(samples) == reference(samples)
+
+
+@pytest.mark.unit
+@pytest.mark.determinism
+def test_determinism_for_representative_batch(
+    registered_model: tuple[object, ReferenceFn],
+) -> None:
+    model, _reference = registered_model
+    samples = ["alpha beta", "shall verify trace", "risk control"]
+
+    assert model.predict(samples) == model.predict(samples)
+
+
+@pytest.mark.unit
+@pytest.mark.parity
+def test_empty_input_returns_empty_batch(registered_model: tuple[object, ReferenceFn]) -> None:
+    model, reference = registered_model
+
+    assert model.predict([]) == reference([]) == []
+
+
+@pytest.mark.unit
+@pytest.mark.determinism
+def test_empty_input_is_deterministic(registered_model: tuple[object, ReferenceFn]) -> None:
+    model, _reference = registered_model
+
+    assert model.predict([]) == model.predict([])
+
+
+@pytest.mark.unit
+@pytest.mark.parity
+def test_single_sample_parity(registered_model: tuple[object, ReferenceFn]) -> None:
+    model, reference = registered_model
+    samples = ["system shall verify trace"]
+
+    assert model.predict(samples) == reference(samples)
+
+
+@pytest.mark.unit
+@pytest.mark.determinism
+def test_single_sample_is_deterministic(registered_model: tuple[object, ReferenceFn]) -> None:
+    model, _reference = registered_model
+    samples = ["system shall verify trace"]
+
+    assert model.predict(samples) == model.predict(samples)
+
+
+@pytest.mark.unit
+@pytest.mark.parity
+def test_large_batch_parity(registered_model: tuple[object, ReferenceFn]) -> None:
+    model, reference = registered_model
+    samples = [f"requirement {index} shall trace" for index in range(32)]
+
+    assert model.predict(samples) == reference(samples)
+
+
+@pytest.mark.unit
+@pytest.mark.determinism
+def test_large_batch_is_deterministic(registered_model: tuple[object, ReferenceFn]) -> None:
+    model, _reference = registered_model
+    samples = [f"requirement {index} shall trace" for index in range(32)]
+
+    assert model.predict(samples) == model.predict(samples)
+
+
+@pytest.mark.unit
+@pytest.mark.parity
+@pytest.mark.determinism
+def test_max_length_sample_parity_and_determinism(
+    registered_model: tuple[object, ReferenceFn],
+) -> None:
+    model, reference = registered_model
+    samples = [MAX_LENGTH_TEXT]
+
+    first = model.predict(samples)
+    second = model.predict(samples)
+
+    assert first == reference(samples)
+    assert first == second

--- a/src/tracertm/ml/test_model_registry.py
+++ b/src/tracertm/ml/test_model_registry.py
@@ -1,0 +1,60 @@
+"""Tests for the ML model registry."""
+
+# ruff: noqa: S101
+
+from pathlib import Path
+
+import pytest
+
+from tracertm.ml import ModelRegistry, ModelRegistryError
+
+
+@pytest.mark.unit
+def test_save_list_and_load_latest(tmp_path: Path) -> None:
+    """Save versions, list metadata, and load the latest version."""
+    registry = ModelRegistry(tmp_path)
+
+    registry.save("ranker", "1.0.0", {"weights": [1]}, metadata={"metric": 0.7})
+    registry.save("ranker", "1.1.0", {"weights": [2]}, metadata={"metric": 0.9})
+
+    entries = registry.list("ranker")
+
+    assert [entry.version for entry in entries] == ["1.1.0", "1.0.0"]
+    assert entries[0].metadata == {"metric": 0.9}
+    assert registry.load("ranker") == {"weights": [2]}
+
+
+@pytest.mark.unit
+def test_pin_controls_default_load_without_blocking_explicit_versions(tmp_path: Path) -> None:
+    """Pinned versions control default loads while explicit versions still work."""
+    registry = ModelRegistry(tmp_path)
+
+    registry.save("classifier", "1.0.0", {"version": "old"})
+    registry.save("classifier", "1.1.0", {"version": "new"}, pin=True)
+    registry.pin("classifier", "1.0.0")
+
+    assert registry.pinned_version("classifier") == "1.0.0"
+    assert registry.load("classifier") == {"version": "old"}
+    assert registry.load("classifier", "1.1.0") == {"version": "new"}
+
+
+@pytest.mark.unit
+def test_save_requires_overwrite_for_existing_version(tmp_path: Path) -> None:
+    """Existing model versions require explicit overwrite."""
+    registry = ModelRegistry(tmp_path)
+    registry.save("embedder", "1.0.0", "first")
+
+    with pytest.raises(ModelRegistryError):
+        registry.save("embedder", "1.0.0", "second")
+
+    registry.save("embedder", "1.0.0", "second", overwrite=True)
+    assert registry.load("embedder", "1.0.0") == "second"
+
+
+@pytest.mark.unit
+def test_rejects_unsafe_model_names(tmp_path: Path) -> None:
+    """Unsafe names cannot escape the registry root."""
+    registry = ModelRegistry(tmp_path)
+
+    with pytest.raises(ModelRegistryError):
+        registry.save("../escape", "v1", object())

--- a/src/tracertm/mlflow_compat.py
+++ b/src/tracertm/mlflow_compat.py
@@ -1,0 +1,203 @@
+"""Small MLflow-compatible tracking client for TraceRTM training runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.parse import ParseResult, urlparse
+
+import httpx
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _as_str(value: object) -> str:
+    return str(value)
+
+
+class Run:
+    """Active MLflow-compatible run."""
+
+    def __init__(
+        self,
+        run_id: str | None = None,
+        tracking_uri: str | None = None,
+        experiment_id: str = "0",
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        """Create a run bound to a file:// or HTTP MLflow-compatible backend."""
+        self.run_id = run_id or uuid.uuid4().hex
+        self.tracking_uri = tracking_uri or "file://.tracertm/mlflow-runs"
+        self.experiment_id = experiment_id
+        self.timeout_seconds = timeout_seconds
+        self._ended = False
+        self._emit("runs/create", {"run_id": self.run_id, "experiment_id": experiment_id})
+
+    def log_metric(self, key: str, value: float | int, step: int = 0) -> None:
+        """Log one scalar metric at a training step."""
+        self._ensure_active()
+        self._emit(
+            "runs/log-metric",
+            {
+                "run_id": self.run_id,
+                "key": key,
+                "value": float(value),
+                "timestamp": _now_ms(),
+                "step": step,
+            },
+        )
+
+    def log_params(self, params: dict[str, object]) -> None:
+        """Log run parameters."""
+        self._ensure_active()
+        for key, value in params.items():
+            self._emit(
+                "runs/log-parameter",
+                {"run_id": self.run_id, "key": key, "value": _as_str(value)},
+            )
+
+    def log_artifact(self, path: str | os.PathLike[str]) -> Path | None:
+        """Log an artifact path, copying it for file:// tracking stores."""
+        self._ensure_active()
+        source = Path(path)
+        copied_to = self._copy_artifact(source)
+        self._emit(
+            "runs/log-artifact",
+            {
+                "run_id": self.run_id,
+                "path": str(source),
+                "local_path": str(copied_to) if copied_to else None,
+            },
+        )
+        return copied_to
+
+    def end(self) -> None:
+        """Mark the run finished."""
+        if self._ended:
+            return
+        self._emit(
+            "runs/update",
+            {"run_id": self.run_id, "status": "FINISHED", "end_time": _now_ms()},
+        )
+        self._ended = True
+
+    def _ensure_active(self) -> None:
+        if self._ended:
+            msg = f"Run {self.run_id} has already ended"
+            raise RuntimeError(msg)
+
+    def _emit(self, endpoint: str, payload: dict[str, Any]) -> None:
+        parsed = urlparse(self.tracking_uri)
+        if parsed.scheme in ("", "file"):
+            self._write_file_event(endpoint, payload)
+            return
+        if parsed.scheme in ("http", "https"):
+            url = self.tracking_uri.rstrip("/") + f"/api/2.0/mlflow/{endpoint}"
+            with httpx.Client(timeout=self.timeout_seconds) as client:
+                client.post(url, json=payload).raise_for_status()
+            return
+        msg = f"Unsupported MLflow tracking URI scheme: {parsed.scheme}"
+        raise ValueError(msg)
+
+    def _write_file_event(self, endpoint: str, payload: dict[str, Any]) -> None:
+        run_dir = self._run_dir()
+        run_dir.mkdir(parents=True, exist_ok=True)
+        event = {
+            "mlflow_endpoint": f"/api/2.0/mlflow/{endpoint}",
+            "payload": payload,
+            "run_id": self.run_id,
+            "timestamp": _now_ms(),
+        }
+        with (run_dir / "events.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+    def _copy_artifact(self, source: Path) -> Path | None:
+        parsed = urlparse(self.tracking_uri)
+        if parsed.scheme not in ("", "file"):
+            return None
+        artifact_dir = self._run_dir() / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        destination = artifact_dir / source.name
+        shutil.copy2(source, destination)
+        return destination
+
+    def _run_dir(self) -> Path:
+        parsed = urlparse(self.tracking_uri)
+        root = Path(parsed.path if parsed.scheme == "file" else self.tracking_uri)
+        return root / self.run_id
+
+
+class TrackingClient:
+    """Minimal client compatible with common MLflow tracking operations."""
+
+    def __init__(self, tracking_uri: str | None = None) -> None:
+        """Create a tracking client with an optional backend URI."""
+        self.tracking_uri = tracking_uri or os.getenv(
+            "MLFLOW_TRACKING_URI",
+            "file://.tracertm/mlflow-runs",
+        )
+
+    def set_tracking_uri(self, uri: str) -> None:
+        """Set the tracking backend URI."""
+        self.tracking_uri = uri
+
+    def start_run(self, run_id: str | None = None, experiment_id: str = "0") -> Run:
+        """Create a new active run."""
+        return Run(run_id=run_id, tracking_uri=self.tracking_uri, experiment_id=experiment_id)
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        """Return run metadata from a file or HTTP tracking backend."""
+        parsed = urlparse(self.tracking_uri)
+        if parsed.scheme in ("", "file"):
+            run_dir = self._file_root(parsed) / run_id
+            return {"run_id": run_id, "path": str(run_dir), "events": self._read_events(run_dir)}
+        if parsed.scheme in ("http", "https"):
+            return self._http_get("/api/2.0/mlflow/runs/get", {"run_id": run_id})
+        msg = f"Unsupported MLflow tracking URI scheme: {parsed.scheme}"
+        raise ValueError(msg)
+
+    def search_runs(self) -> list[dict[str, Any]]:
+        """List runs from a file or HTTP tracking backend."""
+        parsed = urlparse(self.tracking_uri)
+        if parsed.scheme in ("", "file"):
+            root = self._file_root(parsed)
+            if not root.exists():
+                return []
+            return [self.get_run(path.name) for path in sorted(root.iterdir()) if path.is_dir()]
+        if parsed.scheme in ("http", "https"):
+            data = self._http_get("/api/2.0/mlflow/runs/search", {})
+            runs = data.get("runs", data)
+            return runs if isinstance(runs, list) else [runs]
+        msg = f"Unsupported MLflow tracking URI scheme: {parsed.scheme}"
+        raise ValueError(msg)
+
+    def _http_get(self, endpoint: str, params: dict[str, str]) -> dict[str, Any]:
+        with httpx.Client(timeout=5.0) as client:
+            response = client.get(self.tracking_uri.rstrip("/") + endpoint, params=params)
+            response.raise_for_status()
+            return response.json()
+
+    @staticmethod
+    def _file_root(parsed: ParseResult) -> Path:
+        return Path(parsed.path if parsed.scheme == "file" else parsed.geturl())
+
+    @staticmethod
+    def _read_events(run_dir: Path) -> list[dict[str, Any]]:
+        event_file = run_dir / "events.jsonl"
+        if not event_file.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in event_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+
+__all__ = ["Run", "TrackingClient"]

--- a/src/tracertm/test_mlflow_compat.py
+++ b/src/tracertm/test_mlflow_compat.py
@@ -1,0 +1,97 @@
+"""Tests for the MLflow-compatible tracking facade."""
+
+# ruff: noqa: ANN001, ANN002, ANN202, ANN204, D103, S101
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from tracertm.mlflow_compat import Run, TrackingClient
+
+
+def test_file_run_logs_metrics_params_and_artifacts(tmp_path) -> None:
+    artifact = tmp_path / "model.json"
+    artifact.write_text('{"ok": true}', encoding="utf-8")
+    run = Run(tracking_uri=tmp_path.as_uri())
+
+    run.log_params({"model": "ranker", "epochs": 2})
+    run.log_metric("loss", 0.4, step=1)
+    copied_to = run.log_artifact(artifact)
+    run.end()
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / run.run_id / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[1]["payload"] == {"key": "model", "run_id": run.run_id, "value": "ranker"}
+    assert events[3]["payload"]["key"] == "loss"
+    assert events[3]["payload"]["step"] == 1
+    assert copied_to == tmp_path / run.run_id / "artifacts" / "model.json"
+    assert copied_to.read_text(encoding="utf-8") == '{"ok": true}'
+
+
+def test_tracking_client_get_and_search_runs_file_backend(tmp_path) -> None:
+    client = TrackingClient(tmp_path.as_uri())
+    run = client.start_run(run_id="run-1")
+    run.log_metric("accuracy", 0.9, step=3)
+    run.end()
+
+    loaded = client.get_run("run-1")
+    runs = client.search_runs()
+
+    assert loaded["run_id"] == "run-1"
+    assert loaded["events"][1]["payload"]["key"] == "accuracy"
+    assert [item["run_id"] for item in runs] == ["run-1"]
+
+
+def test_http_backend_uses_mlflow_rest_endpoints(monkeypatch) -> None:
+    requests = []
+
+    class FakeClient:
+        def __init__(self, timeout) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def post(self, url, json):
+            requests.append(("POST", url, json))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+        def get(self, url, params):
+            requests.append(("GET", url, params))
+            return httpx.Response(
+                200,
+                json={"runs": [{"info": {"run_id": "abc"}}]},
+                request=httpx.Request("GET", url),
+            )
+
+    monkeypatch.setattr("tracertm.mlflow_compat.httpx.Client", FakeClient)
+    client = TrackingClient("http://mlflow.local")
+    run = client.start_run(run_id="abc")
+    run.log_metric("lr", 0.01, step=4)
+
+    assert client.search_runs() == [{"info": {"run_id": "abc"}}]
+    assert requests[0] == (
+        "POST",
+        "http://mlflow.local/api/2.0/mlflow/runs/create",
+        {"run_id": "abc", "experiment_id": "0"},
+    )
+    assert requests[1][1] == "http://mlflow.local/api/2.0/mlflow/runs/log-metric"
+    assert requests[2][1] == "http://mlflow.local/api/2.0/mlflow/runs/search"
+
+
+def test_ended_run_rejects_late_logging(tmp_path) -> None:
+    run = Run(tracking_uri=tmp_path.as_uri())
+    run.end()
+
+    with pytest.raises(RuntimeError, match="already ended"):
+        run.log_metric("loss", 0.1, step=1)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,61 @@
+"""Tests for content-addressed model registry behavior."""
+
+# ruff: noqa: S101
+
+from pathlib import Path
+
+import pytest
+
+from tracertm.ml.registry import ModelRegistry, ModelRegistryError
+
+
+@pytest.mark.unit
+def test_save_load_and_list_pickle_model(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path)
+
+    first = registry.save("ranker", "1.0.0", {"weights": [1]}, metadata={"auc": 0.7})
+    second = registry.save("ranker", "1.1.0", {"weights": [2]}, metadata={"auc": 0.9})
+
+    assert first.artifact_path.startswith("models/ranker/1.0.0/blobs/")
+    assert second.sha256 != first.sha256
+    assert [entry.version for entry in registry.list("ranker")] == ["1.1.0", "1.0.0"]
+    assert registry.load("ranker") == {"weights": [2]}
+
+
+@pytest.mark.unit
+def test_pin_records_semver_and_sha_for_default_load(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path)
+    registry.save("classifier", "1.0.0", {"version": "old"})
+    registry.save("classifier", "1.1.0", {"version": "new"})
+
+    pinned = registry.pin("classifier", "1.0.0")
+
+    assert registry.pinned_version("classifier") == "1.0.0"
+    assert registry.get("classifier").sha256 == pinned.sha256
+    assert registry.load("classifier") == {"version": "old"}
+    assert registry.load("classifier", "1.1.0") == {"version": "new"}
+
+
+@pytest.mark.unit
+def test_onnx_adapter_stores_content_addressed_blob(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path)
+    payload = b"onnx-model-bytes"
+
+    entry = registry.save("detector", "2.0.0", payload, format="onnx")
+
+    assert entry.format == "onnx"
+    assert entry.artifact_path.endswith(f"{entry.sha256}.onnx")
+    assert (tmp_path / entry.artifact_path).read_bytes() == payload
+    assert registry.load("detector", "2.0.0") == payload
+
+
+@pytest.mark.unit
+def test_rejects_non_semver_and_duplicate_versions(tmp_path: Path) -> None:
+    registry = ModelRegistry(tmp_path)
+
+    with pytest.raises(ModelRegistryError):
+        registry.save("embedder", "v1", object())
+
+    registry.save("embedder", "1.0.0", "first")
+    with pytest.raises(ModelRegistryError):
+        registry.save("embedder", "1.0.0", "second")


### PR DESCRIPTION
## **User description**
Phase 3 of the 2026-06-09 Tracera decouple plan.

**New in this PR (vs existing main):**
- b8213f373 feat(tracera-core): Phase 3 port impact analysis (blast_radius + impact_analysis)

**Already on main from earlier merges (for context):**
- Phases 0/1/2: entity model + matrix
- ML infra: model registry, mlflow compat, 50 inference tests

**Phase 3 ships:**
- ImpactNode, ImpactEdge, ImpactGraph (typed nodes/edges with kinds)
- BFS/DFS traversal with depth limit
- Node/edge kind taxonomy
- blast_radius: BFS from source, returns all reachable
- impact_score: weighted (severity × reach × centrality × confidence)
- critical_path: shortest path to risk/evidence
- top_k: highest-impact K nodes
- summarize: per-kind counts + total score
- 8 new unit tests (25 lib + 8 impact + 39 doc + 41 matrix = 113+)

Refs: plans/2026-06-09-tracera-decouple-plan-v1.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New impact-scoring logic could mis-rank downstream artifacts if matrix keys or link semantics diverge from production data; dual registries and pinned defaults affect which model artifacts load in ML paths.
> 
> **Overview**
> **Phase 3 traceability in Rust:** Adds `compute_impact` to walk a coverage matrix from seed artifacts via bidirectional BFS, apply kind weights and link-type multipliers (including negative `ConflictsWith`), enforce `max_depth`, and return an `ImpactReport` (blast nodes, totals, conflicts, truncation). **`tracera-core`** also lands the canonical trace-link model, **matrix** build/query/diff with per-cell coverage classification, and re-exports wired through `lib.rs`.
> 
> **ML artifact lifecycle (Go + Python):** Introduces content-addressed model registries (`registry.json`, semver validation, SHA256-checked blobs, version **pinning** for default loads). Python adds format adapters (pickle/sklearn/pytorch/onnx), optional overwrite on save, an **MLflow-compatible** file/HTTP tracking client, inference parity/determinism tests, `docs/ML-OPERATIONS.md`, pytest markers for ML tests, and a small training demo script.
> 
> **Note:** Impact tests populate `TraceLink` with `from`/`to` artifact refs while production `TraceLink` in `lib.rs` is UUID-based—worth confirming alignment before wiring callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ac032427408acb9dfac90ae2af390d7fc036a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add content-addressed model storage, MLflow-style run logging, and impact analysis**

### What Changed
- Model saves now keep a checksum-backed artifact, support pinned default versions, and reject invalid or duplicate version entries
- Python code can log training runs, metrics, parameters, and artifacts through a local file store or an MLflow-compatible HTTP endpoint
- Inference models now have parity and repeatability checks, and the test suite covers the new registry and tracking behavior
- Tracera core adds matrix diffing plus blast-radius and impact scoring so changed artifacts can be traced through downstream dependencies
- ML operations docs and test markers were updated to reflect the new training, evaluation, and monitoring workflow

### Impact
`✅ Safer model version pinning`
`✅ Clearer training run tracking`
`✅ More reliable impact analysis`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
