### PR TITLE
DIAGNOSIS: tests/chaos/conftest.py async fixtures — no such file exists

### DIFF
--- a/DIAGNOSIS.md
+++ b/DIAGNOSIS.md
@@ -1,0 +1,8 @@
+# CI Chaos Diagnosis
+
+## Task
+Investigate `tests/chaos/conftest.py` async fixture failures causing CI to go red.
+
+## Findings
+
+### 1. No `tests/chaos/` directory exists


### PR DESCRIPTION
# CI Chaos Diagnosis

## Task
Investigate `tests/chaos/conftest.py` async fixture failures causing CI to go red.

## Findings

### 1. No `tests/chaos/` directory exists
