### PR TITLE
feat(frontend): fill Tracera TS SDK with impact, spec-check, confidence, evidence endpoints

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,3 @@
-06:19:31.008102 exec-cmd.c:266          trace: resolved executable dir: C:/Program Files/Git/mingw64/bin
-06:19:31.023415 git.c:476               trace: built-in: git show :3:frontend/package.json
 {
   "name": "tracera-frontend",
   "private": true,

--- a/frontend/packages/api-client/package.json
+++ b/frontend/packages/api-client/package.json
@@ -13,13 +13,15 @@
   },
   "scripts": {
     "build": "npx -p typescript@5.8.3 tsc -p tsconfig.json",
-    "typecheck": "npx -p typescript@5.8.3 tsc -p tsconfig.json --noEmit"
+    "typecheck": "npx -p typescript@5.8.3 tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tracertm/types": "file:../types"
   },
   "devDependencies": {
     "@types/node": "^22.15.21",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/frontend/packages/api-client/src/index.test.ts
+++ b/frontend/packages/api-client/src/index.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { TraceraApiClient, fetchCoverageMatrix } from './index.js';
+import type {
+  ConfidenceRequest,
+  ConfidenceResponse,
+  CoverageMatrixRequest,
+  CoverageMatrixResponse,
+  EvidenceCreate,
+  EvidenceResponse,
+  GovernanceCheckRequest,
+  GovernanceReport,
+  ImpactRequest,
+  ImpactResponse,
+} from '@tracertm/types';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('fetchCoverageMatrix', () => {
+  it('posts a typed CoverageMatrixRequest and resolves with a CoverageMatrixResponse', async () => {
+    const responseBody: CoverageMatrixResponse = {
+      generated_at: '2026-06-16T00:00:00Z',
+      link_count: 1,
+      cell_count: 1,
+      stale_links: 0,
+      cells: [
+        {
+          source_id: 'req-1',
+          target_id: 'code-1',
+          coverage: 'covered',
+          links: [
+            {
+              source_id: 'req-1',
+              target_id: 'code-1',
+              relationship: 'satisfies',
+              confidence: 1.0,
+            },
+          ],
+        },
+      ],
+    };
+
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify(responseBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    const request: CoverageMatrixRequest = {
+      links: [{ source_id: 'req-1', target_id: 'code-1', relationship: 'satisfies' }],
+      stale_after_days: 30,
+    };
+
+    const result = await fetchCoverageMatrix('https://api.example.test/', request, fetchImpl as unknown as typeof fetch);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const firstCall = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const [calledUrl, calledInit] = firstCall;
+    expect(calledUrl).toBe('https://api.example.test/api/v1/coverage-matrix');
+    expect(calledInit.method).toBe('POST');
+    expect(JSON.parse(calledInit.body as string)).toEqual(request);
+    expect(result).toEqual(responseBody);
+
+    // Type assertions: the resolved value must match CoverageMatrixResponse,
+    // and the request parameter must accept the full typed shape.
+    expectTypeOf(result).toEqualTypeOf<CoverageMatrixResponse>();
+    expectTypeOf(request).toMatchTypeOf<CoverageMatrixRequest>();
+  });
+});
+
+describe('TraceraApiClient', () => {
+  function makeClient(handler: (url: string, init: RequestInit) => Response) {
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        return handler(url, init ?? {});
+      },
+    );
+    const client = new TraceraApiClient({
+      baseUrl: 'https://api.example.test/',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    return { client, fetchImpl };
+  }
+
+  it('buildCoverageMatrix POSTs to /api/v1/coverage-matrix', async () => {
+    const body: CoverageMatrixResponse = {
+      generated_at: '2026-06-16T00:00:00Z',
+      link_count: 1,
+      cell_count: 1,
+      stale_links: 0,
+      cells: [],
+    };
+    const { client, fetchImpl } = makeClient(() => jsonResponse(body));
+    const request: CoverageMatrixRequest = {
+      links: [{ source_id: 'r', target_id: 'c', relationship: 'satisfies' }],
+    };
+
+    const result = await client.buildCoverageMatrix(request);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/v1/coverage-matrix');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(request);
+    expect(result).toEqual(body);
+    expectTypeOf(result).toEqualTypeOf<CoverageMatrixResponse>();
+  });
+
+  it('analyzeImpact POSTs to /api/v1/impact', async () => {
+    const body: ImpactResponse = {
+      seeds: ['c-1'],
+      affected: [{ artifact_id: 't-1', depth: 1, via: ['verifies'], score: 0.75 }],
+      total_score: 0.75,
+      truncated: false,
+      max_depth_seen: 1,
+      conflicts: [],
+    };
+    const { client, fetchImpl } = makeClient(() => jsonResponse(body));
+    const request: ImpactRequest = {
+      changed_artifact_ids: ['c-1'],
+      max_depth: 3,
+      links: [],
+    };
+
+    const result = await client.analyzeImpact(request);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/v1/impact');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(request);
+    expect(result).toEqual(body);
+    expectTypeOf(result).toEqualTypeOf<ImpactResponse>();
+  });
+
+  it('specCheck POSTs to /api/v1/governance/spec-check', async () => {
+    const body: GovernanceReport = {
+      status: 'pass',
+      spec_count: 1,
+      trace_count: 2,
+      violations: [],
+    };
+    const { client, fetchImpl } = makeClient(() => jsonResponse(body));
+    const request: GovernanceCheckRequest = {
+      specs: [
+        {
+          spec_id: 's-1',
+          title: 'Spec',
+          owner: 'koosh',
+          acceptance_criteria: ['a'],
+          evidence_links: ['e'],
+          status: 'approved',
+        },
+      ],
+      traces: [
+        { spec_id: 's-1', target_id: 'c-1', kind: 'implementation' },
+        { spec_id: 's-1', target_id: 't-1', kind: 'test' },
+      ],
+    };
+
+    const result = await client.specCheck(request);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/v1/governance/spec-check');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(request);
+    expect(result).toEqual(body);
+    expectTypeOf(result).toEqualTypeOf<GovernanceReport>();
+  });
+
+  it('computeConfidence POSTs to /api/v1/confidence', async () => {
+    const body: ConfidenceResponse = { confidence: 0.5, rationale: 'jaccard=0.5' };
+    const { client, fetchImpl } = makeClient(() => jsonResponse(body));
+    const request: ConfidenceRequest = {
+      requirement_text: 'must verify',
+      artifact_text: 'verifies that',
+    };
+
+    const result = await client.computeConfidence(request);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/v1/confidence');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(request);
+    expect(result).toEqual(body);
+    expectTypeOf(result).toEqualTypeOf<ConfidenceResponse>();
+  });
+
+  it('listEvidence GETs /api/v1/evidence', async () => {
+    const body: EvidenceResponse[] = [
+      {
+        id: 'ev-1',
+        artifact_id: 'c-1',
+        kind: 'test_run',
+        url: 'https://ci.example.test/runs/1',
+        captured_at: '2026-06-16T00:00:00Z',
+        description: null,
+        metadata: {},
+        created_at: '2026-06-16T00:00:00Z',
+        updated_at: '2026-06-16T00:00:00Z',
+      },
+    ];
+    const { client, fetchImpl } = makeClient(() => jsonResponse(body));
+
+    const result = await client.listEvidence();
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/v1/evidence');
+    expect(init.method).toBe('GET');
+    expect(result).toEqual(body);
+    expectTypeOf(result).toEqualTypeOf<EvidenceResponse[]>();
+  });
+
+  it('createEvidence POSTs to /api/v1/evidence', async () => {
+    const body: EvidenceResponse = {
+      id: 'ev-2',
+      artifact_id: 'c-1',
+      kind: 'screenshot',
+      url: 'https://files.example.test/x.png',
+      captured_at: '2026-06-16T00:00:00Z',
+      description: 'shot',
+      metadata: { sha: 'abc' },
+      created_at: '2026-06-16T00:00:00Z',
+      updated_at: '2026-06-16T00:00:00Z',
+    };
+    const { client, fetchImpl } = makeClient(() => jsonResponse(body));
+    const payload: EvidenceCreate = {
+      artifact_id: 'c-1',
+      kind: 'screenshot',
+      url: 'https://files.example.test/x.png',
+      captured_at: '2026-06-16T00:00:00Z',
+      description: 'shot',
+      metadata: { sha: 'abc' },
+    };
+
+    const result = await client.createEvidence(payload);
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/v1/evidence');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(payload);
+    expect(result).toEqual(body);
+    expectTypeOf(result).toEqualTypeOf<EvidenceResponse>();
+  });
+
+  it('throws on non-2xx responses', async () => {
+    const { client } = makeClient(() => jsonResponse({}, { status: 500 }));
+    await expect(client.buildCoverageMatrix({ links: [] })).rejects.toThrow(
+      /coverage-matrix failed \(500\)/,
+    );
+  });
+});

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -46,6 +46,7 @@ export class TraceraApiClient {
     return this.buildCoverageMatrix({ links: [link] });
   }
 
+  /** POST /api/v1/coverage-matrix — full request body. */
   async buildCoverageMatrix(
     request: CoverageMatrixRequest = {},
   ): Promise<CoverageMatrixResponse> {

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -1,10 +1,30 @@
 import type {
+  ConfidenceRequest,
+  ConfidenceResponse,
   CoverageMatrixRequest,
   CoverageMatrixResponse,
+  EvidenceCreate,
+  EvidenceResponse,
+  GovernanceCheckRequest,
+  GovernanceReport,
+  ImpactRequest,
+  ImpactResponse,
   TraceLinkInput,
 } from '@tracertm/types';
 
-export type { CoverageMatrixRequest, CoverageMatrixResponse, TraceLinkInput };
+export type {
+  ConfidenceRequest,
+  ConfidenceResponse,
+  CoverageMatrixRequest,
+  CoverageMatrixResponse,
+  EvidenceCreate,
+  EvidenceResponse,
+  GovernanceCheckRequest,
+  GovernanceReport,
+  ImpactRequest,
+  ImpactResponse,
+  TraceLinkInput,
+};
 
 export interface TraceraApiClientOptions {
   baseUrl: string;
@@ -39,8 +59,98 @@ export class TraceraApiClient {
     }
     return (await response.json()) as CoverageMatrixResponse;
   }
+
+  /** POST /api/v1/impact */
+  async analyzeImpact(request: ImpactRequest): Promise<ImpactResponse> {
+    return this.postJson<ImpactResponse>(
+      '/api/v1/impact',
+      request,
+      'impact',
+    );
+  }
+
+  /** POST /api/v1/governance/spec-check */
+  async specCheck(
+    request: GovernanceCheckRequest = {},
+  ): Promise<GovernanceReport> {
+    return this.postJson<GovernanceReport>(
+      '/api/v1/governance/spec-check',
+      request,
+      'spec-check',
+    );
+  }
+
+  /** POST /api/v1/confidence */
+  async computeConfidence(
+    request: ConfidenceRequest,
+  ): Promise<ConfidenceResponse> {
+    return this.postJson<ConfidenceResponse>(
+      '/api/v1/confidence',
+      request,
+      'confidence',
+    );
+  }
+
+  /** GET /api/v1/evidence */
+  async listEvidence(): Promise<EvidenceResponse[]> {
+    const response = await this.fetchImpl(`${this.baseUrl}/api/v1/evidence`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`evidence failed (${response.status})`);
+    }
+    return (await response.json()) as EvidenceResponse[];
+  }
+
+  /** POST /api/v1/evidence */
+  async createEvidence(payload: EvidenceCreate): Promise<EvidenceResponse> {
+    return this.postJson<EvidenceResponse>(
+      '/api/v1/evidence',
+      payload,
+      'evidence',
+    );
+  }
+
+  private async postJson<T>(
+    path: string,
+    body: unknown,
+    label: string,
+  ): Promise<T> {
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`${label} failed (${response.status})`);
+    }
+    return (await response.json()) as T;
+  }
 }
 
 export function createTraceraApiClient(baseUrl: string): TraceraApiClient {
   return new TraceraApiClient({ baseUrl });
+}
+
+/**
+ * Standalone typed wrapper for POST /api/v1/coverage-matrix.
+ * Mirrors `CoverageMatrixRequest` / `CoverageMatrixResponse` from `@tracertm/types`
+ * (derived from the FastAPI router at `src/tracertm/api/routers/traceability.py`).
+ */
+export async function fetchCoverageMatrix(
+  baseUrl: string,
+  request: CoverageMatrixRequest = {},
+  fetchImpl: typeof fetch = fetch,
+): Promise<CoverageMatrixResponse> {
+  const url = `${baseUrl.replace(/\/$/, '')}/api/v1/coverage-matrix`;
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    throw new Error(`coverage-matrix failed (${response.status})`);
+  }
+  return (await response.json()) as CoverageMatrixResponse;
 }

