### PR TITLE
layer: chore/gitignore-hardening2 — chore: harden .gitignore for build/cache/coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,94 @@
+# Rust
+/target
+Cargo.lock
+**/*.rs.bk
+*.pdb
+*.so
+*.dylib
+*.dll
+
+# Python
+__pycache__/
+*.py[cod]
+*.class
+*.egg-info/
+.eggs/
+*.egg
+dist/
+build/
+wheels/
+*.whl
+.venv/
+venv/
+env/
+ENV/
+.pytest_cache/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.ruff_cache/
+.uv/
+pip-wheel-metadata/
+*.manifest
+*.spec
+
+# Go
+*.exe
+*.test
+*.out
+vendor/
+
+# Node/TypeScript
+node_modules/
+dist/
+build/
+*.tsbuildinfo
+.npm
+.eslintcache
+.stylelintcache
+.parcel-cache
+.next/
+.nuxt/
+.vuepress/dist
+.docusaurus/
+.cache/
+
+# Coverage
+coverage/
+*.lcov
+.nyc_output/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# IDEs / Editors
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+*.sublime-workspace
+*.sublime-project
+
+# Logs
+*.log
+logs/
+
+# OS
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Misc
+*.bak
+*.tmp
+*.temp
+.env
+.env.local
+.env.*.local
+!.env.example


### PR DESCRIPTION
Layered PR: `chore/gitignore-hardening2` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo hygiene only; no application or infrastructure behavior changes.
> 
> **Overview**
> Introduces a **root `.gitignore`** so common build outputs, caches, coverage reports, editor junk, logs, and OS files stay out of version control across the stack’s **Rust, Python, Go, and Node/TypeScript** workflows.
> 
> It also **blocks `.env` and local env variants** while **keeping `.env.example` committable** via `!.env.example`, reducing accidental secret commits without dropping the template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c23c95bb2ed4fabc70c3d743fb83625a377c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->