### PR TITLE
layer: codex/ci-disable-authkit-performance-env-20260426 — fix: align performance smoke schema guards

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -204,8 +204,6 @@ jobs:
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
-          WORKOS_REDIRECT_URI: http://localhost:8080/api/v1/auth/authkit/callback
-          AUTHKIT_JWT_SECRET: ci-authkit-jwt-secret-at-least-32-bytes
           CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
           TRACING_ENABLED: "false"
 
@@ -367,8 +365,6 @@ jobs:
           WORKOS_CLIENT_ID: client_ci_performance
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
-          WORKOS_REDIRECT_URI: http://localhost:8080/api/v1/auth/authkit/callback
-          AUTHKIT_JWT_SECRET: ci-authkit-jwt-secret-at-least-32-bytes
           CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
           TRACING_ENABLED: "false"
 

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -470,14 +470,22 @@ jobs:
           script: |
             const fs = require('fs');
             const summary = JSON.parse(fs.readFileSync('results/smoke/smoke-test-summary.json', 'utf8'));
+            const metricValue = (metric, ...keys) => {
+              for (const key of keys) {
+                if (summary.metrics[metric] && summary.metrics[metric][key] !== undefined) {
+                  return summary.metrics[metric][key];
+                }
+              }
+              return 0;
+            };
 
             const comment = `
             ## Performance Test Results
 
             ### Smoke Test
-            - **Total Requests**: ${summary.metrics.http_reqs.count}
-            - **P95 Latency**: ${summary.metrics.http_req_duration.p95.toFixed(2)}ms
-            - **Error Rate**: ${(summary.metrics.http_req_failed.rate * 100).toFixed(2)}%
+            - **Total Requests**: ${metricValue('http_reqs', 'count')}
+            - **P95 Latency**: ${metricValue('http_req_duration', 'p(95)', 'p95').toFixed(2)}ms
+            - **Error Rate**: ${(metricValue('http_req_failed', 'rate') * 100).toFixed(2)}%
 
             [Full Report](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
             `;

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -42,6 +42,8 @@ env:
   BASE_URL: http://localhost:4000
   TEST_ENV: ci
   K6_VERSION: '0.48.0'
+  RATE_LIMIT_API_RPM: "10000"
+  RATE_LIMIT_AUTH_RPM: "10000"
 
 jobs:
   # =============================================================================
@@ -205,8 +207,6 @@ jobs:
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
           CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
-          RATE_LIMIT_API_RPM: "10000"
-          RATE_LIMIT_AUTH_RPM: "10000"
           TRACING_ENABLED: "false"
 
       - name: Run smoke test
@@ -368,8 +368,6 @@ jobs:
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
           CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
-          RATE_LIMIT_API_RPM: "10000"
-          RATE_LIMIT_AUTH_RPM: "10000"
           TRACING_ENABLED: "false"
 
       - name: Run load test

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -45,6 +45,11 @@ env:
   RATE_LIMIT_API_RPM: "10000"
   RATE_LIMIT_AUTH_RPM: "10000"
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   # =============================================================================
   # Setup and Environment Preparation
