### PR TITLE
layer: feat/comments-live-submit — feat(comments): live comment submission in CommentsTab (Clos

### DIFF
--- a/alembic/versions/063_add_item_comments.py
+++ b/alembic/versions/063_add_item_comments.py
@@ -1,0 +1,41 @@
+"""Add item_comments table for per-item discussion threads.
+
+Revision ID: 063_add_item_comments
+Revises: 062_add_trace_link_fields
+Create Date: 2026-05-28
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "063_add_item_comments"
+down_revision = "062_add_trace_link_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create item_comments table."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS item_comments (
+            id          VARCHAR(36)  PRIMARY KEY,
+            item_id     VARCHAR(255) NOT NULL,
+            author_id   VARCHAR(255) NOT NULL,
+            author_name VARCHAR(255) NOT NULL DEFAULT '',
+            content     TEXT         NOT NULL,
+            edited      BOOLEAN      NOT NULL DEFAULT FALSE,
+            created_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            updated_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_item_comments_item_id ON item_comments(item_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_item_comments_author_id ON item_comments(author_id)"
+    )
+
+
+def downgrade() -> None:
+    """Drop item_comments table."""
+    op.execute("DROP TABLE IF EXISTS item_comments")

--- a/frontend/apps/web/src/__tests__/components/CommentsTab.test.tsx
+++ b/frontend/apps/web/src/__tests__/components/CommentsTab.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * CommentsTab – live API integration tests (Closes #225)
+ *
+ * Mocks commentsApi at the module boundary so no real HTTP requests are made.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CommentResponse } from '../../api/endpoints';
+import { CommentsTab } from '../../views/details/tabs/CommentsTab';
+
+// ---------------------------------------------------------------------------
+// Module-level mock for commentsApi
+// ---------------------------------------------------------------------------
+vi.mock('../../api/endpoints', () => ({
+  commentsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Import the mock AFTER the mock declaration so vi.mock hoisting works
+import { commentsApi } from '../../api/endpoints';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockItem = {
+  id: 'item-123',
+  projectId: 'proj-1',
+  view: 'feature' as const,
+  type: 'requirement',
+  title: 'Test Item',
+  status: 'todo' as const,
+  priority: 'medium' as const,
+  version: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const makeComment = (overrides: Partial<CommentResponse> = {}): CommentResponse => ({
+  id: 'c-1',
+  item_id: 'item-123',
+  author_id: 'user-1',
+  author: 'Alice',
+  content: 'Hello world',
+  edited: false,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CommentsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading spinner initially', async () => {
+    // list never resolves during this test
+    vi.mocked(commentsApi.list).mockReturnValue(new Promise(() => {}));
+
+    render(<CommentsTab item={mockItem} />);
+    expect(screen.getByText(/loading comments/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no comments exist', async () => {
+    vi.mocked(commentsApi.list).mockResolvedValue([]);
+
+    render(<CommentsTab item={mockItem} />);
+    await waitFor(() => {
+      expect(screen.getByText(/no comments yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders fetched comments', async () => {
+    vi.mocked(commentsApi.list).mockResolvedValue([makeComment({ author: 'Bob', content: 'Nice!' })]);
+
+    render(<CommentsTab item={mockItem} />);
+    await waitFor(() => {
+      expect(screen.getByText('Nice!')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when fetch fails', async () => {
+    vi.mocked(commentsApi.list).mockRejectedValue(new Error('Network error'));
+
+    render(<CommentsTab item={mockItem} />);
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load comments/i)).toBeInTheDocument();
+    });
+  });
+
+  it('submits a new comment and appends it to the list', async () => {
+    const created = makeComment({ id: 'c-new', content: 'My new comment', author: 'Alice' });
+
+    vi.mocked(commentsApi.list).mockResolvedValue([]);
+    vi.mocked(commentsApi.create).mockResolvedValue(created);
+
+    render(<CommentsTab item={mockItem} />);
+    // Wait for initial load
+    await waitFor(() => expect(screen.getByText(/no comments yet/i)).toBeInTheDocument());
+
+    const textarea = screen.getByRole('textbox', { name: /new comment/i });
+    fireEvent.change(textarea, { target: { value: 'My new comment' } });
+
+    const submitBtn = screen.getByRole('button', { name: /submit comment/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(commentsApi.create).toHaveBeenCalledWith('item-123', 'My new comment');
+      expect(screen.getByText('My new comment')).toBeInTheDocument();
+    });
+  });
+
+  it('disables submit button when textarea is empty', async () => {
+    vi.mocked(commentsApi.list).mockResolvedValue([]);
+
+    render(<CommentsTab item={mockItem} />);
+    await waitFor(() => expect(screen.getByText(/no comments yet/i)).toBeInTheDocument());
+
+    const submitBtn = screen.getByRole('button', { name: /submit comment/i });
+    expect(submitBtn).toBeDisabled();
+  });
+});

--- a/frontend/apps/web/src/api/endpoints.ts
+++ b/frontend/apps/web/src/api/endpoints.ts
@@ -594,6 +594,58 @@ export const codeTraceApi = {
   },
 };
 
+// ============================================================================
+// COMMENTS ENDPOINTS
+// ============================================================================
+
+export interface CommentResponse {
+  id: string;
+  item_id: string;
+  author_id: string;
+  author: string;
+  content: string;
+  edited: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export const commentsApi = {
+  list: async (itemId: string): Promise<CommentResponse[]> => {
+    const response = await fetch(`/api/v1/items/${itemId}/comments/`, {
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch comments: ${response.statusText}`);
+    }
+    return response.json() as Promise<CommentResponse[]>;
+  },
+
+  create: async (itemId: string, content: string): Promise<CommentResponse> => {
+    const response = await fetch(`/api/v1/items/${itemId}/comments/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ content }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Failed to create comment: ${response.statusText}`);
+    }
+    return response.json() as Promise<CommentResponse>;
+  },
+
+  delete: async (itemId: string, commentId: string): Promise<void> => {
+    const response = await fetch(`/api/v1/items/${itemId}/comments/${commentId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    if (!response.ok && response.status !== 204) {
+      throw new Error(`Failed to delete comment: ${response.statusText}`);
+    }
+  },
+};
+
 // Export all APIs as a single object for convenience
 export const api = {
   projects: projectsApi,
@@ -603,5 +655,6 @@ export const api = {
   search: searchApi,
   exportImport: exportImportApi,
   codeTrace: codeTraceApi,
+  comments: commentsApi,
   healthCheck,
 };

--- a/frontend/apps/web/src/views/details/tabs/CommentsTab.tsx
+++ b/frontend/apps/web/src/views/details/tabs/CommentsTab.tsx
@@ -8,12 +8,13 @@
  * - Comment metadata
  */
 
-import { MessageSquare, Send, User } from 'lucide-react';
-import { useState } from 'react';
+import { MessageSquare, Send, Trash2, User } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 import type { TypedItem } from '@tracertm/types';
 
+import { commentsApi, type CommentResponse } from '@/api/endpoints';
 import { cn } from '@/lib/utils';
 import { Badge, Button, Card, Textarea } from '@tracertm/ui';
 
@@ -25,19 +26,6 @@ export interface CommentsTabProps {
   className?: string;
 }
 
-interface Comment {
-  id: string;
-  author: string;
-  content: string;
-  timestamp: string;
-  edited?: boolean;
-}
-
-/**
- * CommentsTab displays comments and discussions for an item.
- * Note: This is a placeholder implementation. Real comment data
- * would come from the backend.
- */
 function getInitials(name: string) {
   return name
     .split(' ')
@@ -78,9 +66,39 @@ function formatTimestamp(timestamp: string) {
 export function CommentsTab({ item, className }: CommentsTabProps) {
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [comments, setComments] = useState<CommentResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
-  // Placeholder comments - in real implementation, these would come from the API
-  const comments: Comment[] = [];
+  // Fetch comments on mount and when item changes
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchComments = async () => {
+      setIsLoading(true);
+      setFetchError(null);
+      try {
+        const data = await commentsApi.list(item.id);
+        if (!cancelled) {
+          setComments(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : 'Failed to load comments';
+          setFetchError(msg);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchComments();
+    return () => {
+      cancelled = true;
+    };
+  }, [item.id]);
 
   const handleSubmit = async () => {
     if (!newComment.trim()) {
@@ -90,14 +108,26 @@ export function CommentsTab({ item, className }: CommentsTabProps) {
 
     setIsSubmitting(true);
     try {
-      // tracked: https://github.com/KooshaPari/trace/issues/227
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      const created = await commentsApi.create(item.id, newComment.trim());
+      setComments((prev) => [...prev, created]);
       toast.success('Comment added successfully');
       setNewComment('');
-    } catch {
-      toast.error('Failed to add comment');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to add comment';
+      toast.error(msg);
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    try {
+      await commentsApi.delete(item.id, commentId);
+      setComments((prev) => prev.filter((c) => c.id !== commentId));
+      toast.success('Comment deleted');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to delete comment';
+      toast.error(msg);
     }
   };
 
@@ -158,11 +188,24 @@ export function CommentsTab({ item, className }: CommentsTabProps) {
         <div className='flex items-center gap-2'>
           <h2 className='text-lg font-black tracking-tight'>Discussion</h2>
           <Badge variant='secondary' className='text-xs'>
-            {comments.length}
+            {isLoading ? '…' : comments.length}
           </Badge>
         </div>
 
-        {comments.length > 0 ? (
+        {isLoading ? (
+          <Card className='bg-muted/40 border-0 p-8'>
+            <div className='text-muted-foreground flex flex-col items-center justify-center'>
+              <div className='mb-3 h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent' />
+              <p className='text-sm font-medium'>Loading comments…</p>
+            </div>
+          </Card>
+        ) : fetchError ? (
+          <Card className='bg-destructive/10 border-0 p-6'>
+            <p className='text-destructive text-sm font-medium'>
+              Failed to load comments: {fetchError}
+            </p>
+          </Card>
+        ) : comments.length > 0 ? (
           <div className='space-y-4' role='list' aria-label='Comments'>
             {comments.map((comment) => (
               <Card key={comment.id} className='bg-muted/40 border-0 p-4' role='listitem'>
@@ -177,13 +220,21 @@ export function CommentsTab({ item, className }: CommentsTabProps) {
                     <div className='flex flex-wrap items-center gap-2'>
                       <span className='text-sm font-bold'>{comment.author}</span>
                       <span className='text-muted-foreground text-xs'>
-                        {formatTimestamp(comment.timestamp)}
+                        {formatTimestamp(comment.created_at)}
                       </span>
                       {comment.edited && (
                         <Badge variant='outline' className='text-xs'>
                           Edited
                         </Badge>
                       )}
+                      <button
+                        type='button'
+                        aria-label='Delete comment'
+                        onClick={() => void handleDelete(comment.id)}
+                        className='text-muted-foreground hover:text-destructive ml-auto transition-colors'
+                      >
+                        <Trash2 className='h-3 w-3' />
+                      </button>
                     </div>
 
                     <p className='text-sm leading-relaxed whitespace-pre-wrap'>{comment.content}</p>

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -16,6 +16,7 @@ from tracertm.api.routers import (
     cache,
     chat,
     codex,
+    comments,
     contracts,
     coverage,
     execution,
@@ -62,6 +63,7 @@ def register_api_routers(app: FastAPI) -> None:
     app.include_router(chat.router)
     app.include_router(items.router)
     app.include_router(items_summary.router)
+    app.include_router(comments.router)
     app.include_router(projects.router)
     app.include_router(analysis.router)
     app.include_router(code_trace.router)

--- a/src/tracertm/api/routers/comments.py
+++ b/src/tracertm/api/routers/comments.py
@@ -1,0 +1,171 @@
+"""Item comments API endpoints.
+
+GET  /api/v1/items/{item_id}/comments        - list comments for an item
+POST /api/v1/items/{item_id}/comments        - create a new comment
+DELETE /api/v1/items/{item_id}/comments/{id} - delete own comment
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracertm.api.deps import auth_guard, get_db
+from tracertm.models.item_comment import ItemComment
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/items/{item_id}/comments", tags=["comments"])
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class CommentResponse(BaseModel):
+    """Serialised comment returned to clients."""
+
+    id: str
+    item_id: str
+    author_id: str
+    author: str  # display name alias
+    content: str
+    edited: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    def from_orm_row(cls, row: ItemComment) -> "CommentResponse":
+        """Map ORM row to response schema."""
+        return cls(
+            id=row.id,
+            item_id=row.item_id,
+            author_id=row.author_id,
+            author=row.author_name or row.author_id,
+            content=row.content,
+            edited=row.edited,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+
+class CreateCommentBody(BaseModel):
+    """Request body for comment creation."""
+
+    content: str = Field(..., min_length=1, max_length=10_000)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _table_exists(db: AsyncSession) -> bool:
+    """Return True if the item_comments table exists in the DB."""
+    try:
+        result = await db.execute(
+            text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'item_comments' LIMIT 1"
+            )
+        )
+        return result.scalar() is not None
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/", response_model=list[CommentResponse])
+async def list_comments(
+    item_id: str,
+    claims: Annotated[dict[str, object], Depends(auth_guard)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[Any]:
+    """Return all comments for *item_id*, newest last."""
+    if not await _table_exists(db):
+        return []
+    try:
+        result = await db.execute(
+            select(ItemComment)
+            .where(ItemComment.item_id == item_id)
+            .order_by(ItemComment.created_at.asc())
+        )
+        rows = list(result.scalars().all())
+        return [CommentResponse.from_orm_row(r) for r in rows]
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch comments: {exc}") from exc
+
+
+@router.post("/", response_model=CommentResponse, status_code=201)
+async def create_comment(
+    item_id: str,
+    body: CreateCommentBody,
+    claims: Annotated[dict[str, object], Depends(auth_guard)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Any:
+    """Create a new comment on *item_id*."""
+    if not await _table_exists(db):
+        raise HTTPException(status_code=503, detail="Comments table not yet migrated")
+
+    user_id = str(claims.get("sub", "anonymous"))
+    # Prefer the display name stored in the JWT if present
+    author_name = str(claims.get("name") or claims.get("email") or user_id)
+
+    try:
+        comment = ItemComment(
+            item_id=item_id,
+            author_id=user_id,
+            author_name=author_name,
+            content=body.content.strip(),
+        )
+        db.add(comment)
+        await db.commit()
+        await db.refresh(comment)
+        return CommentResponse.from_orm_row(comment)
+    except Exception as exc:
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to create comment: {exc}") from exc
+
+
+@router.delete("/{comment_id}", status_code=204)
+async def delete_comment(
+    item_id: str,
+    comment_id: str,
+    claims: Annotated[dict[str, object], Depends(auth_guard)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Delete own comment. Non-owners receive 403."""
+    if not await _table_exists(db):
+        raise HTTPException(status_code=503, detail="Comments table not yet migrated")
+
+    user_id = str(claims.get("sub", ""))
+    result = await db.execute(
+        select(ItemComment).where(
+            ItemComment.id == comment_id,
+            ItemComment.item_id == item_id,
+        )
+    )
+    comment = result.scalar_one_or_none()
+    if comment is None:
+        raise HTTPException(status_code=404, detail="Comment not found")
+    if comment.author_id != user_id:
+        raise HTTPException(status_code=403, detail="Cannot delete another user's comment")
+
+    try:
+        await db.delete(comment)
+        await db.commit()
+    except Exception as exc:
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to delete comment: {exc}") from exc

--- a/src/tracertm/models/item_comment.py
+++ b/src/tracertm/models/item_comment.py
@@ -1,0 +1,23 @@
+"""ItemComment model — per-item discussion thread entry."""
+
+from sqlalchemy import Boolean, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tracertm.models.base import Base, TimestampMixin, generate_uuid
+
+
+class ItemComment(Base, TimestampMixin):
+    """A single comment posted on a TraceRTM item."""
+
+    __tablename__ = "item_comments"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(generate_uuid()))
+    item_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    author_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    author_name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    edited: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"<ItemComment(id={self.id!r}, item_id={self.item_id!r}, author={self.author_name!r})>"


### PR DESCRIPTION
## **User description**
Layered PR: `feat/comments-live-submit` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user-generated content and auth-protected write/delete paths require the migration; endpoints do not appear to validate item/project access, and the UI exposes delete for every comment (relying on backend 403 for non-owners).
> 
> **Overview**
> Adds **end-to-end per-item comments**: a new `item_comments` table (Alembic **063**), SQLAlchemy `ItemComment` model, and authenticated REST routes to **list**, **create**, and **delete** comments under `/api/v1/items/{item_id}/comments`, registered in the API router.
> 
> **CommentsTab** is switched from placeholder/mock behavior to the real API: load on mount with loading/error/empty states, **live submit** that appends the created comment, and **delete** with optimistic UI updates. The web client gains `commentsApi` (`list` / `create` / `delete`) and exports it on the shared `api` object.
> 
> Backend create/delete return **503** if the migration has not run; list returns **[]** in that case. Delete is restricted to the comment author (**403** otherwise). Vitest coverage exercises CommentsTab against mocked `commentsApi`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc8ad1490d2b03890925fb4039b42522dd43e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Enable live comments on items with load, add, and delete actions**

### What Changed
- Comments now load from the server instead of showing a placeholder list, with a loading state and an error message if fetching fails
- Users can post a comment and see it appear immediately in the discussion thread
- Users can delete their own comments from the item view
- The backend now stores item comments and serves list, create, and delete actions for each item

### Impact
`✅ Live item discussions`
`✅ Fewer lost comments after posting`
`✅ Clearer comment loading and error states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
