### PR TITLE
fix(ci): replace ubuntu-24.04 runner pin with ubuntu-latest

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   cargo-deny:
     name: cargo-deny
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/journey-gate.yml
+++ b/.github/workflows/journey-gate.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   journey-verify:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release-plz:
     name: release-plz
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   cargo-hack:
     name: cargo-hack per-crate tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5


### PR DESCRIPTION
## **User description**
Replaces \`runs-on: ubuntu-24.04\` with \`runs-on: ubuntu-latest\` in the four CI workflows that pinned the runner image. The pinned label is rejected by the account's runner pool at dispatch, causing jobs to fail in ~2s with no steps executed and an empty log; the \`ubuntu-latest\` alias is what green sibling repos use.


___

## **CodeAnt-AI Description**
**Use the shared GitHub runner so CI jobs can start successfully**

### What Changed
- The Rust tests, release publishing, dependency checks, and journey validation workflows now run on the shared `ubuntu-latest` runner
- This avoids the pinned runner label that was causing jobs to fail before any steps could run

### Impact
`✅ CI jobs start successfully`
`✅ Fewer immediate workflow failures`
`✅ Faster feedback from repository checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