@@ -488,9 +493,13 @@ jobs:
             [Full Report](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
             `;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            } catch (error) {
+              core.warning(`Unable to comment performance results: ${error.message}`);
+            }

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -205,6 +205,8 @@ jobs:
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
           CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
+          RATE_LIMIT_API_RPM: "10000"
+          RATE_LIMIT_AUTH_RPM: "10000"
           TRACING_ENABLED: "false"
 
       - name: Run smoke test
@@ -366,6 +368,8 @@ jobs:
           WORKOS_API_KEY: sk_test_ci_performance
           WORKOS_AUTHKIT_DOMAIN: http://localhost:4000
           CSRF_SECRET: ci-csrf-secret-at-least-32-bytes
+          RATE_LIMIT_API_RPM: "10000"
+          RATE_LIMIT_AUTH_RPM: "10000"
           TRACING_ENABLED: "false"
 
       - name: Run load test

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -161,6 +161,7 @@ func (handler *ProjectHandler) CreateProject(c echo.Context) error {
 	}
 
 	project := &models.Project{
+		ID:          uuid.NewString(),
 		Name:        req.Name,
 		Description: req.Description,
 		Metadata:    metadata,

--- a/backend/internal/infrastructure/profiles_schema.go
+++ b/backend/internal/infrastructure/profiles_schema.go
@@ -3,6 +3,7 @@ package infrastructure
 
 import (
 	"fmt"
+	"log/slog"
 
 	"gorm.io/gorm"
 
@@ -36,7 +37,15 @@ func migrateAuthProfilesSchema(gormDB *gorm.DB) error {
 		return fmt.Errorf("failed to auto-migrate profiles: %w", err)
 	}
 	for _, schema := range []string{"public", "tracertm"} {
-		_ = dropProfileEmailConstraint(gormDB, schema)
+		if err := dropProfileEmailConstraint(gormDB, schema); err != nil {
+			slog.Debug(
+				"profile email constraint cleanup failed",
+				"schema",
+				schema,
+				"error",
+				err,
+			)
+		}
 	}
 	return nil
 }

--- a/backend/internal/infrastructure/profiles_schema.go
+++ b/backend/internal/infrastructure/profiles_schema.go
@@ -51,7 +51,12 @@ func migrateAuthProfilesSchema(gormDB *gorm.DB) error {
 }
 
 func prepareProfileEmailConstraint(gormDB *gorm.DB, schema string) error {
-	err := gormDB.Exec(fmt.Sprintf(`DO $$
+	schemaName, err := profileSchemaIdentifier(schema)
+	if err != nil {
+		return err
+	}
+
+	err = gormDB.Exec(fmt.Sprintf(`DO $$
 BEGIN
   IF EXISTS (
     SELECT 1 FROM information_schema.tables
@@ -67,7 +72,7 @@ BEGIN
 EXCEPTION
   WHEN undefined_table THEN NULL;
   WHEN invalid_schema_name THEN NULL;
-END $$`, schema, schema, schema)).Error
+END $$`, schemaName, schemaName, schemaName)).Error
 	if err != nil {
 		return fmt.Errorf("failed to prepare %s.profiles email uniqueness for automigrate: %w", schema, err)
 	}
@@ -75,6 +80,11 @@ END $$`, schema, schema, schema)).Error
 }
 
 func dropProfileEmailConstraint(gormDB *gorm.DB, schema string) error {
+	schemaName, err := profileSchemaIdentifier(schema)
+	if err != nil {
+		return err
+	}
+
 	return gormDB.Exec(fmt.Sprintf(`DO $$
 BEGIN
   IF EXISTS (
@@ -86,5 +96,14 @@ BEGIN
 EXCEPTION
   WHEN undefined_table THEN NULL;
   WHEN invalid_schema_name THEN NULL;
-END $$`, schema, schema)).Error
+END $$`, schemaName, schemaName)).Error
+}
+
+func profileSchemaIdentifier(schema string) (string, error) {
+	switch schema {
+	case "public", "tracertm":
+		return schema, nil
+	default:
+		return "", fmt.Errorf("unsupported profiles schema %q", schema)
+	}
 }

--- a/backend/internal/infrastructure/profiles_schema.go
+++ b/backend/internal/infrastructure/profiles_schema.go
@@ -28,9 +28,26 @@ func migrateAuthProfilesSchema(gormDB *gorm.DB) error {
 	END $$`).Error
 
 	for _, schema := range []string{"public", "tracertm"} {
-		if err := gormDB.Exec(fmt.Sprintf(`DO $$
+		if err := prepareProfileEmailConstraint(gormDB, schema); err != nil {
+			return err
+		}
+	}
+	if err := gormDB.AutoMigrate(&models.Profile{}); err != nil {
+		return fmt.Errorf("failed to auto-migrate profiles: %w", err)
+	}
+	for _, schema := range []string{"public", "tracertm"} {
+		_ = dropProfileEmailConstraint(gormDB, schema)
+	}
+	return nil
+}
+
+func prepareProfileEmailConstraint(gormDB *gorm.DB, schema string) error {
+	err := gormDB.Exec(fmt.Sprintf(`DO $$
 BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = '%s' AND table_name = 'profiles'
+  ) AND NOT EXISTS (
     SELECT 1 FROM pg_constraint c
     JOIN pg_class t ON t.oid = c.conrelid
     JOIN pg_namespace n ON n.oid = t.relnamespace
@@ -40,15 +57,25 @@ BEGIN
   END IF;
 EXCEPTION
   WHEN undefined_table THEN NULL;
-END $$`, schema, schema)).Error; err != nil {
-			return fmt.Errorf("failed to prepare %s.profiles email uniqueness for automigrate: %w", schema, err)
-		}
-	}
-	if err := gormDB.AutoMigrate(&models.Profile{}); err != nil {
-		return fmt.Errorf("failed to auto-migrate profiles: %w", err)
-	}
-	for _, schema := range []string{"public", "tracertm"} {
-		_ = gormDB.Exec("ALTER TABLE " + schema + ".profiles DROP CONSTRAINT IF EXISTS uni_profiles_email").Error
+  WHEN invalid_schema_name THEN NULL;
+END $$`, schema, schema, schema)).Error
+	if err != nil {
+		return fmt.Errorf("failed to prepare %s.profiles email uniqueness for automigrate: %w", schema, err)
 	}
 	return nil
+}
+
+func dropProfileEmailConstraint(gormDB *gorm.DB, schema string) error {
+	return gormDB.Exec(fmt.Sprintf(`DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = '%s' AND table_name = 'profiles'
+  ) THEN
+    ALTER TABLE %s.profiles DROP CONSTRAINT IF EXISTS uni_profiles_email;
+  END IF;
+EXCEPTION
+  WHEN undefined_table THEN NULL;
+  WHEN invalid_schema_name THEN NULL;
+END $$`, schema, schema)).Error
 }

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -68,7 +68,7 @@ type Project struct {
 	ID          string         `gorm:"primaryKey" json:"id"`
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
-	Metadata    datatypes.JSON `json:"metadata"`
+	Metadata    datatypes.JSON `gorm:"column:project_metadata" json:"metadata"`
 	CreatedAt   time.Time      `json:"created_at"`
 	UpdatedAt   time.Time      `json:"updated_at"`
 	DeletedAt   *time.Time     `json:"deleted_at,omitempty"`

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -68,7 +68,7 @@ type Project struct {
 	ID          string         `gorm:"primaryKey" json:"id"`
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
-	Metadata    datatypes.JSON `gorm:"column:project_metadata" json:"metadata"`
+	Metadata    datatypes.JSON `gorm:"column:metadata" json:"metadata"`
 	CreatedAt   time.Time      `json:"created_at"`
 	UpdatedAt   time.Time      `json:"updated_at"`
 	DeletedAt   *time.Time     `json:"deleted_at,omitempty"`

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -68,7 +68,7 @@ type Project struct {
 	ID          string         `gorm:"primaryKey" json:"id"`
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
-	Metadata    datatypes.JSON `gorm:"column:metadata" json:"metadata"`
+	Metadata    datatypes.JSON `gorm:"column:project_metadata" json:"metadata"`
 	CreatedAt   time.Time      `json:"created_at"`
 	UpdatedAt   time.Time      `json:"updated_at"`
 	DeletedAt   *time.Time     `json:"deleted_at,omitempty"`

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -201,7 +201,8 @@ repo cleanup.
   project API also assigns UUIDs before service validation because validation
   runs before GORM `BeforeCreate` hooks. The performance report PR comment now
   accepts both k6 percentile key shapes (`p(95)` and `p95`) so a successful
-  smoke run is not failed by post-processing.
+  smoke run is not failed by post-processing, and PR comment posting is
+  permissioned but non-fatal when GitHub still denies the integration token.
 - **Excluded:** changing production rate-limit defaults, changing protected route
   policy, or rewriting load/stress scenario auth flows.
 

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -164,10 +164,10 @@ repo cleanup.
   The backend now exposes `/api/v1/csrf-token`, returns `{ "token": ... }`,
   and removed password login in favor of AuthKit.
 - **Action:** add CI `csrf-only` k6 auth mode that prepares CSRF headers/cookie
-  without reintroducing password login, set required CI auth/CSRF environment
-  values in the performance workflow, guard smoke iterations when session
-  preparation fails, and create a real smoke project before item creation so
-  item CRUD uses a valid UUID project ID.
+  without reintroducing password login, set the required CI CSRF secret in the
+  performance workflow, guard smoke iterations when session preparation fails,
+  and create a real smoke project before item creation so item CRUD uses a
+  valid UUID project ID.
 - **Excluded:** re-adding password auth, mocking WorkOS in production code,
   changing protected route policy, and broad load/stress data-model cleanup.
 

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -197,7 +197,9 @@ repo cleanup.
   while logging failed status/body evidence, carry rotated CSRF tokens forward
   after each k6 request, replace fragile k6 `randomItem` usage with a local
   random-choice helper, normalize null search options to an empty object, and
-  align the Go project model with Alembic's `project_metadata` column.
+  align the Go project model with Alembic's `project_metadata` column. The
+  project API also assigns UUIDs before service validation because validation
+  runs before GORM `BeforeCreate` hooks.
 - **Excluded:** changing production rate-limit defaults, changing protected route
   policy, or rewriting load/stress scenario auth flows.
 

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -199,7 +199,9 @@ repo cleanup.
   random-choice helper, normalize null search options to an empty object, and
   align the Go project model with Alembic's `project_metadata` column. The
   project API also assigns UUIDs before service validation because validation
-  runs before GORM `BeforeCreate` hooks.
+  runs before GORM `BeforeCreate` hooks. The performance report PR comment now
+  accepts both k6 percentile key shapes (`p(95)` and `p95`) so a successful
+  smoke run is not failed by post-processing.
 - **Excluded:** changing production rate-limit defaults, changing protected route
   policy, or rewriting load/stress scenario auth flows.
 

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -184,6 +184,21 @@ repo cleanup.
 - **Excluded:** redesigning profile schema ownership, changing AuthKit adapter
   behavior, and changing Alembic profile migrations.
 
+## SIZE-CI-K6-SMOKE-RATE-DATA: Performance Smoke Runtime Determinism
+
+- **Scope:** performance workflow runtime env and k6 helper data/auth guards.
+- **Reason:** after profile schema startup was guarded, performance smoke reached
+  k6 execution and exposed two deterministic smoke harness blockers: CSRF token
+  setup could be rate-limited by the default `/api/v1/*` limiter during the
+  local CI ramp, and `generateSearchQuery` could crash when called with a null
+  options object.
+- **Action:** raise API/auth rate limits only inside the CI performance backend
+  jobs, make CSRF token extraction tolerant of body-vs-cookie token placement
+  while logging failed status/body evidence, and normalize null search options
+  to an empty object.
+- **Excluded:** changing production rate-limit defaults, changing protected route
+  policy, or rewriting load/stress scenario auth flows.
+
 ## Validation Targets
 
 ```bash

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -171,6 +171,19 @@ repo cleanup.
 - **Excluded:** re-adding password auth, mocking WorkOS in production code,
   changing protected route policy, and broad load/stress data-model cleanup.
 
+## SIZE-CI-PROFILES-SCHEMA-GUARD: Profile Constraint Startup Schema Safety
+
+- **Scope:** Go profile startup helper for the temporary email uniqueness
+  constraint used around `AutoMigrate`.
+- **Reason:** after the k6 auth lane merged, performance smoke startup failed
+  before k6 because the helper tried to alter `tracertm.profiles` even though
+  CI/Alembic creates `profiles` in `public` and no `tracertm` schema exists.
+- **Action:** guard the temporary profile email constraint add/drop by checking
+  that the target schema/table exists, and tolerate missing schemas without
+  hiding other migration errors.
+- **Excluded:** redesigning profile schema ownership, changing AuthKit adapter
+  behavior, and changing Alembic profile migrations.
+
 ## Validation Targets
 
 ```bash

--- a/docs/sessions/20260426-dependency-alert-remediation.md
+++ b/docs/sessions/20260426-dependency-alert-remediation.md
@@ -194,8 +194,10 @@ repo cleanup.
   options object.
 - **Action:** raise API/auth rate limits only inside the CI performance backend
   jobs, make CSRF token extraction tolerant of body-vs-cookie token placement
-  while logging failed status/body evidence, and normalize null search options
-  to an empty object.
+  while logging failed status/body evidence, carry rotated CSRF tokens forward
+  after each k6 request, replace fragile k6 `randomItem` usage with a local
+  random-choice helper, normalize null search options to an empty object, and
+  align the Go project model with Alembic's `project_metadata` column.
 - **Excluded:** changing production rate-limit defaults, changing protected route
   policy, or rewriting load/stress scenario auth flows.
 

--- a/tests/load/k6/helpers/auth.js
+++ b/tests/load/k6/helpers/auth.js
@@ -144,7 +144,16 @@ function readCsrfToken(response) {
 
 function failCsrfTokenRequest(response) {
   const body = response && response.body ? String(response.body).slice(0, 500) : '';
-  console.error(`CSRF token request failed: status=${response.status} body=${body}`);
+  const headers = response && response.headers ? response.headers : {};
+  const details = [
+    `status=${response.status}`,
+    `contentType=${headers['Content-Type'] || ''}`,
+    `retryAfter=${headers['Retry-After'] || ''}`,
+    `rateLimit=${headers['X-RateLimit-Remaining'] || ''}/${headers['X-RateLimit-Limit'] || ''}`,
+    `setCookie=${headers['Set-Cookie'] ? String(headers['Set-Cookie']).slice(0, 160) : ''}`,
+    `body=${body}`,
+  ].join(' ');
+  console.error(`CSRF token request failed: ${details}`);
   fail('Failed to retrieve CSRF token');
 }
 
@@ -200,6 +209,25 @@ export function getAuthHeaders(authData) {
   }
 
   return headers;
+}
+
+export function updateCsrfFromResponse(authData, response) {
+  if (!authData || !response) {
+    return authData;
+  }
+
+  const csrfToken = readCsrfToken(response);
+  const csrfCookie = extractCookie(response, 'csrf_token');
+
+  if (csrfToken) {
+    authData.csrfToken = csrfToken;
+  }
+
+  if (csrfCookie) {
+    authData.csrfCookie = csrfCookie;
+  }
+
+  return authData;
 }
 
 /**
@@ -259,6 +287,7 @@ export default {
   getTestUser,
   authenticate,
   getAuthHeaders,
+  updateCsrfFromResponse,
   verifyAuth,
   logout,
   setupTestUsers,

--- a/tests/load/k6/helpers/auth.js
+++ b/tests/load/k6/helpers/auth.js
@@ -57,14 +57,14 @@ export function authenticate(user) {
 
   const csrfCheck = check(csrfResponse, {
     'CSRF token retrieved': (r) => r.status === 200,
-    'CSRF token in response': (r) => r.json('token') !== undefined,
+    'CSRF token in response': (r) => readCsrfToken(r) !== undefined,
   });
 
   if (!csrfCheck) {
-    fail('Failed to retrieve CSRF token');
+    failCsrfTokenRequest(csrfResponse);
   }
 
-  const csrfToken = csrfResponse.json('token');
+  const csrfToken = readCsrfToken(csrfResponse);
   const csrfCookie = extractCookie(csrfResponse, 'csrf_token');
 
   // Step 2: Authenticate with WorkOS (or mock auth endpoint)
@@ -123,9 +123,29 @@ function getCsrfTokenResponse() {
   });
 }
 
+function readJsonField(response, field) {
+  try {
+    return response.json(field);
+  } catch {
+    return undefined;
+  }
+}
+
 function extractCookie(response, name) {
   const cookie = response.cookies[name];
   return cookie && cookie.length > 0 ? cookie[0].value : undefined;
+}
+
+function readCsrfToken(response) {
+  return readJsonField(response, 'token') ||
+    readJsonField(response, 'csrf_token') ||
+    extractCookie(response, 'csrf_token');
+}
+
+function failCsrfTokenRequest(response) {
+  const body = response && response.body ? String(response.body).slice(0, 500) : '';
+  console.error(`CSRF token request failed: status=${response.status} body=${body}`);
+  fail('Failed to retrieve CSRF token');
 }
 
 function getCsrfOnlySession() {
@@ -133,14 +153,14 @@ function getCsrfOnlySession() {
 
   const csrfCheck = check(csrfResponse, {
     'CSRF token retrieved': (r) => r.status === 200,
-    'CSRF token in response': (r) => r.json('token') !== undefined,
+    'CSRF token in response': (r) => readCsrfToken(r) !== undefined,
   });
 
   if (!csrfCheck) {
-    fail('Failed to retrieve CSRF token');
+    failCsrfTokenRequest(csrfResponse);
   }
 
-  const csrfToken = csrfResponse.json('token');
+  const csrfToken = readCsrfToken(csrfResponse);
   const csrfCookie = extractCookie(csrfResponse, 'csrf_token');
 
   return {

--- a/tests/load/k6/helpers/auth.js
+++ b/tests/load/k6/helpers/auth.js
@@ -143,6 +143,7 @@ function readCsrfToken(response) {
 }
 
 function failCsrfTokenRequest(response) {
+  const debugCsrf = __ENV.K6_DEBUG_CSRF === 'true' || __ENV.K6_DEBUG_CSRF === '1';
   const body = response && response.body ? String(response.body).slice(0, 500) : '';
   const headers = response && response.headers ? response.headers : {};
   const details = [
@@ -150,8 +151,10 @@ function failCsrfTokenRequest(response) {
     `contentType=${headers['Content-Type'] || ''}`,
     `retryAfter=${headers['Retry-After'] || ''}`,
     `rateLimit=${headers['X-RateLimit-Remaining'] || ''}/${headers['X-RateLimit-Limit'] || ''}`,
-    `setCookie=${headers['Set-Cookie'] ? String(headers['Set-Cookie']).slice(0, 160) : ''}`,
-    `body=${body}`,
+    `setCookie=${debugCsrf && headers['Set-Cookie']
+      ? String(headers['Set-Cookie']).slice(0, 160)
+      : '[REDACTED]'}`,
+    `body=${debugCsrf ? body : '[REDACTED]'}`,
   ].join(' ');
   console.error(`CSRF token request failed: ${details}`);
   fail('Failed to retrieve CSRF token');
@@ -213,6 +216,10 @@ export function getAuthHeaders(authData) {
 
 export function updateCsrfFromResponse(authData, response) {
   if (!authData || !response) {
+    return authData;
+  }
+
+  if (response.status < 200 || response.status >= 400) {
     return authData;
   }
 

--- a/tests/load/k6/helpers/data-generators.js
+++ b/tests/load/k6/helpers/data-generators.js
@@ -5,7 +5,10 @@
  * to simulate production-like load patterns.
  */
 
-import { randomString, randomIntBetween } from 'k6';
+import {
+  randomString,
+  randomIntBetween,
+} from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
 
 // Realistic data pools for generation
 const ITEM_TYPES = ['requirement', 'feature', 'task', 'bug', 'epic', 'story'];
@@ -240,6 +243,7 @@ export function generateSearchQuery(options = {}) {
     order: options.order || randomChoice(['asc', 'desc']),
     limit: options.limit || randomIntBetween(10, 100),
     offset: options.offset || 0,
+    projectId: options.projectId,
   };
 }
 

--- a/tests/load/k6/helpers/data-generators.js
+++ b/tests/load/k6/helpers/data-generators.js
@@ -5,7 +5,7 @@
  * to simulate production-like load patterns.
  */
 
-import { randomString, randomIntBetween, randomItem } from 'k6';
+import { randomString, randomIntBetween } from 'k6';
 
 // Realistic data pools for generation
 const ITEM_TYPES = ['requirement', 'feature', 'task', 'bug', 'epic', 'story'];
@@ -41,6 +41,10 @@ const BUG_DESCRIPTIONS = [
   'Export fails for datasets over 10k records',
 ];
 
+function randomChoice(values) {
+  return values[randomIntBetween(0, values.length - 1)];
+}
+
 /**
  * Generate a random item (requirement, feature, task, etc.)
  *
@@ -48,22 +52,22 @@ const BUG_DESCRIPTIONS = [
  * @returns {Object} - Generated item
  */
 export function generateItem(options = {}) {
-  const type = options.type || randomItem(ITEM_TYPES);
+  const type = options.type || randomChoice(ITEM_TYPES);
   const projectId = options.projectId || randomIntBetween(1, 100);
 
   let title, description;
 
   switch (type) {
     case 'requirement':
-      title = `${randomItem(REQUIREMENT_PREFIXES)} ${randomString(20)}`;
+      title = `${randomChoice(REQUIREMENT_PREFIXES)} ${randomString(20)}`;
       description = `Detailed requirement: ${randomString(100)}`;
       break;
     case 'feature':
-      title = randomItem(FEATURE_NAMES);
+      title = randomChoice(FEATURE_NAMES);
       description = `Feature implementation for ${randomString(50)}`;
       break;
     case 'bug':
-      title = `Bug: ${randomItem(BUG_DESCRIPTIONS)}`;
+      title = `Bug: ${randomChoice(BUG_DESCRIPTIONS)}`;
       description = `Steps to reproduce: ${randomString(80)}`;
       break;
     default:
@@ -76,13 +80,13 @@ export function generateItem(options = {}) {
     type: type,
     title: title,
     description: description,
-    status: options.status || randomItem(ITEM_STATUSES),
-    priority: options.priority || randomItem(PRIORITIES),
+    status: options.status || randomChoice(ITEM_STATUSES),
+    priority: options.priority || randomChoice(PRIORITIES),
     tags: generateTags(options.tagCount || randomIntBetween(1, 4)),
     metadata: {
       created_by: `user_${randomIntBetween(1, 1000)}`,
       estimated_hours: randomIntBetween(1, 40),
-      complexity: randomItem(['low', 'medium', 'high']),
+      complexity: randomChoice(['low', 'medium', 'high']),
     },
   };
 }
@@ -112,7 +116,7 @@ export function generateLink(options = {}) {
   return {
     source_id: options.sourceId || randomIntBetween(1, 10000),
     target_id: options.targetId || randomIntBetween(1, 10000),
-    link_type: options.linkType || randomItem(['depends_on', 'blocks', 'relates_to', 'implements', 'tests']),
+    link_type: options.linkType || randomChoice(['depends_on', 'blocks', 'relates_to', 'implements', 'tests']),
     metadata: {
       created_at: new Date().toISOString(),
       strength: randomIntBetween(1, 10),
@@ -136,8 +140,8 @@ export function generateTestCase(options = {}) {
       { step: 2, action: `Click on ${randomString(15)}`, expected: `Modal appears` },
       { step: 3, action: `Enter ${randomString(10)}`, expected: `Data is saved` },
     ],
-    priority: options.priority || randomItem(PRIORITIES),
-    status: options.status || randomItem(['passed', 'failed', 'skipped', 'pending']),
+    priority: options.priority || randomChoice(PRIORITIES),
+    status: options.status || randomChoice(['passed', 'failed', 'skipped', 'pending']),
     automated: options.automated !== undefined ? options.automated : randomIntBetween(0, 1) === 1,
     tags: generateTags(2),
   };
@@ -152,12 +156,12 @@ export function generateTestCase(options = {}) {
 export function generateGraphNode(options = {}) {
   return {
     id: options.id || `node_${randomString(10)}`,
-    type: options.type || randomItem(['requirement', 'feature', 'component', 'service', 'database']),
+    type: options.type || randomChoice(['requirement', 'feature', 'component', 'service', 'database']),
     label: options.label || randomString(30),
     metadata: {
       weight: randomIntBetween(1, 100),
       layer: randomIntBetween(1, 5),
-      status: randomItem(ITEM_STATUSES),
+      status: randomChoice(ITEM_STATUSES),
     },
     position: options.position || {
       x: randomIntBetween(0, 1000),
@@ -196,7 +200,7 @@ export function generateGraph(nodeCount = 100, edgeCount = 150) {
       id: `edge_${i}`,
       source: `node_${sourceIdx}`,
       target: `node_${targetIdx}`,
-      type: randomItem(['depends_on', 'contains', 'implements', 'tests']),
+      type: randomChoice(['depends_on', 'contains', 'implements', 'tests']),
       weight: randomIntBetween(1, 10),
     });
   }
@@ -225,15 +229,15 @@ export function generateSearchQuery(options = {}) {
   ];
 
   return {
-    query: options.query || randomItem(queries),
+    query: options.query || randomChoice(queries),
     filters: {
-      type: options.type || (randomIntBetween(0, 1) === 1 ? randomItem(ITEM_TYPES) : undefined),
-      status: options.status || (randomIntBetween(0, 1) === 1 ? randomItem(ITEM_STATUSES) : undefined),
-      priority: options.priority || (randomIntBetween(0, 1) === 1 ? randomItem(PRIORITIES) : undefined),
+      type: options.type || (randomIntBetween(0, 1) === 1 ? randomChoice(ITEM_TYPES) : undefined),
+      status: options.status || (randomIntBetween(0, 1) === 1 ? randomChoice(ITEM_STATUSES) : undefined),
+      priority: options.priority || (randomIntBetween(0, 1) === 1 ? randomChoice(PRIORITIES) : undefined),
       tags: randomIntBetween(0, 1) === 1 ? generateTags(randomIntBetween(1, 2)) : undefined,
     },
-    sort: options.sort || randomItem(['created_at', 'updated_at', 'priority', 'title']),
-    order: options.order || randomItem(['asc', 'desc']),
+    sort: options.sort || randomChoice(['created_at', 'updated_at', 'priority', 'title']),
+    order: options.order || randomChoice(['asc', 'desc']),
     limit: options.limit || randomIntBetween(10, 100),
     offset: options.offset || 0,
   };
@@ -268,7 +272,7 @@ export function generateWebSocketMessage(options = {}) {
   const messageTypes = ['item_created', 'item_updated', 'item_deleted', 'link_created', 'notification'];
 
   return {
-    type: options.type || randomItem(messageTypes),
+    type: options.type || randomChoice(messageTypes),
     payload: options.payload || {
       item_id: randomIntBetween(1, 10000),
       timestamp: new Date().toISOString(),

--- a/tests/load/k6/helpers/data-generators.js
+++ b/tests/load/k6/helpers/data-generators.js
@@ -211,6 +211,8 @@ export function generateGraph(nodeCount = 100, edgeCount = 150) {
  * @returns {Object} - Search query parameters
  */
 export function generateSearchQuery(options = {}) {
+  options = options || {};
+
   const queries = [
     'performance optimization',
     'authentication flow',

--- a/tests/load/k6/scenarios/smoke.js
+++ b/tests/load/k6/scenarios/smoke.js
@@ -249,9 +249,10 @@ export default function (data) {
 
     const headers = getAuthHeaders(authData);
     const searchQuery = generateSearchQuery({ limit: 20, projectId: smokeProjectId });
+    const searchProjectId = searchQuery.projectId || smokeProjectId;
 
     const searchResponse = http.get(
-      `${API_BASE_URL}/search?q=${encodeURIComponent(searchQuery.query)}&limit=${searchQuery.limit}&project_id=${smokeProjectId}`,
+      `${API_BASE_URL}/search?q=${encodeURIComponent(searchQuery.query)}&limit=${searchQuery.limit}&project_id=${searchProjectId}`,
       {
         headers,
         tags: { name: 'search_items' },

--- a/tests/load/k6/scenarios/smoke.js
+++ b/tests/load/k6/scenarios/smoke.js
@@ -14,7 +14,12 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend, Counter } from 'k6/metrics';
-import { authenticate, getAuthHeaders, getTestUser } from '../helpers/auth.js';
+import {
+  authenticate,
+  getAuthHeaders,
+  getTestUser,
+  updateCsrfFromResponse,
+} from '../helpers/auth.js';
 import { generateItem, generateSearchQuery } from '../helpers/data-generators.js';
 
 // Custom metrics
@@ -79,6 +84,7 @@ export function setup() {
 // Main test function - runs for each VU iteration
 export default function (data) {
   let authData;
+  let smokeProjectId;
 
   // Group: Authentication
   group('Authentication', () => {
@@ -120,6 +126,7 @@ export default function (data) {
 
     requestCounter.add(1);
     apiResponseTime.add(projectsResponse.timings.duration);
+    updateCsrfFromResponse(authData, projectsResponse);
 
     const projectsCheck = check(projectsResponse, {
       'Projects loaded': (r) => r.status === 200,
@@ -159,6 +166,7 @@ export default function (data) {
 
     requestCounter.add(1);
     apiResponseTime.add(projectResponse.timings.duration);
+    updateCsrfFromResponse(authData, projectResponse);
 
     const projectCheck = check(projectResponse, {
       'Project created for item': (r) => r.status === 200 || r.status === 201,
@@ -166,26 +174,31 @@ export default function (data) {
     });
 
     if (!projectCheck) {
+      const body = projectResponse.body ? String(projectResponse.body).slice(0, 500) : '';
+      console.error(`Project fixture creation failed: status=${projectResponse.status} body=${body}`);
       errorRate.add(1);
       return;
     }
 
     const createdProject = projectResponse.json();
     const projectId = createdProject.id || createdProject.project_id;
+    smokeProjectId = projectId;
 
     // Create a new item
+    const itemHeaders = getAuthHeaders(authData);
     const newItem = generateItem({ projectId: projectId, priority: 2 });
     const createResponse = http.post(
       `${API_BASE_URL}/items`,
       JSON.stringify(newItem),
       {
-        headers,
+        headers: itemHeaders,
         tags: { name: 'create_item' },
       }
     );
 
     requestCounter.add(1);
     apiResponseTime.add(createResponse.timings.duration);
+    updateCsrfFromResponse(authData, createResponse);
 
     const createCheck = check(createResponse, {
       'Item created': (r) => r.status === 200 || r.status === 201,
@@ -203,16 +216,18 @@ export default function (data) {
     sleep(0.5);
 
     // Get the created item
+    const getHeaders = getAuthHeaders(authData);
     const getResponse = http.get(
       `${API_BASE_URL}/items/${itemId}`,
       {
-        headers,
+        headers: getHeaders,
         tags: { name: 'get_item' },
       }
     );
 
     requestCounter.add(1);
     apiResponseTime.add(getResponse.timings.duration);
+    updateCsrfFromResponse(authData, getResponse);
 
     const getCheck = check(getResponse, {
       'Item retrieved': (r) => r.status === 200,
@@ -228,11 +243,15 @@ export default function (data) {
 
   // Group: Search
   group('Search Operations', () => {
+    if (!smokeProjectId) {
+      return;
+    }
+
     const headers = getAuthHeaders(authData);
-    const searchQuery = generateSearchQuery({ limit: 20 });
+    const searchQuery = generateSearchQuery({ limit: 20, projectId: smokeProjectId });
 
     const searchResponse = http.get(
-      `${API_BASE_URL}/search?q=${encodeURIComponent(searchQuery.query)}&limit=${searchQuery.limit}`,
+      `${API_BASE_URL}/search?q=${encodeURIComponent(searchQuery.query)}&limit=${searchQuery.limit}&project_id=${smokeProjectId}`,
       {
         headers,
         tags: { name: 'search_items' },
@@ -241,6 +260,7 @@ export default function (data) {
 
     requestCounter.add(1);
     apiResponseTime.add(searchResponse.timings.duration);
+    updateCsrfFromResponse(authData, searchResponse);
 
     const searchCheck = check(searchResponse, {
       'Search completed': (r) => r.status === 200,


### PR DESCRIPTION
## **User description**
Layered PR: `codex/ci-disable-authkit-performance-env-20260426` → integration/consolidate (10 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project create path and GORM project metadata mapping (API persistence), plus startup profile migration SQL; changes are targeted to CI and smoke fixtures but could affect project creation if misaligned with DB schema.
> 
> **Overview**
> This PR makes **CI performance smoke** more deterministic end-to-end: the performance workflow raises API/auth rate limits only for backend jobs, trims unused AuthKit JWT/redirect env from those jobs, adds PR comment permissions, and hardens the smoke summary comment (flexible k6 metric keys, non-fatal comment failures).
> 
> **Backend:** Profile startup no longer assumes a `tracertm.profiles` table—temporary email uniqueness constraints are added/dropped only when the schema and table exist. **Project** metadata maps to Alembic’s `project_metadata` column, and **CreateProject** assigns a UUID before service validation so smoke project fixtures succeed.
> 
> **k6:** CSRF handling reads tokens from body or cookie, logs richer failures, and refreshes tokens after responses; data generators avoid brittle `randomItem` and null search options; smoke ties search to the created project and skips search when fixture creation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fea4484ee2c83e9db9e7aa1378ba560ae9ad7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Make performance smoke runs more reliable and keep project data aligned with the database

### What Changed
- Performance smoke tests now keep using the latest CSRF token and cookie after each request, and show clearer failure details when CSRF setup fails
- Smoke runs create a real project ID before item creation, pass that project into search requests, and include it in search results
- The project API now assigns an ID before validation, and project metadata is saved using the database column name expected by migrations
- CI performance jobs now allow higher request rates, handle both k6 percentile summary formats, and do not fail the run if posting the results comment is blocked

### Impact
`✅ Fewer performance smoke failures`
`✅ Stable item and search checks in CI`
`✅ Fewer project creation validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
