### PR TITLE
fix(ci): merge duplicate filterwarnings key (uv --all-groups parse error line 280)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,12 +232,6 @@ include = [
 ]
 
 [tool.pytest.ini_options]
-filterwarnings = [
-    "ignore::DeprecationWarning:starlette.*",
-    "ignore::DeprecationWarning:httpx.*",
-    "ignore::DeprecationWarning:fastapi.*",
-    "ignore::PendingDeprecationWarning",
-]
 testpaths = [
     "tests",
 ]
@@ -281,6 +275,9 @@ filterwarnings = [
     "error",
     "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
     "ignore::DeprecationWarning",
+    "ignore::DeprecationWarning:starlette.*",
+    "ignore::DeprecationWarning:httpx.*",
+    "ignore::DeprecationWarning:fastapi.*",
     "ignore::PendingDeprecationWarning",
     "ignore::pytest.PytestConfigWarning",
     "ignore::pytest.PytestUnraisableExceptionWarning",


### PR DESCRIPTION
## **User description**
The pytest config had two filterwarnings keys in [tool.pytest.ini_options]; uv sync --all-groups (PEP 735) strictly rejects the duplicate, failing dependency install and cascading to all 14 Python checks. Merged into one. Pushed via Contents API (repo .git is bloated and blocks normal git push).


___

## **CodeAnt-AI Description**
**Fix pytest config so Python CI can install and run**

### What Changed
- Merged the duplicate warning settings into one pytest configuration block so the project config is accepted by strict TOML parsing
- Kept the existing warning ignores for Starlette, HTTPX, FastAPI, and pending deprecations in the active test settings
- Prevents dependency setup from failing before the Python checks start

### Impact
`✅ Fewer CI setup failures`
`✅ Reliable Python test runs`
`✅ Cleaner dependency installation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
