### PR TITLE
layer: wip/preserve-2026-06-05 — wip(2026-06-05): preserve in-flight seed+cors+conflict-detec

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,7 +144,7 @@ GITHUB_PRIVATE_KEY_PATH=/path/to/your/github-app-private-key.pem
 # -----------------------------------------------------------------------------
 # AgilePlus Integration (Optional)
 # -----------------------------------------------------------------------------
-AGILEPLUS_URL=https://agileplus.example
+AGILEPLUS_URL=http://localhost:3000
 AGILEPLUS_API_KEY=YOUR_AGILEPLUS_API_KEY
 
 # -----------------------------------------------------------------------------

--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -347,7 +347,7 @@
 | FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | SHIPPED | Branch `feat/trc013-bulk-tracelink-ingestion`; sources: `src/tracertm/services/github_import_service.py`, `src/tracertm/services/jira_import_service.py`, `src/tracertm/api/routers/ingest.py`; validated with 28 unit tests; `uv run python -c "import tracertm"` |
 | FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | SHIPPED | Pure-function `coverage_matrix_service.py`; rows=requirements, cols=impl/test + ArtifactKind buckets; endpoint GET /api/v1/coverage/matrix?format=csv\|json; CSV RFC 4180 + pipe-separated multi-artifact cells; PDF deferred (heavy dep); 25 unit tests; PR: feat/coverage-matrix-export |
 | FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | SHIPPED | Pure-function `blast_radius_service.py`; BFS over Requirement/Artifact/TraceLink graph with per-ArtifactKind risk weights + link-confidence multipliers; score 0–100 with LOW/MEDIUM/HIGH/CRITICAL tiers; endpoint `GET /api/v1/impact/blast-radius/{artifact_id}`; 20 unit tests; PR: feat/trc015-blast-radius-scoring |
-| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | `agileplus_adapter.py` pushes Requirement / TraceLink payloads; endpoint `POST /api/v1/integrations/agileplus/push`; dog-food use case for AgilePlus |
+| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | branch `feat/trc016-agileplus-push`; `tests/unit/services/test_agileplus_adapter.py` (17 tests); `src/tracertm/adapters/agileplus_adapter.py`; endpoint `POST /api/v1/integrations/agileplus/push`; `.env.example` AgilePlus config |
 | FR-TRC-017 | Traceability coverage / health scoring over Requirement-Artifact-TraceLink graph | SHIPPED | Pure-function `traceability_score_service.py`; metrics: impl_coverage, test_coverage, orphan_req_pct, orphan_art_pct, avg_confidence, composite 0-100; endpoint GET /api/v1/quality/score; 19 unit tests; PR: feat/quality-scoring |
 | NFR-TRC-008 | Link confidence index selectivity target ≥ 90% for miner-generated links | PLANNED | Baseline TBD once miner ships |
 | NFR-TRC-009 | Neo4j projection sync latency < 500 ms p99 for single-link writes | PLANNED | No SLA defined yet |
@@ -372,6 +372,6 @@
 | FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
 | FR-TRC-014 | feat/coverage-matrix-export | `test_coverage_matrix_service.py` (25 tests) |
 | FR-TRC-015 | feat/trc015-blast-radius-scoring | `test_blast_radius_scoring.py` (20 tests) |
-| FR-TRC-016 | feat/integration: AgilePlus push adapter | `test_agileplus_adapter.py` (17 tests) |
+| FR-TRC-016 | feat/trc016-agileplus-push | `test_agileplus_adapter.py` (17 tests) |
 | FR-TRC-017 | feat/quality-scoring | `test_traceability_score_service.py` (19 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |

--- a/scripts/seed_requirements.py
+++ b/scripts/seed_requirements.py
@@ -111,6 +111,9 @@ class ParsedArtifact:
 
 _FR_HEADING = re.compile(r"###\s+(FR-[A-Z]+-\d+)\s+[—–-]\s+(.+)")
 _NFR_HEADING = re.compile(r"###\s+(NFR-[A-Z]+-\d+)\s+[—–-]\s+(.+)")
+_TABLE_ROW = re.compile(
+    r"^\|\s*((?:FR|NFR)-[A-Z]+-\d+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*(.*?)\s*\|?\s*$"
+)
 _PR_REF = re.compile(r"#(\d+)")
 _TEST_REF = re.compile(r"(tests?/[^\s,;|`\"']+\.(?:py|tsx|rs|go))")
 _STATUS_SHIPPED = re.compile(r"\bSHIPPED\b", re.IGNORECASE)
@@ -251,6 +254,38 @@ def parse_catalog(project_key: str, path: Path) -> list[ParsedRequirement]:
                 tests=tests,
             )
         )
+
+    # --- Phase 2: parse table-format rows (| FR-xxx | title | STATUS | notes |)
+    # These appear in "Gap Analysis" sections and are not split by ### headings.
+    seen_ids = {r.req_id for r in requirements}
+    for line in text.splitlines():
+        m = _TABLE_ROW.match(line.strip())
+        if not m:
+            continue
+        req_id, title, status_cell, notes = m.group(1), m.group(2).strip(), m.group(3).strip(), m.group(4).strip()
+        if req_id in seen_ids:
+            continue  # already parsed via ### heading
+        # Skip separator rows
+        if re.match(r"^[-|: ]+$", title):
+            continue
+        kind = "functional" if req_id.startswith("FR-") else "non-functional"
+        status = _infer_status(status_cell)
+        row_text = f"{status_cell} {notes}"
+        prs = _extract_prs(row_text)
+        tests = _extract_tests(row_text)
+        requirements.append(
+            ParsedRequirement(
+                req_id=req_id,
+                title=title,
+                description=notes or title,
+                kind=kind,
+                status=status,
+                acceptance_criteria=[],
+                prs=prs,
+                tests=tests,
+            )
+        )
+        seen_ids.add(req_id)
 
     return requirements
 

--- a/src/tracertm/adapters/agileplus_adapter.py
+++ b/src/tracertm/adapters/agileplus_adapter.py
@@ -122,23 +122,33 @@ class AgilePlusAdapter:
         return str(error)
 
     def _requirement_payload(self, requirement: Requirement) -> dict[str, Any]:
-        return {
-            "id": str(requirement.id),
+        metadata: dict[str, Any] = {
+            "external_id": str(requirement.id),
             "project_id": str(requirement.project_id),
             "kind": requirement.kind.value,
-            "title": requirement.title,
-            "description": requirement.description,
-            "external_id": requirement.external_id,
-            "metadata": requirement.metadata,
             "status": requirement.status.value,
-            "priority": requirement.priority,
-            "rationale": requirement.rationale,
-            "acceptance_criteria": requirement.acceptance_criteria,
-            "verification_method": requirement.verification_method.value if requirement.verification_method else None,
+        }
+        if requirement.priority is not None:
+            metadata["priority"] = requirement.priority
+        if requirement.rationale is not None:
+            metadata["rationale"] = requirement.rationale
+        if requirement.acceptance_criteria:
+            metadata["acceptance_criteria"] = requirement.acceptance_criteria
+        if requirement.verification_method is not None:
+            metadata["verification_method"] = requirement.verification_method.value
+        if requirement.external_id is not None:
+            metadata["source_external_id"] = requirement.external_id
+        if requirement.metadata:
+            metadata["source_metadata"] = requirement.metadata
+
+        return {
+            "title": requirement.title,
+            "body": requirement.description,
+            "metadata": metadata,
         }
 
     def _trace_link_payload(self, link: TraceLink) -> dict[str, Any]:
-        return {
+        trace_link = {
             "id": str(link.id),
             "project_id": str(link.project_id),
             "source_artifact_id": str(link.source_artifact_id),
@@ -148,12 +158,20 @@ class AgilePlusAdapter:
             "rationale": link.rationale,
             "metadata": link.metadata,
         }
+        return {
+            "tags": [
+                f"trace-link:{link.link_type.value.lower()}",
+                f"trace-link:{link.id}",
+            ],
+            "metadata": {
+                "trace_link": trace_link,
+            },
+        }
 
     async def _post_json(self, path: str, payload: dict[str, Any]) -> AgilePlusPushResult:
         client = await self._get_client()
-        url = f"{self.base_url}{path}"
         try:
-            response = await client.post(url, json=payload, headers=self._headers())
+            response = await client.post(path, json=payload, headers=self._headers())
         except httpx.HTTPError as exc:
             return AgilePlusPushResult(success=False, error=self._stringify_failure(None, exc))
 
@@ -172,25 +190,28 @@ class AgilePlusAdapter:
 
     async def push_requirement(self, req: Requirement) -> AgilePlusPushResult:
         """Push one requirement to AgilePlus."""
-        return await self._post_json("/api/v1/requirements", self._requirement_payload(req))
+        return await self._post_json("/api/stories", self._requirement_payload(req))
 
     async def push_trace_link(self, link: TraceLink) -> AgilePlusPushResult:
         """Push one trace link to AgilePlus."""
-        return await self._post_json("/api/v1/trace-links", self._trace_link_payload(link))
+        return await self._post_json(
+            f"/api/stories/{link.target_artifact_id}/tags",
+            self._trace_link_payload(link),
+        )
 
     async def push_project_requirements(
         self,
         project_id: str,
-        reqs: list[Requirement],
+        requirements: list[Requirement],
         links: list[TraceLink],
     ) -> BulkPushResult:
         """Push a project's requirements and trace links to AgilePlus."""
-        total = len(reqs) + len(links)
+        total = len(requirements) + len(links)
         succeeded = 0
         failed = 0
         errors: list[str] = []
 
-        for requirement in reqs:
+        for requirement in requirements:
             if str(requirement.project_id) != str(project_id):
                 failed += 1
                 errors.append(

--- a/src/tracertm/api/middleware/cors.py
+++ b/src/tracertm/api/middleware/cors.py
@@ -36,10 +36,12 @@ def setup_cors(app: FastAPI) -> None:
         ),
     ).split(",")
 
+    parsed_origins = [origin.strip() for origin in cors_origins]
+
     # Add CORS middleware with strict origin whitelist
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=[origin.strip() for origin in cors_origins],
+        allow_origins=parsed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/src/tracertm/api/router_registry.py
+++ b/src/tracertm/api/router_registry.py
@@ -8,13 +8,13 @@ from tracertm.api.routers import (
     agent,
     analysis,
     auth,
-    code_trace,
     auth_public,
     auth_refresh,
     auth_session,
     blockchain,
     cache,
     chat,
+    code_trace,
     codex,
     comments,
     contracts,
@@ -30,6 +30,7 @@ from tracertm.api.routers import (
     impact,
     impact_scoring,
     ingest,
+    integrations,
     items,
     items_summary,
     linear,
@@ -37,7 +38,6 @@ from tracertm.api.routers import (
     mcp,
     mine,
     notifications,
-    traceability_score,
     oauth,
     problems,
     processes,
@@ -50,6 +50,7 @@ from tracertm.api.routers import (
     test_run_results,
     test_runs,
     test_suites,
+    traceability_score,
     webhooks,
     websocket,
     workflows,
@@ -130,6 +131,7 @@ def register_api_routers(app: FastAPI) -> None:
     app.include_router(github.router)
     app.include_router(github.webhook_router)
     app.include_router(linear.router)
+    app.include_router(integrations.router)
     app.include_router(webhooks.router)
     app.include_router(webhooks.project_router)
     app.include_router(websocket.router)

--- a/tests/unit/services/test_agileplus_adapter.py
+++ b/tests/unit/services/test_agileplus_adapter.py
@@ -101,12 +101,12 @@ async def test_push_requirement_sends_expected_payload() -> None:
     def callback(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         assert request.method == "POST"
-        assert request.url.path == "/api/v1/requirements"
-        assert body["id"] == str(requirement.id)
-        assert body["project_id"] == str(requirement.project_id)
+        assert request.url.path == "/api/stories"
         assert body["title"] == "Payload check"
-        assert body["status"] == RequirementStatus.APPROVED.value
-        assert body["acceptance_criteria"] == ["works"]
+        assert body["body"] == "A traced requirement"
+        assert body["metadata"]["external_id"] == str(requirement.id)
+        assert body["metadata"]["project_id"] == str(requirement.project_id)
+        assert body["metadata"]["status"] == RequirementStatus.APPROVED.value
         return httpx.Response(200, json={"agileplus_id": "req-456"})
 
     adapter, _handler = _adapter_with(callback)
@@ -132,7 +132,7 @@ async def test_push_requirement_handles_non_success_status() -> None:
 @pytest.mark.asyncio
 async def test_push_requirement_handles_network_error() -> None:
     def callback(_request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=httpx.Request("POST", "https://agileplus.example/api/v1/requirements"))
+        raise httpx.ConnectError("boom", request=httpx.Request("POST", "https://agileplus.example/api/stories"))
 
     adapter, _handler = _adapter_with(callback)
     result = await adapter.push_requirement(_requirement())
@@ -160,7 +160,7 @@ async def test_push_requirement_uses_other_project_id() -> None:
 
     def callback(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
-        assert body["project_id"] == str(OTHER_PROJECT_ID)
+        assert body["metadata"]["project_id"] == str(OTHER_PROJECT_ID)
         return httpx.Response(200, json={"id": "req-999"})
 
     adapter, _handler = _adapter_with(callback)
@@ -189,14 +189,19 @@ async def test_push_trace_link_sends_expected_payload() -> None:
     def callback(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         assert request.method == "POST"
-        assert request.url.path == "/api/v1/trace-links"
-        assert body["id"] == str(link.id)
-        assert body["project_id"] == str(link.project_id)
-        assert body["source_artifact_id"] == str(link.source_artifact_id)
-        assert body["target_artifact_id"] == str(link.target_artifact_id)
-        assert body["link_type"] == TraceLinkType.SATISFIES.value
-        assert body["confidence"] == pytest.approx(0.85)
-        assert body["rationale"] == "Trace evidence"
+        assert request.url.path == f"/api/stories/{link.target_artifact_id}/tags"
+        assert body["tags"] == [
+            f"trace-link:{link.link_type.value.lower()}",
+            f"trace-link:{link.id}",
+        ]
+        trace_link = body["metadata"]["trace_link"]
+        assert trace_link["id"] == str(link.id)
+        assert trace_link["project_id"] == str(link.project_id)
+        assert trace_link["source_artifact_id"] == str(link.source_artifact_id)
+        assert trace_link["target_artifact_id"] == str(link.target_artifact_id)
+        assert trace_link["link_type"] == TraceLinkType.SATISFIES.value
+        assert trace_link["confidence"] == pytest.approx(0.85)
+        assert trace_link["rationale"] == "Trace evidence"
         return httpx.Response(201, json={"agileplus_id": "link-456"})
 
     adapter, _handler = _adapter_with(callback)
@@ -228,10 +233,10 @@ async def test_push_project_requirements_success_counts_all_items() -> None:
 
     def callback(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content)
-        if request.url.path == "/api/v1/requirements":
+        if request.url.path == "/api/stories":
             return httpx.Response(200, json={"id": f"req-{payload['title'].lower().replace(' ', '-')}"})
-        if request.url.path == "/api/v1/trace-links":
-            return httpx.Response(200, json={"id": f"link-{payload['target_artifact_id'][-4:]}"})
+        if request.url.path.endswith("/tags"):
+            return httpx.Response(200, json={"id": f"link-{payload['metadata']['trace_link']['target_artifact_id'][-4:]}"})
         pytest.fail(f"unexpected path: {request.url.path}")
 
     adapter, _handler = _adapter_with(callback)
@@ -293,7 +298,7 @@ async def test_push_project_requirements_preserves_order() -> None:
     adapter, _handler = _adapter_with(callback)
     await adapter.push_project_requirements(PROJECT_ID, [req], [link])
 
-    assert paths == ["/api/v1/requirements", "/api/v1/trace-links"]
+    assert paths == ["/api/stories", f"/api/stories/{req.id}/tags"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_dup_conflict_detector.py
+++ b/tests/unit/services/test_dup_conflict_detector.py
@@ -1,0 +1,262 @@
+"""Unit tests for the duplicate / conflict detector service.
+
+Functional Requirements: FR-TRC-012
+
+Coverage
+--------
+* Near-duplicate pair detected above threshold.
+* Distinct requirements NOT flagged as duplicates.
+* Conflicting link pair detected.
+* Clean link set returns empty findings.
+* Edge cases: threshold validation, empty inputs.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tracertm.models.trace_link import Artifact, ArtifactKind, TraceLink, TraceLinkType
+from tracertm.services.dup_conflict_detector import (
+    detect_conflicting_links,
+    detect_duplicate_requirements,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _req(title: str, description: str | None = None) -> Artifact:
+    """Construct a minimal REQUIREMENT Artifact."""
+    return Artifact(
+        id=uuid.uuid4(),
+        project_id=uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001"),
+        kind=ArtifactKind.REQUIREMENT,
+        title=title,
+        description=description,
+    )
+
+
+def _link(
+    src: uuid.UUID,
+    tgt: uuid.UUID,
+    link_type: TraceLinkType,
+    *,
+    project_id: uuid.UUID | None = None,
+) -> TraceLink:
+    """Construct a minimal TraceLink."""
+    return TraceLink(
+        id=uuid.uuid4(),
+        project_id=project_id or uuid.UUID("bbbbbbbb-0000-0000-0000-000000000001"),
+        source_artifact_id=src,
+        target_artifact_id=tgt,
+        link_type=link_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDuplicateRequirements:
+    """Tests for detect_duplicate_requirements."""
+
+    def test_near_duplicate_pair_detected(self) -> None:
+        """Two requirements with near-identical text are flagged."""
+        a = _req(
+            "The system shall validate user input before processing",
+            "Input validation is required",
+        )
+        b = _req(
+            "The system shall validate user input before processing",
+            "Input validation is required for all forms",
+        )
+        findings = detect_duplicate_requirements([a, b], threshold=0.70)
+        assert len(findings) == 1
+        finding = findings[0]
+        assert {finding.artifact_a_id, finding.artifact_b_id} == {a.id, b.id}
+        assert finding.similarity >= 0.70
+
+    def test_exact_duplicates_detected_at_default_threshold(self) -> None:
+        """Identical title+description is always above the 0.75 default."""
+        same_title = "The system shall authenticate users via OAuth2"
+        a = _req(same_title, "OAuth2 PKCE flow required")
+        b = _req(same_title, "OAuth2 PKCE flow required")
+        findings = detect_duplicate_requirements([a, b])
+        assert len(findings) == 1
+        assert findings[0].similarity == 1.0
+
+    def test_distinct_requirements_not_flagged(self) -> None:
+        """Requirements with clearly different text are not flagged."""
+        a = _req("The system shall export reports to PDF", "PDF export via wkhtmltopdf")
+        b = _req("The system shall authenticate users via SSO", "SAML 2.0 IdP required")
+        c = _req("Database backups must run daily at midnight", "Automated pg_dump scheduled task")
+        findings = detect_duplicate_requirements([a, b, c])
+        assert findings == []
+
+    def test_empty_input_returns_no_findings(self) -> None:
+        """Empty artifact list yields empty findings."""
+        assert detect_duplicate_requirements([]) == []
+
+    def test_single_artifact_returns_no_findings(self) -> None:
+        """Single artifact has no pair to compare against."""
+        assert detect_duplicate_requirements([_req("Only one requirement")]) == []
+
+    def test_findings_sorted_descending_by_similarity(self) -> None:
+        """Multiple pairs are sorted highest similarity first."""
+        base = "The system shall log all user actions to the audit trail"
+        a = _req(base)
+        b = _req(base)  # exact match → 1.0
+        c = _req("The system shall log user actions to audit")  # partial match
+        findings = detect_duplicate_requirements([a, b, c], threshold=0.5)
+        assert len(findings) >= 2
+        sims = [f.similarity for f in findings]
+        assert sims == sorted(sims, reverse=True)
+
+    def test_threshold_validation_raises_on_zero(self) -> None:
+        """Threshold of 0.0 is invalid and raises ValueError."""
+        with pytest.raises(ValueError, match="threshold"):
+            detect_duplicate_requirements([_req("x")], threshold=0.0)
+
+    def test_threshold_validation_raises_on_negative(self) -> None:
+        """Negative threshold raises ValueError."""
+        with pytest.raises(ValueError, match="threshold"):
+            detect_duplicate_requirements([_req("x")], threshold=-0.1)
+
+    def test_threshold_1_0_only_exact(self) -> None:
+        """Threshold 1.0 flags only token-identical pairs."""
+        a = _req("System shall validate input")
+        b = _req("System shall validate input")          # exact
+        c = _req("System shall validate all user input")  # slightly different
+        findings = detect_duplicate_requirements([a, b, c], threshold=1.0)
+        assert len(findings) == 1
+        assert {findings[0].artifact_a_id, findings[0].artifact_b_id} == {a.id, b.id}
+
+    def test_description_contributes_to_similarity(self) -> None:
+        """Description text is included in the token set."""
+        a = _req("Auth requirement", "Users must log in with their corporate SSO credentials")
+        b = _req("Auth requirement", "Users must log in with their corporate SSO credentials")
+        findings = detect_duplicate_requirements([a, b], threshold=0.9)
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Conflict detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectConflictingLinks:
+    """Tests for detect_conflicting_links."""
+
+    def test_satisfies_and_conflicts_with_flagged(self) -> None:
+        """SATISFIES + CONFLICTS_WITH on same pair is a conflict."""
+        src = uuid.uuid4()
+        tgt = uuid.uuid4()
+        satisfies = _link(src, tgt, TraceLinkType.SATISFIES)
+        conflicts = _link(src, tgt, TraceLinkType.CONFLICTS_WITH)
+        findings = detect_conflicting_links([satisfies, conflicts])
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.source_artifact_id == src
+        assert f.target_artifact_id == tgt
+        assert TraceLinkType.CONFLICTS_WITH.value in {f.link_type_a, f.link_type_b}
+        assert f.confidence == 1.0
+
+    def test_implements_and_conflicts_with_flagged(self) -> None:
+        """IMPLEMENTS + CONFLICTS_WITH on same pair is a conflict."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        impl = _link(src, tgt, TraceLinkType.IMPLEMENTS)
+        conf = _link(src, tgt, TraceLinkType.CONFLICTS_WITH)
+        findings = detect_conflicting_links([impl, conf])
+        assert len(findings) == 1
+
+    def test_verifies_and_conflicts_with_flagged(self) -> None:
+        """VERIFIES + CONFLICTS_WITH on same pair is a conflict."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        findings = detect_conflicting_links([
+            _link(src, tgt, TraceLinkType.VERIFIES),
+            _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+        ])
+        assert len(findings) == 1
+
+    def test_derives_from_and_conflicts_with_flagged(self) -> None:
+        """DERIVES_FROM + CONFLICTS_WITH on same pair is a conflict."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        findings = detect_conflicting_links([
+            _link(src, tgt, TraceLinkType.DERIVES_FROM),
+            _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+        ])
+        assert len(findings) == 1
+
+    def test_refines_and_conflicts_with_flagged(self) -> None:
+        """REFINES + CONFLICTS_WITH on same pair is a conflict."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        findings = detect_conflicting_links([
+            _link(src, tgt, TraceLinkType.REFINES),
+            _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+        ])
+        assert len(findings) == 1
+
+    def test_different_pairs_no_cross_conflict(self) -> None:
+        """CONFLICTS_WITH on one pair does not affect a different (src, tgt)."""
+        src1, tgt1 = uuid.uuid4(), uuid.uuid4()
+        src2, tgt2 = uuid.uuid4(), uuid.uuid4()
+        findings = detect_conflicting_links([
+            _link(src1, tgt1, TraceLinkType.SATISFIES),
+            _link(src1, tgt1, TraceLinkType.CONFLICTS_WITH),
+            _link(src2, tgt2, TraceLinkType.SATISFIES),
+        ])
+        assert len(findings) == 1
+        assert findings[0].source_artifact_id == src1
+
+    def test_clean_links_returns_empty(self) -> None:
+        """A set of links with no conflicts returns an empty list."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        findings = detect_conflicting_links([
+            _link(src, tgt, TraceLinkType.SATISFIES),
+            _link(src, tgt, TraceLinkType.VERIFIES),
+        ])
+        assert findings == []
+
+    def test_two_cooperative_types_no_conflict(self) -> None:
+        """SATISFIES + IMPLEMENTS on same pair is NOT a conflict."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        assert detect_conflicting_links([
+            _link(src, tgt, TraceLinkType.SATISFIES),
+            _link(src, tgt, TraceLinkType.IMPLEMENTS),
+        ]) == []
+
+    def test_empty_links_returns_empty(self) -> None:
+        """Empty link list yields empty findings."""
+        assert detect_conflicting_links([]) == []
+
+    def test_single_link_no_conflict(self) -> None:
+        """A single link cannot conflict with itself."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        assert detect_conflicting_links([_link(src, tgt, TraceLinkType.SATISFIES)]) == []
+
+    def test_conflicts_with_only_pair_no_conflict(self) -> None:
+        """Two CONFLICTS_WITH links on same pair are NOT a structural conflict."""
+        src, tgt = uuid.uuid4(), uuid.uuid4()
+        findings = detect_conflicting_links([
+            _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+            _link(src, tgt, TraceLinkType.CONFLICTS_WITH),
+        ])
+        # CONFLICTS_WITH paired with itself is not in _CONFLICT_PAIRS
+        assert findings == []
+
+    def test_multiple_conflict_pairs_all_found(self) -> None:
+        """Multiple conflicting pairs on different (src, tgt) are all reported."""
+        pairs = [(uuid.uuid4(), uuid.uuid4()) for _ in range(3)]
+        links = []
+        for src, tgt in pairs:
+            links.append(_link(src, tgt, TraceLinkType.SATISFIES))
+            links.append(_link(src, tgt, TraceLinkType.CONFLICTS_WITH))
+        findings = detect_conflicting_links(links)
+        assert len(findings) == 3


### PR DESCRIPTION
## **User description**
Layered PR: `wip/preserve-2026-06-05` → integration/consolidate (2 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> AgilePlus adapter endpoint and payload shape changes can break pushes if the remote service still expects the previous `/api/v1/requirements` and `/api/v1/trace-links` contract; other changes are docs, CORS refactor, router registration, and tests.
> 
> **Overview**
> Aligns **AgilePlus push** with story-based APIs: requirements go to `POST /api/stories` as `title`/`body` with trace fields in `metadata`, and trace links go to `POST /api/stories/{target_artifact_id}/tags` with tags plus nested `trace_link` metadata. HTTP posts use client-relative paths; bulk push renames the requirements list parameter. Unit tests for the adapter are updated accordingly.
> 
> **Local/dev wiring:** `.env.example` sets `AGILEPLUS_URL` to `http://localhost:3000`, CORS origin parsing is a small refactor, and the **integrations** router is registered on the FastAPI app.
> 
> **Seeding & docs:** `seed_requirements.py` adds a second pass that ingests Gap Analysis **table rows** (`| FR-xxx | … |`) so shipped items not under `###` headings still seed. The Tracera FR/NFR catalog notes for FR-TRC-016 are refreshed (branch, tests, adapter).
> 
> Adds **`tests/unit/services/test_dup_conflict_detector.py`** (FR-TRC-012) covering duplicate and conflicting link detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afc139646e584d334cabb1748e72d056868cf07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Push requirements and trace links to AgilePlus in the format the project expects

### What Changed
- Requirements now send their details as story content with supporting data kept in metadata, and trace links are added through the story tags endpoint
- AgilePlus requests now use the configured API base path directly, which avoids building the wrong URL
- The requirements seed parser now picks up table-style requirement rows, so items listed in gap-analysis tables are imported too
- The integrations API is now available through the router registry, and CORS origin values are cleaned before being applied
- Added coverage for AgilePlus pushes and duplicate/conflict detection behavior

### Impact
`✅ Successful AgilePlus requirement sync`
`✅ Trace links show up under the right AgilePlus story`
`✅ Fewer missed requirements from table-based catalogs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
