### PR TITLE
chore: add root .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{rs,toml,py}]
+indent_size = 4
+
+[*.{js,ts,jsx,tsx,json,yml,yaml}]
+indent_size = 2
+
+[*.go]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = 120
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Adds a normalized root  covering Rust, Python, Go, JS/TS, JSON, YAML, and Markdown files.