### PR TITLE
fix(ci): silence starlette/httpx deprecation warnings + pure-ASGI middleware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,12 @@ include = [
 ]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning:starlette.*",
+    "ignore::DeprecationWarning:httpx.*",
+    "ignore::DeprecationWarning:fastapi.*",
+    "ignore::PendingDeprecationWarning",
+]
 testpaths = [
     "tests",
 ]

--- a/src/tracertm/api/middleware/request_id.py
+++ b/src/tracertm/api/middleware/request_id.py
@@ -4,15 +4,21 @@ Reads ``X-Request-Id`` from the inbound request (or generates a UUID4),
 stores it in a module-level :class:`contextvars.ContextVar`, and echoes the
 value on the response.  This replaces the removed ``phenotype-request-id``
 PyPI dependency (which was a project-private package unavailable on PyPI).
+
+Implemented as a pure-ASGI middleware to avoid the known limitations of
+``starlette.middleware.base.BaseHTTPMiddleware`` (in particular, the
+disruption of ``contextvars`` propagation when ``BaseHTTPMiddleware`` is
+sits in front of downstream middleware).  This pattern is the
+recommendation from the Starlette docs (see
+https://www.starlette.io/middleware/#pure-asgi-middleware).
 """
 from __future__ import annotations
 
 import uuid
 from contextvars import ContextVar
 
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 #: Holds the current request-ID for the active request context.
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
@@ -20,7 +26,7 @@ request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 HEADER_NAME = "X-Request-ID"
 
 
-class RequestIdMiddleware(BaseHTTPMiddleware):
+class RequestIdMiddleware:
     """Attach a unique request-ID to every request and response.
 
     Parameters
@@ -33,15 +39,30 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
     """
 
     def __init__(self, app: ASGIApp, header_name: str = HEADER_NAME) -> None:
-        super().__init__(app)
+        self.app = app
         self.header_name = header_name
 
-    async def dispatch(self, request: Request, call_next):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Extract or generate the request ID before entering the context.
+        request = Request(scope, receive=receive)
         req_id = request.headers.get(self.header_name) or str(uuid.uuid4())
         token = request_id_var.set(req_id)
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                # Append (do not overwrite) the request-ID header.
+                headers.append(
+                    (self.header_name.lower().encode("latin-1"), req_id.encode("latin-1"))
+                )
+                message = {**message, "headers": headers}
+            await send(message)
+
         try:
-            response = await call_next(request)
+            await self.app(scope, receive, send_wrapper)
         finally:
             request_id_var.reset(token)
-        response.headers[self.header_name] = req_id
-        return response


### PR DESCRIPTION
## **User description**
## Context


___

## **CodeAnt-AI Description**
Keep request IDs working through middleware and hide test deprecation warnings

### What Changed
- Request IDs are now handled in a way that keeps them available to downstream middleware and request handlers
- The request ID response header is still added for every HTTP request, and incoming request IDs are still reused when present
- Non-HTTP traffic is passed through without request-ID handling
- Test runs now ignore known deprecation warnings from Starlette, httpx, FastAPI, and pending deprecations

### Impact
`✅ Fewer lost request IDs in middleware chains`
`✅ Consistent request-ID headers on responses`
`✅ Cleaner test output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
