### PR TITLE
layer: test/onefn — test(observability): add unit test for FromConfig with nil i

### DIFF
--- a/backend/internal/observability/otel_test.go
+++ b/backend/internal/observability/otel_test.go
@@ -56,3 +56,10 @@ func assertEnv(t *testing.T, env map[string]string, key string, want string) {
 		t.Fatalf("%s = %q, want %q", key, got, want)
 	}
 }
+
+func TestFromConfigNilReturnsEmpty(t *testing.T) {
+	otel := FromConfig(nil)
+	if otel.Enabled || otel.ServiceName != "" || otel.Environment != "" || otel.GRPCEndpoint != "" || otel.HTTPEndpoint != "" {
+		t.Fatalf("expected empty OTELCollectorConfig for nil input, got %#v", otel)
+	}
+}


### PR DESCRIPTION
## **User description**
Layered PR: `test/onefn` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or behavior modifications.
> 
> **Overview**
> Adds **`TestFromConfigNilReturnsEmpty`**, which asserts that calling **`FromConfig(nil)`** returns a zero **`OTELCollectorConfig`** (disabled, empty service name, environment, and endpoints).
> 
> This locks in the existing nil guard in **`FromConfig`** so regressions are caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42a562e2b1aa4f20003a8676c1dfd2d1e400900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Lock in the empty observability config returned for nil input

### What Changed
- Added a unit test that checks `FromConfig(nil)` returns an empty observability config
- Confirms nil input leaves observability disabled and all config fields blank

### Impact
`✅ Fewer regressions in observability setup`
`✅ Safer handling of missing config`
`✅ Clearer test coverage for nil input`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
