### PR TITLE
feat(api): add /healthz and /readyz health endpoints

### DIFF
--- a/src/tracertm/api/main.py
+++ b/src/tracertm/api/main.py
@@ -24,6 +24,15 @@ def create_app() -> FastAPI:
     app.include_router(sdlc_pm_router, prefix="/api/v1")
     app.include_router(evidence_router, prefix="/api/v1")
     app.include_router(org_intel_router, prefix="/api/v1")
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readyz")
+    async def readyz() -> dict[str, str]:
+        return {"status": "ready"}
+
     return app
 
 

--- a/src/tracertm/api/main.py
+++ b/src/tracertm/api/main.py
@@ -25,13 +25,23 @@ def create_app() -> FastAPI:
     app.include_router(evidence_router, prefix="/api/v1")
     app.include_router(org_intel_router, prefix="/api/v1")
 
-    @app.get("/healthz")
+    @app.get("/healthz", include_in_schema=False)
     async def healthz() -> dict[str, str]:
+        """Liveness probe — process is up and serving HTTP.
+
+        Excluded from OpenAPI schema (operational endpoint for orchestrators).
+        """
         return {"status": "ok"}
 
-    @app.get("/readyz")
+    @app.get("/readyz", include_in_schema=False)
     async def readyz() -> dict[str, str]:
-        return {"status": "ready"}
+        """Readiness probe — minimal check; orchestrator-driven verification.
+
+        Excluded from OpenAPI schema (operational endpoint for orchestrators).
+        Returns version + liveness; deeper downstream checks are deferred to
+        orchestrator-side probes per ADR-OPS-HEALTH-001.
+        """
+        return {"status": "ready", "version": app.version}
 
     return app
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,0 +1,43 @@
+"""Unit tests for /healthz and /readyz endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tracertm.api.main import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.mark.asyncio
+async def test_healthz_returns_ok(app) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_readyz_returns_ready(app) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_healthz_content_type_json(app) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/healthz")
+    assert "application/json" in response.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_readyz_content_type_json(app) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/readyz")
+    assert "application/json" in response.headers["content-type"]


### PR DESCRIPTION
## **User description**
## Summary
- Adds GET /healthz returning {"status": "ok"} for liveness probes
- Adds GET /readyz returning {"status": "ready"} for readiness probes
- Both endpoints registered inside create_app() in src/tracertm/api/main.py
- 4 async unit tests in tests/unit/api/test_health.py using httpx AsyncClient

## Test plan
- [ ] pytest tests/unit/api/test_health.py -- 4 tests: status codes, JSON bodies, content-type headers
- [ ] curl http://localhost:8000/healthz returns {"status":"ok"}
- [ ] curl http://localhost:8000/readyz returns {"status":"ready"}

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only endpoints with static JSON responses; no auth, data, or business logic changes.
> 
> **Overview**
> Adds **Kubernetes-style liveness and readiness** routes on the FastAPI app root (outside `/api/v1`): `GET /healthz` returns `{"status": "ok"}` and `GET /readyz` returns `{"status": "ready"}`. Both are registered inside `create_app()` in `main.py` and do not check dependencies yet.
> 
> Adds **four async unit tests** in `tests/unit/api/test_health.py` that hit each route via `httpx` `AsyncClient`, asserting HTTP 200, JSON bodies, and JSON `content-type`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb26242c23c53de0f806187b9db4a097ce247b44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add root health and readiness checks for the API**

### What Changed
- The API now responds to `GET /healthz` with `{"status": "ok"}` for basic liveness checks.
- The API now responds to `GET /readyz` with `{"status": "ready"}` for readiness checks.
- Added tests that confirm both endpoints return HTTP 200, the expected JSON body, and JSON content type.

### Impact
`✅ Easier deployment health checks`
`✅ Clearer service readiness signals`
`✅ Safer container monitoring`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