--- a/frontend/packages/api-client/tsconfig.json
+++ b/frontend/packages/api-client/tsconfig.json
@@ -6,9 +6,11 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
-    "rootDir": "src",
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@tracertm/types": ["../types/src/index.ts"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/frontend/packages/api-client/vitest.config.ts
+++ b/frontend/packages/api-client/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@tracertm/types': new URL('../types/src/index.ts', import.meta.url).pathname,
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/frontend/packages/types/src/index.ts
+++ b/frontend/packages/types/src/index.ts
@@ -65,3 +65,98 @@ export interface CoverageMatrixResponse {
   stale_links: number;
   cells: MatrixCellResponse[];
 }
+
+export interface ImpactRequest extends CoverageMatrixRequest {
+  changed_artifact_ids: string[];
+  max_depth?: number;
+}
+
+export interface ImpactNodeResponse {
+  artifact_id: string;
+  depth: number;
+  via: TraceRelationship[];
+  score: number;
+}
+
+export interface ImpactResponse {
+  seeds: string[];
+  affected: ImpactNodeResponse[];
+  total_score: number;
+  truncated: boolean;
+  max_depth_seen: number;
+  conflicts: TraceLinkInput[];
+}
+
+export type GovernanceTraceKind =
+  | 'implementation'
+  | 'test'
+  | 'evidence'
+  | 'decision';
+
+export type GovernanceGateStatus = 'pass' | 'fail';
+
+export type GovernanceSpecStatus = 'draft' | 'approved' | 'implemented';
+
+export interface GovernanceTrace {
+  spec_id: string;
+  target_id: string;
+  kind: GovernanceTraceKind;
+}
+
+export interface GovernanceSpec {
+  spec_id: string;
+  title: string;
+  owner: string;
+  acceptance_criteria?: string[];
+  evidence_links?: string[];
+  status?: GovernanceSpecStatus;
+}
+
+export interface GovernanceViolation {
+  spec_id: string;
+  code: string;
+  message: string;
+}
+
+export interface GovernanceReport {
+  status: GovernanceGateStatus;
+  spec_count: number;
+  trace_count: number;
+  violations: GovernanceViolation[];
+}
+
+export interface GovernanceCheckRequest {
+  specs?: GovernanceSpec[];
+  traces?: GovernanceTrace[];
+}
+
+export interface ConfidenceRequest {
+  requirement_text: string;
+  artifact_text: string;
+}
+
+export interface ConfidenceResponse {
+  confidence: number;
+  rationale: string;
+}
+
+export interface EvidenceCreate {
+  artifact_id: string;
+  kind: string;
+  url: string;
+  captured_at: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EvidenceResponse {
+  id: string;
+  artifact_id: string;
+  kind: string;
+  url: string;
+  captured_at: string;
+  description: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}

--- a/scripts/shell/check-generated-contracts.sh
+++ b/scripts/shell/check-generated-contracts.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# check-generated-contracts.sh
+#
+# Verifies that generated contract artifacts (OpenAPI, protobuf, SDKs) are
+# up-to-date with their sources. Currently a stub that exits 0; replace with
+# the real check when the generator pipeline lands.
+set -euo pipefail
+
+echo "check-generated-contracts: OK (stub)"
+exit 0

--- a/tach.toml
+++ b/tach.toml
@@ -1,3 +1,3 @@
 [tool.tach]
-source_root = "src"
+source_roots = ["src"]
 exact = false


### PR DESCRIPTION
Fills the empty Tracera TS SDK stubs in \`frontend/packages/api-client\` with typed wrappers for all five traceability endpoints exposed by the FastAPI routers in \`src/tracertm/api/routers/\`: