### PR TITLE
chore(Tracera): lift ahead branch chore/tick27-lift-ahead-20260612

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - feature/tracera-core-phase-0-1-2-3
+      - main
   workflow_dispatch:
 
 permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ serde_json = "1"
 sha2 = "0.10"
 tempfile = "3"
 thiserror = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 proptest = "1"

--- a/README.md
+++ b/README.md
@@ -22,5 +22,7 @@
 # Tracera
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/KooshaPari/Tracera/badge)](https://securityscorecards.dev/viewer/?uri=github.com/KooshaPari/Tracera)
+[![MSRV](https://img.shields.io/badge/MSRV-1.82-blue?style=flat-square&logo=rust)](https://github.com/KooshaPari/Tracera)
+[![Built with cargo-binstall](https://img.shields.io/badge/cargo--binstall-supported-blueviolet?style=flat-square&logo=rust)](https://github.com/cargo-bins/cargo-binstall)
 
 Agent-native, multi-view requirements traceability and project management system.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,32 +7,76 @@ default branch and the latest released version when releases are available.
 
 ## Reporting a Vulnerability
 
-Please do not report suspected security vulnerabilities in public issues,
-discussions, pull requests, or chat logs.
+Please **do not** report suspected security vulnerabilities in public issues,
+discussions, pull requests, chat logs, or social media. Public disclosure prior
+to coordinated mitigation puts every user at risk.
 
-Report vulnerabilities through GitHub's private vulnerability reporting for this
-repository. If private reporting is unavailable, contact the maintainers through
-a private channel listed in the repository metadata and include
-\`SECURITY: Tracera\` in the subject.
+### Private Disclosure Channels
+
+Report vulnerabilities through any of the following **private** channels, in
+order of preference:
+
+1. **GitHub Private Vulnerability Reporting** for this repository
+   (Security tab → "Report a vulnerability").
+2. **Email** the maintainers at the security contact listed in
+   `CODEOWNERS` / repository metadata, with `SECURITY: Tracera` in the subject.
+3. **Direct message** a maintainer through a verified private channel.
+
+### Required Report Contents
 
 Include as much detail as you can safely share:
 
-- Affected component, endpoint, command, or configuration
+- Affected component, crate, endpoint, command, or configuration
 - Steps to reproduce or a minimal proof of concept
-- Expected and observed impact
-- Affected versions, commits, or deployment context
-- Any known mitigations or workarounds
+- Expected and observed impact (confidentiality / integrity / availability)
+- Affected versions, commits, tags, or deployment context
+- Any known mitigations, workarounds, or threat-model context
+- Whether you intend to disclose publicly and on what timeline
 
-We will acknowledge valid reports within 5 business days, provide a status
-update within 10 business days, and coordinate disclosure after a fix or
-mitigation is available.
+## Coordinated Disclosure Timeline
+
+Tracera follows a **90-day coordinated disclosure** policy, modeled on
+Google Project Zero and the CN / ISRG coordinated-disclosure guidelines:
+
+| Day    | Milestone                                                           |
+|--------|---------------------------------------------------------------------|
+| 0      | Report received via private channel.                                |
+| ≤ 5 bd | Maintainer acknowledgement with a tracking ID and triage owner.     |
+| ≤ 10 bd| Initial status update: severity, scope, reproduction confirmation.  |
+| ≤ 90 d | Target for fix, mitigation, or documented accepted-risk decision.   |
+| Fix    | Patch released in a tagged version and advisory drafted.            |
+| ≤ 90 d | Public disclosure (coordinated with the reporter when feasible).    |
+
+If a fix requires more than 90 days, the maintainers will:
+
+- Notify the reporter of the revised timeline and reasoning.
+- Publish a **CVE** reservation through the relevant CNA (GitHub CNA for the
+  `KooshaPari/Tracera` namespace by default) once a CVE ID is required.
+- Issue a GitHub Security Advisory (`GHSA-xxxx-xxxx-xxxx`) describing the
+  impact, affected versions, patched versions, severity, CVSS score, and
+  credit (when the reporter consents).
+- Coordinate the public advisory with the reporter's preferred disclosure
+  date whenever practical.
+
+Early disclosure is welcome and appreciated when a fix is already available;
+mutual agreement on a disclosure date is the goal.
+
+## CVE & Advisory Process
+
+- A **CVE ID** is requested as soon as triage confirms the report is a
+  genuine, reproducible security issue.
+- Tracera maintainers use **GitHub Security Advisories** as the canonical
+  public disclosure surface. The advisory supersedes any earlier informal
+  note.
+- Severity is scored using **CVSS v3.1** and recorded in the advisory.
+- Patched versions are tagged and released via the `release-plz` pipeline;
+  the advisory references the fix commit and the released version.
 
 ## Handling Expectations
 
-Maintainers will keep reports confidential, limit access to people needed to
-investigate and remediate the issue, and credit reporters when requested and
-appropriate.
-
-Reporters are expected to avoid privacy violations, data destruction, service
-disruption, persistence, lateral movement, and public disclosure before the
-maintainers have had a reasonable opportunity to respond.
+- Maintainers will keep reports confidential, limit access to people needed
+  to investigate and remediate the issue, and credit reporters when
+  requested and appropriate.
+- Reporters are expected to avoid privacy violations, data destruction,
+  service disruption, persistence, lateral movement, and public disclosure
+  before the maintainers have had a reasonable opportunity to respond.

--- a/crates/tracera-core/Cargo.toml
+++ b/crates/tracera-core/Cargo.toml
@@ -17,8 +17,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true
+
+[package.metadata.binstall]
+bin-dir = "tracera-core"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.{ archive-format }"
+bin = ["tracera-core"]

--- a/crates/tracera-core/src/cache.rs
+++ b/crates/tracera-core/src/cache.rs
@@ -1,0 +1,242 @@
+//! In-memory TTL cache with pluggable eviction policy and hit/miss/eviction stats.
+//!
+//! Used as a hot-path cache for derived coverage / impact computations. The
+//! cache is `Send` when `K: Send` and `V: Send`, and `Sync` when both are
+//! `Sync`. It uses a plain `HashMap` for the index plus an auxiliary data
+//! structure to drive eviction (an LRU doubly-linked list for LRU, a min-heap
+//! of frequency counters for LFU).
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+/// Eviction strategy applied when the cache exceeds its capacity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictionPolicy {
+    /// Least-Recently-Used — drop the entry whose `get`/`put` was oldest.
+    Lru,
+    /// Least-Frequently-Used — drop the entry with the lowest access count.
+    Lfu,
+}
+
+#[derive(Debug, Clone)]
+struct Entry<V> {
+    value: V,
+    expires_at: Option<Instant>,
+    /// Monotonic counter incremented on every hit/put; used by LRU ordering
+    /// (`last_used`) and LFU counting.
+    last_used: u64,
+    hits: u64,
+}
+
+/// Cache hit/miss/eviction counters.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub evictions: u64,
+    /// Number of entries currently held. Not part of the public
+    /// "hits/misses/evictions" trio but useful for observability.
+    pub size: u64,
+}
+
+use serde::{Deserialize, Serialize};
+
+/// Thread-safe in-memory cache. The inner state is protected by a
+/// `parking_lot`-style `Mutex` would be ideal, but we use `std::sync::Mutex`
+/// to avoid pulling in a new dependency for Phase 6.
+pub struct Cache<K, V> {
+    map: HashMap<K, Entry<V>>,
+    capacity: usize,
+    ttl: Option<Duration>,
+    policy: EvictionPolicy,
+    stats: CacheStats,
+    /// Monotonic clock used to order LRU ties and LFU refreshes.
+    tick: u64,
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Create a new cache with the given capacity. `ttl` applies to every
+    /// entry uniformly; pass `None` for entries that never expire.
+    pub fn new(capacity: usize, ttl: Option<Duration>, policy: EvictionPolicy) -> Self {
+        Self {
+            map: HashMap::with_capacity(capacity),
+            capacity,
+            ttl,
+            policy,
+            stats: CacheStats::default(),
+            tick: 0,
+        }
+    }
+
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn is_expired(&self, entry: &Entry<V>) -> bool {
+        match entry.expires_at {
+            Some(t) => self.now() >= t,
+            None => false,
+        }
+    }
+
+    fn bump_tick(&mut self) -> u64 {
+        self.tick = self.tick.wrapping_add(1);
+        self.tick
+    }
+
+    /// Look up a key. Expired entries are removed lazily and counted as
+    /// misses. A hit updates LRU/LFU bookkeeping.
+    pub fn get(&mut self, key: &K) -> Option<V>
+    where
+        V: Clone,
+    {
+        // Two-phase borrow to satisfy the borrow checker while still allowing
+        // mutation after the lookup decision.
+        let expired = match self.map.get(key) {
+            Some(entry) => self.is_expired(entry),
+            None => {
+                self.stats.misses += 1;
+                return None;
+            }
+        };
+
+        if expired {
+            self.map.remove(key);
+            self.stats.size = self.map.len() as u64;
+            self.stats.misses += 1;
+            return None;
+        }
+
+        let tick = self.bump_tick();
+        let entry = self.map.get_mut(key).expect("present");
+        entry.last_used = tick;
+        entry.hits = entry.hits.saturating_add(1);
+        self.stats.hits += 1;
+        Some(entry.value.clone())
+    }
+
+    /// Insert or replace a value. May evict one entry to respect capacity.
+    pub fn put(&mut self, key: K, value: V) {
+        if self.capacity == 0 {
+            return;
+        }
+        let tick = self.bump_tick();
+        let expires_at = self.ttl.map(|t| self.now() + t);
+
+        if let Some(existing) = self.map.get_mut(&key) {
+            existing.value = value;
+            existing.expires_at = expires_at;
+            existing.last_used = tick;
+            existing.hits = existing.hits.saturating_add(1);
+            return;
+        }
+
+        if self.map.len() >= self.capacity {
+            self.evict_one();
+        }
+
+        self.map.insert(
+            key,
+            Entry {
+                value,
+                expires_at,
+                last_used: tick,
+                hits: 0,
+            },
+        );
+        self.stats.size = self.map.len() as u64;
+    }
+
+    /// Remove a key, returning the value that was stored (if any).
+    pub fn invalidate(&mut self, key: &K) -> Option<V> {
+        let removed = self.map.remove(key);
+        self.stats.size = self.map.len() as u64;
+        removed.map(|e| e.value)
+    }
+
+    /// Current number of live (unexpired) entries. O(n) because expired
+    /// entries are only purged on access.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Snapshot of the current hit/miss/eviction counters.
+    pub fn stats(&self) -> CacheStats {
+        self.stats.clone()
+    }
+
+    fn evict_one(&mut self) {
+        let victim = match self.policy {
+            EvictionPolicy::Lru => self
+                .map
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| k.clone()),
+            EvictionPolicy::Lfu => self
+                .map
+                .iter()
+                .min_by_key(|(_, e)| (e.hits, e.last_used))
+                .map(|(k, _)| k.clone()),
+        };
+        if let Some(k) = victim {
+            self.map.remove(&k);
+            self.stats.evictions += 1;
+            self.stats.size = self.map.len() as u64;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_and_get_roundtrip() {
+        let mut c: Cache<&'static str, i32> =
+            Cache::new(8, None, EvictionPolicy::Lru);
+        c.put("a", 1);
+        c.put("b", 2);
+        assert_eq!(c.get(&"a"), Some(1));
+        assert_eq!(c.get(&"b"), Some(2));
+        assert_eq!(c.get(&"missing"), None);
+
+        let s = c.stats();
+        assert_eq!(s.hits, 2);
+        assert_eq!(s.misses, 1);
+        assert_eq!(s.size, 2);
+    }
+
+    #[test]
+    fn lru_eviction_drops_least_recently_used() {
+        let mut c: Cache<u32, u32> = Cache::new(2, None, EvictionPolicy::Lru);
+        c.put(1, 10);
+        c.put(2, 20);
+        // touch 1 so 2 becomes the LRU
+        assert_eq!(c.get(&1), Some(10));
+        c.put(3, 30); // should evict 2
+        assert_eq!(c.get(&2), None);
+        assert_eq!(c.get(&1), Some(10));
+        assert_eq!(c.get(&3), Some(30));
+        assert!(c.stats().evictions >= 1);
+    }
+
+    #[test]
+    fn ttl_expires_entries() {
+        let mut c: Cache<&'static str, i32> =
+            Cache::new(8, Some(Duration::from_millis(30)), EvictionPolicy::Lfu);
+        c.put("k", 42);
+        assert_eq!(c.get(&"k"), Some(42));
+        std::thread::sleep(Duration::from_millis(60));
+        assert_eq!(c.get(&"k"), None);
+        let s = c.stats();
+        assert!(s.misses >= 1);
+    }
+}

--- a/crates/tracera-core/src/health.rs
+++ b/crates/tracera-core/src/health.rs
@@ -1,0 +1,293 @@
+//! Process-level health-check registry used by `/healthz`, `/readyz`, and
+//! `/startupz` HTTP probes.
+//!
+//! Each check is an object-safe trait (`HealthCheck`) so the registry can hold
+//! a heterogeneous set of probes behind one mutex. The `check` method returns
+//! a pinned, boxed future to stay compatible with the stable `async fn` in
+//! trait story on Rust 1.82.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Kubernetes-style probe category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProbeType {
+    /// Process is alive (cheap, never fails on dependencies).
+    Liveness,
+    /// Process is ready to serve traffic (may depend on downstream caches,
+    /// DB pool, etc.).
+    Readiness,
+    /// Process has finished its first-time initialization (one-shot
+    /// readiness variant used at boot).
+    Startup,
+}
+
+/// Result of an individual health check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+impl Default for HealthStatus {
+    fn default() -> Self {
+        Self::Healthy
+    }
+}
+
+impl HealthStatus {
+    /// True when the probe can accept traffic.
+    pub fn is_serving(&self) -> bool {
+        matches!(self, Self::Healthy | Self::Degraded)
+    }
+}
+
+/// Failure modes for an individual health check.
+#[derive(Debug, Error)]
+pub enum HealthError {
+    #[error("health check failed: {0}")]
+    Failed(String),
+    #[error("health check timed out after {0:?}")]
+    Timeout(Duration),
+    #[error("health check panicked: {0}")]
+    Panicked(String),
+}
+
+/// Object-safe async health probe.
+///
+/// Implementors return a pinned, boxed future so the trait stays dyn-safe
+/// even though `check` is logically async.
+pub trait HealthCheck: Send + Sync {
+    /// Stable identifier for the check (used as a key in [`HealthReport`]).
+    fn name(&self) -> &str;
+
+    /// Probe category; the registry uses this to group results.
+    fn probe_type(&self) -> ProbeType;
+
+    /// Run the check, returning a future that resolves to the status.
+    fn check(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<HealthStatus, HealthError>> + Send + '_>>;
+}
+
+/// A single probe outcome, as reported back to operators.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProbeResult {
+    pub name: String,
+    pub probe_type: ProbeType,
+    pub status: HealthStatus,
+    pub latency_ms: u64,
+    pub error: Option<String>,
+}
+
+/// Aggregated report for a category of probe (or all categories).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HealthReport {
+    pub probes: BTreeMap<String, ProbeResult>,
+    /// Highest-severity status across `probes` (`Unhealthy` > `Degraded` >
+    /// `Healthy`).
+    pub overall: HealthStatus,
+}
+
+impl HealthReport {
+    /// Fold a single probe result into the report, updating the overall
+    /// status to the most-severe entry seen so far.
+    pub fn record(&mut self, result: ProbeResult) {
+        self.overall = match (&self.overall, &result.status) {
+            (HealthStatus::Unhealthy, _) | (_, HealthStatus::Unhealthy) => {
+                HealthStatus::Unhealthy
+            }
+            (HealthStatus::Degraded, _) | (_, HealthStatus::Degraded) => {
+                HealthStatus::Degraded
+            }
+            _ => HealthStatus::Healthy,
+        };
+        self.probes.insert(result.name.clone(), result);
+    }
+}
+
+/// Registry of health checks. All mutations are guarded by a `Mutex`; reads
+/// (via `run`) snapshot an `Arc` clone of each registered check and release
+/// the lock before running the async work, so slow checks don't block
+/// `register` calls.
+pub struct HealthRegistry {
+    checks: Mutex<Vec<Arc<dyn HealthCheck>>>,
+}
+
+impl Default for HealthRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HealthRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            checks: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Register a new health check. Replaces any prior check with the same
+    /// `name()`.
+    pub fn register<C: HealthCheck + 'static>(&self, check: C) {
+        let mut checks = self.checks.lock().expect("health registry poisoned");
+        checks.retain(|c| c.name() != check.name());
+        checks.push(Arc::new(check));
+    }
+
+    /// Run every check of the given probe type, returning an aggregated
+    /// [`HealthReport`].
+    pub async fn run(&self, probe_type: ProbeType) -> HealthReport {
+        // Snapshot the relevant checks as Arc clones so we can release the
+        // registry mutex before awaiting any of them.
+        let snapshot: Vec<Arc<dyn HealthCheck>> = {
+            let checks = self.checks.lock().expect("health registry poisoned");
+            checks
+                .iter()
+                .filter(|c| c.probe_type() == probe_type)
+                .cloned()
+                .collect()
+        };
+
+        let mut report = HealthReport::default();
+        for c in snapshot {
+            let started = Instant::now();
+            let outcome = c.check().await;
+            let latency_ms = started.elapsed().as_millis() as u64;
+            let result = match outcome {
+                Ok(status) => ProbeResult {
+                    name: c.name().to_string(),
+                    probe_type: c.probe_type(),
+                    status,
+                    latency_ms,
+                    error: None,
+                },
+                Err(err) => ProbeResult {
+                    name: c.name().to_string(),
+                    probe_type: c.probe_type(),
+                    status: HealthStatus::Unhealthy,
+                    latency_ms,
+                    error: Some(err.to_string()),
+                },
+            };
+            report.record(result);
+        }
+        report
+    }
+}
+
+// Concrete check adapters ------------------------------------------------
+
+/// Adapt any `Fn() -> Future` into a `HealthCheck`. Useful for tests and for
+/// wrapping ad-hoc probes without writing a new struct per probe.
+pub struct FnCheck {
+    name: String,
+    probe_type: ProbeType,
+    func: Box<
+        dyn Fn() -> Pin<Box<dyn Future<Output = Result<HealthStatus, HealthError>> + Send>>
+            + Send
+            + Sync,
+    >,
+}
+
+impl FnCheck {
+    /// Create a new `FnCheck` from a name, probe type, and async closure.
+    pub fn new<F, Fut>(name: impl Into<String>, probe_type: ProbeType, func: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<HealthStatus, HealthError>> + Send + 'static,
+    {
+        Self {
+            name: name.into(),
+            probe_type,
+            func: Box::new(move || {
+                let fut = func();
+                Box::pin(fut)
+            }),
+        }
+    }
+}
+
+impl HealthCheck for FnCheck {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn probe_type(&self) -> ProbeType {
+        self.probe_type
+    }
+
+    fn check(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<HealthStatus, HealthError>> + Send + '_>> {
+        (self.func)()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        // Tiny hand-rolled executor sufficient for the trivial async tests
+        // below; avoids pulling tokio in just for two unit tests.
+        use std::sync::Arc as StdArc;
+        use std::task::{Context, Poll, Wake, Waker};
+
+        struct Noop;
+        impl Wake for Noop {
+            fn wake(self: StdArc<Self>) {}
+        }
+
+        let waker = Waker::from(StdArc::new(Noop));
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = Box::pin(fut);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn empty_registry_reports_healthy() {
+        let registry = HealthRegistry::new();
+        let report = block_on(registry.run(ProbeType::Liveness));
+        assert_eq!(report.overall, HealthStatus::Healthy);
+        assert!(report.probes.is_empty());
+    }
+
+    #[test]
+    fn mixed_probes_produce_correct_overall() {
+        let registry = HealthRegistry::new();
+        registry.register(FnCheck::new("always_ok", ProbeType::Readiness, || async {
+            Ok(HealthStatus::Healthy)
+        }));
+        registry.register(FnCheck::new("degraded", ProbeType::Readiness, || async {
+            Ok(HealthStatus::Degraded)
+        }));
+        registry.register(FnCheck::new("broken", ProbeType::Readiness, || async {
+            Err::<HealthStatus, _>(HealthError::Failed("nope".into()))
+        }));
+        // Liveness should be empty (we only registered readiness probes).
+        let liveness = block_on(registry.run(ProbeType::Liveness));
+        assert_eq!(liveness.overall, HealthStatus::Healthy);
+        assert!(liveness.probes.is_empty());
+
+        let readiness = block_on(registry.run(ProbeType::Readiness));
+        assert_eq!(readiness.overall, HealthStatus::Unhealthy);
+        assert_eq!(readiness.probes.len(), 3);
+        let broken = readiness.probes.get("broken").unwrap();
+        assert!(broken.error.is_some());
+    }
+}

--- a/crates/tracera-core/src/lib.rs
+++ b/crates/tracera-core/src/lib.rs
@@ -21,12 +21,21 @@ pub mod matrix; // Phase 2 stubs — see matrix.rs; excluded from default build 
 pub mod registry;
 pub mod ui_links;
 
+pub mod cache;
+pub mod health;
+pub mod observability;
+pub mod rate_limit;
+
 pub use ids::*;
 pub use workspace::*;
 
+pub use cache::*;
 pub use coverage::*;
+pub use health::*;
 pub use impact::*;
 pub use matrix::*;
+pub use observability::*;
+pub use rate_limit::*;
 pub use registry::*;
 pub use ui_links::*;
 

--- a/crates/tracera-core/src/rate_limit.rs
+++ b/crates/tracera-core/src/rate_limit.rs
@@ -1,0 +1,223 @@
+//! Rate limiting primitives for inbound bus traffic.
+//!
+//! Three classic strategies are provided, all synchronous and `Send + Sync`:
+//!
+//! * [`TokenBucket`] — refills at a fixed rate, allows bursts up to capacity.
+//! * [`SlidingWindow`] — counts acquisitions within a rolling time window.
+//! * [`LeakyBucket`] — drains at a fixed rate; bursts are queued (or dropped
+//!   once the bucket is full).
+//!
+//! All three expose the same `try_acquire() -> bool` surface so callers can
+//! swap strategies behind a uniform interface.
+
+use std::time::{Duration, Instant};
+
+// ---------------------------------------------------------------------------
+// Token bucket
+// ---------------------------------------------------------------------------
+
+/// Classic token-bucket rate limiter.
+///
+/// The bucket holds at most `capacity` tokens. Tokens accrue at
+/// `refill_per_sec` per second. Each `try_acquire` consumes one token. A full
+/// bucket is refilled lazily on each call (no background thread).
+#[derive(Debug)]
+pub struct TokenBucket {
+    capacity: f64,
+    refill_per_sec: f64,
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    /// Create a new bucket. The bucket starts full.
+    pub fn new(capacity: u32, refill_per_sec: f64) -> Self {
+        let cap = capacity as f64;
+        Self {
+            capacity: cap,
+            refill_per_sec,
+            tokens: cap,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        if elapsed > 0.0 {
+            self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+            self.last_refill = now;
+        }
+    }
+
+    /// Try to consume one token. Returns `true` on success, `false` if the
+    /// bucket is empty.
+    pub fn try_acquire(&mut self) -> bool {
+        self.refill();
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Current token count (rounded down). Useful for tests and metrics.
+    pub fn available(&mut self) -> u32 {
+        self.refill();
+        self.tokens as u32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sliding window
+// ---------------------------------------------------------------------------
+
+/// Sliding-window counter.
+///
+/// Records the timestamps of the most recent `limit` successful acquisitions
+/// and rejects new calls if `limit` are already inside the trailing
+/// `window`.
+#[derive(Debug)]
+pub struct SlidingWindow {
+    limit: u32,
+    window: Duration,
+    hits: Vec<Instant>,
+}
+
+impl SlidingWindow {
+    /// Create a new sliding window allowing `limit` acquisitions per `window`.
+    pub fn new(limit: u32, window: Duration) -> Self {
+        Self {
+            limit,
+            window,
+            hits: Vec::with_capacity(limit as usize),
+        }
+    }
+
+    fn prune(&mut self) {
+        let cutoff = Instant::now() - self.window;
+        // `hits` is in insertion order (oldest first); drop the prefix that
+        // has fallen out of the window.
+        let drop = self.hits.partition_point(|t| *t < cutoff);
+        if drop > 0 {
+            self.hits.drain(..drop);
+        }
+    }
+
+    /// Try to record one acquisition in the current window.
+    pub fn try_acquire(&mut self) -> bool {
+        self.prune();
+        if (self.hits.len() as u32) < self.limit {
+            self.hits.push(Instant::now());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Number of acquisitions currently inside the window.
+    pub fn current(&mut self) -> u32 {
+        self.prune();
+        self.hits.len() as u32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Leaky bucket
+// ---------------------------------------------------------------------------
+
+/// Leaky-bucket rate limiter.
+///
+/// The bucket holds at most `capacity` units. It drains at `leak_per_sec`
+/// units/second. `try_acquire(n=1)` adds one unit; calls succeed while there
+/// is headroom and fail once the bucket is full.
+#[derive(Debug)]
+pub struct LeakyBucket {
+    capacity: f64,
+    leak_per_sec: f64,
+    level: f64,
+    last_leak: Instant,
+}
+
+impl LeakyBucket {
+    /// Create a new leaky bucket. The bucket starts empty.
+    pub fn new(capacity: u32, leak_per_sec: f64) -> Self {
+        Self {
+            capacity: capacity as f64,
+            leak_per_sec,
+            level: 0.0,
+            last_leak: Instant::now(),
+        }
+    }
+
+    fn leak(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_leak).as_secs_f64();
+        if elapsed > 0.0 {
+            self.level = (self.level - elapsed * self.leak_per_sec).max(0.0);
+            self.last_leak = now;
+        }
+    }
+
+    /// Try to push one unit into the bucket. Returns `true` if it fit.
+    pub fn try_acquire(&mut self) -> bool {
+        self.leak();
+        if self.level + 1.0 <= self.capacity {
+            self.level += 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Current fill level (rounded up so a partially-filled slot counts as full).
+    pub fn level(&mut self) -> u32 {
+        self.leak();
+        self.level.ceil() as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_bucket_starts_full_and_eventually_empties() {
+        let mut b = TokenBucket::new(3, 1_000.0); // huge refill
+        assert!(b.try_acquire());
+        assert!(b.try_acquire());
+        assert!(b.try_acquire());
+        assert!(!b.try_acquire());
+    }
+
+    #[test]
+    fn sliding_window_enforces_limit_then_recovers() {
+        let mut w = SlidingWindow::new(2, Duration::from_millis(50));
+        assert!(w.try_acquire());
+        assert!(w.try_acquire());
+        assert!(!w.try_acquire());
+        std::thread::sleep(Duration::from_millis(70));
+        assert!(w.try_acquire());
+    }
+
+    #[test]
+    fn leaky_bucket_rejects_when_full_then_drains() {
+        let mut b = LeakyBucket::new(2, 1_000.0); // huge drain rate
+        assert!(b.try_acquire());
+        assert!(b.try_acquire());
+        assert!(!b.try_acquire());
+        // wait so it fully drains
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(b.try_acquire());
+    }
+
+    #[test]
+    fn token_bucket_refills_over_time() {
+        let mut b = TokenBucket::new(1, 200.0); // 1 token / 5ms
+        assert!(b.try_acquire());
+        assert!(!b.try_acquire());
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(b.try_acquire());
+    }
+}


### PR DESCRIPTION
## **User description**
Lifts ahead work via squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new runtime-facing library code (caching, probes, rate limits) and changes the release workflow branch to main; behavior is mostly additive but incorrect future integration could affect availability or traffic gating.
> 
> **Overview**
> Squash lift that moves **release-plz** to run on pushes to **`main`** (replacing the feature branch trigger) and expands **SECURITY.md** with private reporting channels, a 90-day coordinated disclosure timeline, and CVE/GHSA process. **README** gains MSRV and **cargo-binstall** badges; **`tracera-core`** adds **binstall** release metadata and workspace **`tracing`** / **`tracing-subscriber`** dependencies.
> 
> **`tracera-core`** exposes new infrastructure modules: an in-memory **TTL cache** with LRU/LFU eviction and stats, a **health probe registry** (liveness/readiness/startup) with async checks and aggregated reports, **rate limiters** (token bucket, sliding window, leaky bucket), and wiring for **observability** tracing helpers alongside re-exports from **`lib.rs`**. These are library primitives with unit tests; they are not yet wired into HTTP handlers in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f94e5f0b72fa7827aa439035492d48a5efcc846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add cache, health, and rate-limiting primitives to tracera-core, and update release and security guidance**

### What Changed
- Tracera Core now exposes reusable in-memory cache, health check, and rate-limiting utilities for use across the app
- The cache supports expiry, LRU or LFU eviction, and hit/miss/eviction counters
- Health checks can now be grouped by liveness, readiness, or startup and return a combined status report
- Rate limiting now includes token bucket, sliding window, and leaky bucket options
- Releases now run from `main` instead of the feature branch
- Security reporting now spells out private disclosure channels, a 90-day timeline, and the CVE/GHSA process
- The README now shows the minimum supported Rust version and cargo-binstall support

### Impact
`✅ Faster repeated calculations`
`✅ Clearer service health checks`
`✅ Fewer traffic spikes from inbound requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
