### PR TITLE
layer: fix/mdx-typescript-build — fix(docs): resolve MDX TypeScript type errors in docs app

### DIFF
--- a/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/frontend/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
 
+import type { MDXComponents } from 'mdx/types.js';
 import { mdxComponents } from '@/components/mdx-components';
 import { source } from '@/source';
 
@@ -41,7 +42,7 @@ export default async function Page(props: PageProps) {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={mdxComponents} />
+        <MDX components={mdxComponents as MDXComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/frontend/apps/docs/components/mdx-components.tsx
+++ b/frontend/apps/docs/components/mdx-components.tsx
@@ -37,12 +37,14 @@ export const mdxComponents = {
   // Media (optimized with Next.js Image)
   ImageZoom: ImageZoomLazy,
   img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    const src = typeof props.src === 'string' ? props.src : null;
     // For documentation images, use optimized component
-    if (props.src && !props.src.startsWith('http')) {
-      return <DocImage src={props.src} alt={props.alt || ''} />;
+    if (src && !src.startsWith('http')) {
+      return <DocImage src={src} alt={props.alt || ''} />;
     }
-    // For external images, use ImageZoom
-    return <ImageZoomLazy {...props} />;
+    // For external images, use ImageZoom with sizes default
+    const { src: _src, ...rest } = props;
+    return <ImageZoomLazy {...rest} src={src ?? ''} sizes={rest.sizes ?? '100vw'} />;
   },
 
   // File tree visualization (lazy-loaded)


### PR DESCRIPTION
## **User description**
Layered PR: `fix/mdx-typescript-build` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small typing and prop-shaping changes in the docs MDX layer only; runtime image routing logic is unchanged aside from safer defaults for external images.
> 
> **Overview**
> Fixes **TypeScript build failures** in the docs app around MDX rendering, without changing doc content behavior.
> 
> The docs page now passes custom MDX components using an explicit **`MDXComponents`** cast so the compiled MDX body accepts the extended Fumadocs component map.
> 
> The custom **`img`** handler narrows **`src`** to a string before routing local vs external images, and passes **`ImageZoomLazy`** a string **`src`** plus a default **`sizes`** of **`100vw`** instead of spreading raw **`img`** props that no longer match the zoom component’s types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2febf779419bb6795c75fb5bb828759e37453dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix docs app TypeScript build errors in MDX pages**

### What Changed
- Fixed the docs page so it builds with the custom MDX component set again
- Local documentation images now keep using the optimized docs image view
- External images now render with a safe image source and a default full-width size when one is not provided

### Impact
`✅ Docs builds complete again`
`✅ Fewer broken image renders in docs`
`✅ Clearer handling of external images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
