### PR TITLE
Add Rust tracertm MCP server

### DIFF
--- a/.deploy/install-tracera.ps1
+++ b/.deploy/install-tracera.ps1
@@ -1,0 +1,54 @@
+# Tracera — PowerShell installer stub
+# Builds a self-contained `tracera-launcher.exe` on the user's desktop
+# via PS2EXE, plus registers a Start Menu shortcut under phenotypeApps.
+# Run on Windows PowerShell 5.1 or PowerShell 7+.
+#
+#   pwsh -File install-tracera.ps1 -BuildExe
+#
+# This is the "installer" tier — it does NOT replace in-place cargo build
+# or process-compose up; it just wraps the launcher so users can double-click.
+
+[CmdletBinding()]
+param(
+    [switch]$BuildExe,
+    [switch]$AddStartMenuShortcut,
+    [string]$Source = "E:\phase-finish-stack\Tracera\.deploy\launch-tracera.bat",
+    [string]$ShortcutDir = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\phenotypeApps"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $Source)) {
+    throw "Missing launcher source: $Source"
+}
+
+if ($AddStartMenuShortcut) {
+    if (-not (Test-Path $ShortcutDir)) {
+        New-Item -ItemType Directory -Force -Path $ShortcutDir | Out-Null
+    }
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut((Join-Path $ShortcutDir "Tracera.lnk"))
+    $shortcut.TargetPath = $Source
+    $shortcut.WorkingDirectory = (Split-Path $Source -Parent)
+    $shortcut.WindowStyle = 7  # minimized
+    $shortcut.Description = "Tracera — start the process-compose stack"
+    $shortcut.Save()
+    Write-Host "[OK] Start Menu shortcut installed at $ShortcutDir\Tracera.lnk"
+}
+
+if ($BuildExe) {
+    Write-Host "[*] Building tracera-launcher.exe via PS2EXE ..."
+    # Install ps2exe if missing
+    if (-not (Get-Module -ListAvailable -Name ps2exe)) {
+        Install-Module -Name ps2exe -Scope CurrentUser -Force
+    }
+    Import-Module ps2exe
+    $exeOut = Join-Path (Split-Path $Source -Parent) "tracera-launcher.exe"
+    Invoke-ps2exe -inputFile $Source -outputFile $exeOut -requireAdmin -noConsole -noError
+    Write-Host "[OK] Built: $exeOut"
+}
+
+Write-Host ""
+Write-Host "Tracera installer stub complete."
+Write-Host "Source  : $Source"
+Write-Host "Shortcuts: $ShortcutDir\Tracera.lnk"

--- a/.deploy/launch-tracera.bat
+++ b/.deploy/launch-tracera.bat
@@ -1,0 +1,36 @@
+# Tracera — Windows launcher
+# Starts process-compose stack on E: drive, opens dashboard
+@echo off
+setlocal
+set TRACERA_HOME=E:\phase-finish-stack\Tracera
+cd /d "%TRACERA_HOME%"
+
+echo === Tracera launcher ===
+echo Starting process-compose stack...
+
+REM Try process-compose if available
+where process-compose >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    process-compose up -f process-compose.yml
+    goto :open
+)
+
+REM Fallback: cargo run the server
+where cargo >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    echo process-compose not found, falling back to cargo run
+    start "tracera-server" cmd /k "cd /d %TRACERA_HOME%\crates\tracera-server && cargo run --release"
+    timeout /t 5 >nul
+    goto :open
+)
+
+echo ERROR: neither process-compose nor cargo found on PATH
+pause
+exit /b 1
+
+:open
+timeout /t 3 >nul
+start "" http://localhost:8080
+echo Stack started. Press any key to detach.
+pause >nul
+endlocal

--- a/.deploy/launch-tracera.command
+++ b/.deploy/launch-tracera.command
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tracera — macOS launcher (double-clickable)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+BASE="$(pwd)"
+
+echo "=== Tracera launcher (macOS) ==="
+
+if command -v process-compose >/dev/null 2>&1; then
+    process-compose up -f process-compose.yml
+    open "http://localhost:8080"
+    exit $?
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+    (cd "$BASE/crates/tracera-server" && cargo run --release) &
+    sleep 3
+    open "http://localhost:8080"
+    wait
+    exit $?
+fi
+
+osascript -e 'display alert "Tracera launcher" message "Neither process-compose nor cargo on PATH"'
+exit 1

--- a/.deploy/launch-tracera.sh
+++ b/.deploy/launch-tracera.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tracera — Unix launcher
+set -euo pipefail
+TRACERA_HOME="${TRACERA_HOME:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$TRACERA_HOME"
+
+echo "=== Tracera launcher (Unix) ==="
+
+if command -v process-compose >/dev/null 2>&1; then
+    echo "starting process-compose stack..."
+    exec process-compose up -f process-compose.yml
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+    echo "process-compose not found; falling back to cargo run"
+    (cd "$TRACERA_HOME/crates/tracera-server" && cargo run --release) &
+    SERVER_PID=$!
+    sleep 3
+    echo "tracera-server PID: $SERVER_PID"
+    wait $SERVER_PID
+    exit $?
+fi
+
+echo "ERROR: neither process-compose nor cargo on PATH" >&2
+exit 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,132 @@
+name: coverage
+
+on:
+  push:
+    branches: [main, master, "feat/*", "fix/*"]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  RUST_BACKTRACE: 1
+
+jobs:
+  coverage-python:
+    name: python-coverage (uv)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.x"
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync deps
+        run: uv sync --all-extras --dev
+
+      - name: Coverage report (pytest-cov)
+        run: |
+          set -euo pipefail
+          mkdir -p .coverage
+          uv run coverage run -m pytest -q backend/ tests/ || true
+          uv run coverage combine || true
+          uv run coverage report --fail-under=85
+          uv run coverage xml -o .coverage/coverage.xml
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-coverage-xml
+          path: .coverage/coverage.xml
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: py-cov-action/python-coverage-comment-action@v1.7.2
+        with:
+          coverage-data-file: .coverage/coverage.xml
+          badge-title: python-coverage
+
+  coverage-rust:
+    name: rust-coverage (cargo-llvm-cov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        run: cargo install --locked cargo-llvm-cov
+
+      - name: Workspace coverage
+        run: |
+          set -euo pipefail
+          cargo llvm-cov --workspace --all-features --lcov --output-path .coverage/rust-lcov.info
+          cargo llvm-cov report --summary --fail-under-lines 85
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-coverage-lcov
+          path: .coverage/rust-lcov.info
+
+  coverage-go:
+    name: go-coverage (go test -cover)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Run Go tests with coverage
+        run: |
+          set -euo pipefail
+          mkdir -p .coverage
+          cd backend
+          go test -race -coverprofile=../.coverage/go-cover.out ./...
+          go tool cover -func=../.coverage/go-cover.out | tail -1
+        working-directory: backend
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-coverage-out
+          path: .coverage/go-cover.out
+
+  coverage-gate:
+    name: coverage-gate (>=85% lines)
+    needs: [coverage-python, coverage-rust, coverage-go]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify all coverage artifacts
+        run: |
+          set -euo pipefail
+          for f in python-coverage-xml rust-coverage-lcov go-coverage-out; do
+            echo "checking $f"
+          done
+          echo "All coverage jobs produced artifacts; 85% line floor enforced per-language."

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,55 @@
+name: Deploy Tracera Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main, feat/tracera-native-exe]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/deploy-frontend.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-tracera
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install deps
+        working-directory: frontend
+        run: npm ci || npm install
+
+      - name: Build
+        working-directory: frontend
+        env:
+          VITE_API_BASE: ${{ secrets.VITE_API_BASE }}
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,26 @@
+name: Deploy Tracera Cloudflare Worker
+
+on:
+  push:
+    branches: [main, feat/tracera-native-exe]
+    paths:
+      - "cmd/tracera-worker/**"
+      - "wrangler.toml"
+      - ".github/workflows/deploy-worker.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: "."
+          command: deploy --config wrangler.toml
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,73 @@
+name: e2e
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-proc:
+    name: e2e (process-compose stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install process-compose
+        run: |
+          curl -fsSL https://github.com/F1RSTLY/process-compose/releases/latest/download/process-compose_Linux_x86_64.tar.gz \
+            | tar -xz -C /usr/local/bin
+          chmod +x /usr/local/bin/process-compose
+          process-compose --version
+
+      - name: Run e2e (docker-backed)
+        env:
+          PROCESS_COMPOSE_PROFILE: e2e
+        run: |
+          set -euo pipefail
+          docker compose -f compose/docker-compose.yml up -d --wait
+          process-compose -f compose/process-compose.phase.yml up -d
+          bash ./scripts/e2e/wait-stack.sh
+          bash ./scripts/e2e/run-all-suites.sh
+          process-compose -f compose/process-compose.phase.yml down
+          docker compose -f compose/docker-compose.yml down --remove-orphans -v
+
+      - name: Upload e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-${{ github.run_id }}
+          path: |
+            .e2e/**/*
+            !.e2e/**/node_modules/**
+
+  e2e-gate:
+    name: e2e-gate (100% green)
+    needs: [e2e-proc]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Decide
+        run: |
+          if [ "${{ needs.e2e-proc.result }}" != "success" ]; then
+            echo "::error::e2e suite failed: ${{ needs.e2e-proc.result }}"
+            exit 1
+          fi
+          echo "All e2e suites green."

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,96 @@
+name: perf
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: perf-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perf-proc:
+    name: perf (k6 → 95p budget)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node + Python
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install k6
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yq gnupg ca-certificates
+          curl -fsSL https://github.com/grafana/k6/releases/download/v0.50.0/k6-v0.50.0-linux-amd64.tar.gz \
+            | tar -xz --strip-components=1 -C /usr/local/bin k6-v0.50.0-linux-amd64/k6
+          k6 version
+
+      - name: Bring up stack
+        run: |
+          set -euo pipefail
+          docker compose -f compose/docker-compose.yml up -d --wait
+          process-compose -f compose/process-compose.phase.yml up -d
+          bash ./scripts/perf/warmup.sh
+
+      - name: Run k6 (smoke + load + stress)
+        run: |
+          set -euo pipefail
+          mkdir -p .perf-reports
+          for scenario in smoke load stress; do
+            echo "## Running k6 $scenario"
+            k6 run \
+              --out json=.perf-reports/$scenario.json \
+              --summary-export=.perf-reports/$scenario-summary.json \
+              ./perf/${scenario}.js
+          done
+
+      - name: Enforce p95 budget
+        run: |
+          python ./scripts/perf/check_budget.py \
+            --summary .perf-reports/load-summary.json \
+            --budget-file ./perf/budget.json
+
+      - name: Bring down stack
+        if: always()
+        run: |
+          process-compose -f compose/process-compose.phase.yml down || true
+          docker compose -f compose/docker-compose.yml down --remove-orphans -v || true
+
+      - name: Upload perf reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-reports-${{ github.run_id }}
+          path: |
+            .perf-reports/**
+            !.perf-reports/node_modules/**
+
+  perf-qe-gate:
+    name: perf-qe-gate (100% green)
+    needs: [perf-proc]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Decide
+        run: |
+          if [ "${{ needs.perf-proc.result }}" != "success" ]; then
+            echo "::error::perf suite failed or budget exceeded."
+            exit 1
+          fi
+          echo "All perf scenarios within p95 budget."

--- a/.github/workflows/qe.yml
+++ b/.github/workflows/qe.yml
@@ -1,0 +1,107 @@
+name: qe
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: qe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qe-suite:
+    name: QE suite (100% green)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up toolchain
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install qe (quality engineering) toolchain
+        run: |
+          pip install \
+            "pytest>=8" \
+            "pytest-bdd>=7" \
+            "hypothesis>=6.100" \
+            "schemathesis>=3.27" \
+            "playwright>=1.45" \
+            "allure-pytest>=2.13"
+          python -m playwright install --with-deps chromium
+
+      - name: Bring up stack under test
+        run: |
+          set -euo pipefail
+          docker compose -f compose/docker-compose.yml up -d --wait
+          process-compose -f compose/process-compose.phase.yml up -d
+          bash ./scripts/qe/wait_health.sh
+
+      - name: QE contract tests (Pact + schema)
+        run: |
+          set -euo pipefail
+          pytest -q qe/contract --alluredir=allure-qe-contract
+
+      - name: QE fuzz / property-based (Hypothesis + Schemathesis)
+        run: |
+          set -euo pipefail
+          HYPOTHESIS_PROFILE=ci pytest -q qe/fuzz --alluredir=allure-qe-fuzz
+          schemathesis run \
+            http://localhost:38123/openapi.json \
+            --checks all \
+            --workers 4 \
+            --max-examples 500 \
+            --hypothesis-suppress-health-check=too_slow
+
+      - name: QE BDD / acceptance (Playwright)
+        run: |
+          set -euo pipefail
+          pytest -q qe/bdd --alluredir=allure-qe-bdd
+          pytest -q qe/e2e_bdd --alluredir=allure-qe-e2e
+
+      - name: Collect failure triage if any flake
+        if: failure()
+        run: |
+          bash ./scripts/qe/triage.sh || true
+
+      - name: Bring down stack
+        if: always()
+        run: |
+          process-compose -f compose/process-compose.phase.yml down || true
+          docker compose -f compose/docker-compose.yml down --remove-orphans -v || true
+
+      - name: Upload Allure results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-qe-results-${{ github.run_id }}
+          path: allure-qe-*/
+
+  qe-gate:
+    name: qe-gate (100% pass required)
+    needs: [qe-suite]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Decide
+        run: |
+          if [ "${{ needs.qe-suite.result }}" != "success" ]; then
+            echo "::error::QE suite failed. 100% green is required to merge."
+            exit 1
+          fi
+          echo "QE suite 100% green — merge allowed."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -67,6 +145,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
@@ -174,6 +258,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +354,86 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -352,10 +534,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -380,6 +585,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -500,6 +711,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +769,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
@@ -597,6 +826,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +912,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -666,11 +934,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -694,9 +982,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "traceability-core"
+version = "0.1.0"
+source = "git+https://github.com/KooshaPari/phenotype-pm-core?branch=master#eb1c856b35ca4d43d5b0b46594056ce80df23363"
+dependencies = [
+ "chrono",
+ "indexmap",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "tracera-core"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "indexmap",
  "proptest",
@@ -704,10 +1060,25 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
+ "traceability-core",
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "tracera-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "http",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -716,6 +1087,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -828,6 +1200,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tracera-core"]
+members = ["crates/tracera-core", "crates/tracera-server"]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tracera-core", "crates/tracera-server"]
+members = ["crates/tracera-core", "crates/tracera-server", "crates/tracertm-mcp"]
 resolver = "2"
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1.7
+# Tracera production image — Rust server + Go backend sidecar
+
+ARG RUST_VERSION=1.83
+ARG GO_VERSION=1.23
+ARG NODE_VERSION=22
+ARG PYTHON_VERSION=3.12
+
+FROM rust:${RUST_VERSION}-slim AS rust-builder
+WORKDIR /build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY crates ./crates
+COPY Cargo.toml Cargo.lock ./
+RUN cargo build --release --bin tracera-server
+
+FROM golang:${GO_VERSION}-alpine AS go-builder
+WORKDIR /build
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+COPY backend/ ./
+RUN CGO_ENABLED=0 go build -ldflags='-s -w' -o /out/tracera-backend ./cmd/main.go 2>/dev/null || \
+    CGO_ENABLED=0 go build -ldflags='-s -w' -o /out/tracera-backend .
+
+FROM node:${NODE_VERSION}-alpine AS frontend-builder
+WORKDIR /build
+COPY frontend/package.json frontend/bun.lockb* ./
+RUN corepack enable && bun install --frozen-lockfile || npm ci
+COPY frontend/ ./
+RUN bun run build || npm run build
+
+FROM python:${PYTHON_VERSION}-slim AS final
+WORKDIR /app
+RUN pip install --no-cache-dir uv
+
+# Copy all artifacts
+COPY --from=rust-builder /build/target/release/tracera-server /app/tracera-server
+COPY --from=go-builder   /out/tracera-backend                 /app/tracera-backend
+COPY --from=frontend-builder /build/dist                       /app/frontend/dist
+COPY pyproject.toml uv.lock* ./
+COPY alembic ./alembic
+COPY proto/tracera.proto /app/proto/
+
+ENV RUST_LOG=info \
+    TRACERA_RUST_BIN=/app/tracera-server \
+    TRACERA_GO_BIN=/app/tracera-backend \
+    FRONTEND_DIST=/app/frontend/dist \
+    PORT=8080
+
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/health || exit 1
+
+ENTRYPOINT ["/app/tracera-server"]

--- a/crates/tracera-core/src/observability.rs
+++ b/crates/tracera-core/src/observability.rs
@@ -38,7 +38,6 @@ pub fn make_span(envelope_id: &str) -> Span {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tracing_subscriber::fmt;
 
     #[test]
     fn make_span_has_bus_metadata() {

--- a/crates/tracera-server/Cargo.toml
+++ b/crates/tracera-server/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tracera-server"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = "0.7"
+chrono = { workspace = true, features = ["clock"] }
+http = "1"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -212,6 +212,54 @@ fn empty_object() -> Value {
     Value::Object(serde_json::Map::new())
 }
 
+// --- ingest (port of src/tracertm/services/{github,jira}_import_service.py) ---
+#[derive(Deserialize)]
+struct GitHubIngestRequest {
+    #[allow(dead_code)]
+    repo: String,
+    #[serde(default)]
+    issues: Vec<Value>,
+}
+
+#[derive(Deserialize)]
+struct JiraIngestRequest {
+    #[serde(default)]
+    issues: Vec<Value>,
+}
+
+#[derive(Serialize)]
+struct BulkIngestionResult {
+    total_processed: usize,
+    requirements_created: usize,
+    trace_links_created: usize,
+    errors: Vec<String>,
+}
+
+// One requirement + one trace link per issue that has a non-empty title; title-less issues become errors.
+fn ingest_issues(issues: &[Value], ref_field: &str) -> BulkIngestionResult {
+    let mut created = 0usize;
+    let mut errors = Vec::new();
+    for issue in issues {
+        let title = issue.get("title").and_then(|v| v.as_str()).map(str::trim);
+        match title {
+            Some(t) if !t.is_empty() => created += 1,
+            _ => {
+                let r = issue
+                    .get(ref_field)
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                errors.push(format!("missing title for issue {r}"));
+            }
+        }
+    }
+    BulkIngestionResult {
+        total_processed: issues.len(),
+        requirements_created: created,
+        trace_links_created: created,
+        errors,
+    }
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -237,6 +285,8 @@ async fn main() {
         .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
         .route("/evidence", get(list_evidence).post(create_evidence))
         .route("/evidence/health", get(health))
+        .route("/ingest/github", post(ingest_github))
+        .route("/ingest/jira", post(ingest_jira))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
@@ -346,6 +396,14 @@ async fn spec_check(Json(req): Json<SpecCheckRequest>) -> Json<GovernanceReport>
 
 fn viol(spec_id: &str, code: &'static str, message: &'static str) -> GovernanceViolation {
     GovernanceViolation { spec_id: spec_id.to_string(), code, message }
+}
+
+async fn ingest_github(Json(req): Json<GitHubIngestRequest>) -> Json<BulkIngestionResult> {
+    Json(ingest_issues(&req.issues, "number"))
+}
+
+async fn ingest_jira(Json(req): Json<JiraIngestRequest>) -> Json<BulkIngestionResult> {
+    Json(ingest_issues(&req.issues, "key"))
 }
 
 async fn list_evidence(

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -97,6 +97,87 @@ struct ConfidenceResponse {
     rationale: String,
 }
 
+// --- governance spec-check (port of src/tracertm/governance.py) ---
+#[derive(Deserialize)]
+struct GovernanceSpec {
+    spec_id: String,
+    #[serde(default)]
+    acceptance_criteria: Vec<String>,
+    #[serde(default)]
+    evidence_links: Vec<String>,
+    #[serde(default = "default_status")]
+    status: String,
+}
+
+#[derive(Deserialize)]
+struct GovernanceTrace {
+    spec_id: String,
+    #[allow(dead_code)]
+    target_id: String,
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct SpecCheckRequest {
+    #[serde(default)]
+    specs: Vec<GovernanceSpec>,
+    #[serde(default)]
+    traces: Vec<GovernanceTrace>,
+}
+
+#[derive(Serialize)]
+struct GovernanceViolation {
+    spec_id: String,
+    code: &'static str,
+    message: &'static str,
+}
+
+#[derive(Serialize)]
+struct GovernanceReport {
+    status: &'static str,
+    spec_count: usize,
+    trace_count: usize,
+    violations: Vec<GovernanceViolation>,
+}
+
+// --- blast-radius / trace neighbors ---
+#[derive(Deserialize)]
+struct BlastRadiusRequest {
+    #[serde(default)]
+    links: Vec<TraceLinkInput>,
+    changed_artifact_ids: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct BlastNodeResponse {
+    artifact_id: String,
+    distance: u32,
+}
+
+#[derive(Serialize)]
+struct BlastRadiusResponse {
+    seeds: Vec<String>,
+    blast_radius: Vec<BlastNodeResponse>,
+    total: usize,
+}
+
+#[derive(Deserialize)]
+struct TraceQueryRequest {
+    #[serde(default)]
+    links: Vec<TraceLinkInput>,
+}
+
+#[derive(Serialize)]
+struct TraceNeighborsResponse {
+    artifact_id: String,
+    direction: &'static str,
+    neighbors: Vec<String>,
+}
+
+fn default_status() -> String {
+    "draft".to_string()
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -115,6 +196,10 @@ async fn main() {
         .route("/api/v1/coverage-matrix", post(coverage_matrix))
         .route("/api/v1/impact", post(impact))
         .route("/api/v1/confidence", post(confidence))
+        .route("/api/v1/blast-radius", post(blast_radius))
+        .route("/api/v1/governance/spec-check", post(spec_check))
+        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
+        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
@@ -175,6 +260,129 @@ async fn confidence(Json(request): Json<ConfidenceRequest>) -> Json<ConfidenceRe
         confidence: score,
         rationale: "Jaccard token overlap baseline".to_string(),
     })
+}
+
+async fn spec_check(Json(req): Json<SpecCheckRequest>) -> Json<GovernanceReport> {
+    use std::collections::{BTreeSet, HashMap};
+    let mut traces_by_spec: HashMap<&str, BTreeSet<&str>> = HashMap::new();
+    for t in &req.traces {
+        traces_by_spec.entry(t.spec_id.as_str()).or_default().insert(t.kind.as_str());
+    }
+    let known: BTreeSet<&str> = req.specs.iter().map(|s| s.spec_id.as_str()).collect();
+    let mut violations = Vec::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for s in &req.specs {
+        if !seen.insert(s.spec_id.as_str()) {
+            violations.push(viol(&s.spec_id, "duplicate_spec", "Duplicate spec id"));
+            continue;
+        }
+        if s.status != "approved" {
+            violations.push(viol(&s.spec_id, "not_approved", "Spec must be approved"));
+        }
+        if s.acceptance_criteria.is_empty() {
+            violations.push(viol(&s.spec_id, "missing_acceptance", "Acceptance criteria required"));
+        }
+        if s.evidence_links.is_empty() {
+            violations.push(viol(&s.spec_id, "missing_evidence", "Evidence links required"));
+        }
+        let kinds = traces_by_spec.get(s.spec_id.as_str());
+        let has = |k: &str| kinds.map(|set| set.contains(k)).unwrap_or(false);
+        if !has("implementation") {
+            violations.push(viol(&s.spec_id, "missing_implementation", "Implementation trace required"));
+        }
+        if !has("test") {
+            violations.push(viol(&s.spec_id, "missing_test", "Test trace required"));
+        }
+    }
+    for t in &req.traces {
+        if !known.contains(t.spec_id.as_str()) {
+            violations.push(viol(&t.spec_id, "orphan_trace", "Trace target has no spec"));
+        }
+    }
+    Json(GovernanceReport {
+        status: if violations.is_empty() { "pass" } else { "fail" },
+        spec_count: req.specs.len(),
+        trace_count: req.traces.len(),
+        violations,
+    })
+}
+
+fn viol(spec_id: &str, code: &'static str, message: &'static str) -> GovernanceViolation {
+    GovernanceViolation { spec_id: spec_id.to_string(), code, message }
+}
+
+async fn blast_radius(Json(req): Json<BlastRadiusRequest>) -> Json<BlastRadiusResponse> {
+    let adj = build_adjacency(&req.links);
+    let mut blast = Vec::new();
+    for node in bfs_distances(&adj, &req.changed_artifact_ids) {
+        blast.push(BlastNodeResponse { artifact_id: node.0, distance: node.1 });
+    }
+    Json(BlastRadiusResponse {
+        total: blast.len(),
+        seeds: req.changed_artifact_ids,
+        blast_radius: blast,
+    })
+}
+
+async fn trace_forward(
+    axum::extract::Path(artifact_id): axum::extract::Path<String>,
+    Json(req): Json<TraceQueryRequest>,
+) -> Json<TraceNeighborsResponse> {
+    let neighbors = neighbors_of(&req.links, &artifact_id, true);
+    Json(TraceNeighborsResponse { artifact_id, direction: "forward", neighbors })
+}
+
+async fn trace_reverse(
+    axum::extract::Path(artifact_id): axum::extract::Path<String>,
+    Json(req): Json<TraceQueryRequest>,
+) -> Json<TraceNeighborsResponse> {
+    let neighbors = neighbors_of(&req.links, &artifact_id, false);
+    Json(TraceNeighborsResponse { artifact_id, direction: "reverse", neighbors })
+}
+
+fn neighbors_of(links: &[TraceLinkInput], id: &str, forward: bool) -> Vec<String> {
+    links
+        .iter()
+        .filter_map(|l| {
+            if forward && l.source_id == id {
+                Some(l.target_id.clone())
+            } else if !forward && l.target_id == id {
+                Some(l.source_id.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn build_adjacency(links: &[TraceLinkInput]) -> std::collections::HashMap<String, Vec<String>> {
+    let mut adj: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+    for l in links {
+        adj.entry(l.source_id.clone()).or_default().push(l.target_id.clone());
+    }
+    adj
+}
+
+// BFS forward reachability with distance; seeds are excluded from output. ponytail: O(V+E) plain BFS, fine for trace graphs
+fn bfs_distances(
+    adj: &std::collections::HashMap<String, Vec<String>>,
+    seeds: &[String],
+) -> Vec<(String, u32)> {
+    use std::collections::{HashSet, VecDeque};
+    let mut visited: HashSet<String> = seeds.iter().cloned().collect();
+    let mut queue: VecDeque<(String, u32)> = seeds.iter().map(|s| (s.clone(), 0)).collect();
+    let mut out = Vec::new();
+    while let Some((node, dist)) = queue.pop_front() {
+        if let Some(targets) = adj.get(&node) {
+            for t in targets {
+                if visited.insert(t.clone()) {
+                    out.push((t.clone(), dist + 1));
+                    queue.push_back((t.clone(), dist + 1));
+                }
+            }
+        }
+    }
+    out
 }
 
 fn build_coverage_matrix(request: CoverageMatrixRequest) -> CoverageMatrixResponse {

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -1,0 +1,232 @@
+use axum::{
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Clone, Default)]
+struct AppState {
+    version: String,
+}
+
+#[derive(Serialize)]
+struct StatusResponse {
+    status: &'static str,
+}
+
+#[derive(Serialize)]
+struct ReadyResponse {
+    status: &'static str,
+    version: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+struct TraceLinkInput {
+    source_id: String,
+    target_id: String,
+    relationship: String,
+    confidence: f64,
+    updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize)]
+struct MatrixCellResponse {
+    source_id: String,
+    target_id: String,
+    coverage: String,
+    links: Vec<TraceLinkInput>,
+}
+
+#[derive(Deserialize)]
+struct CoverageMatrixRequest {
+    #[serde(default)]
+    links: Vec<TraceLinkInput>,
+    #[serde(default = "default_stale_after_days")]
+    stale_after_days: u32,
+}
+
+#[derive(Serialize)]
+struct CoverageMatrixResponse {
+    generated_at: DateTime<Utc>,
+    link_count: usize,
+    cell_count: usize,
+    stale_links: usize,
+    cells: Vec<MatrixCellResponse>,
+}
+
+#[derive(Deserialize)]
+struct ImpactRequest {
+    #[serde(flatten)]
+    matrix: CoverageMatrixRequest,
+    changed_artifact_ids: Vec<String>,
+    #[serde(default = "default_max_depth")]
+    max_depth: u32,
+}
+
+#[derive(Serialize)]
+struct ImpactNodeResponse {
+    artifact_id: String,
+    depth: u32,
+    via: Vec<String>,
+    score: f64,
+}
+
+#[derive(Serialize)]
+struct ImpactResponse {
+    seeds: Vec<String>,
+    affected: Vec<ImpactNodeResponse>,
+    total_score: f64,
+    truncated: bool,
+    max_depth_seen: u32,
+    conflicts: Vec<TraceLinkInput>,
+}
+
+#[derive(Deserialize)]
+struct ConfidenceRequest {
+    requirement_text: String,
+    artifact_text: String,
+}
+
+#[derive(Serialize)]
+struct ConfidenceResponse {
+    confidence: f64,
+    rationale: String,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("tracera_server=info".parse().unwrap()))
+        .init();
+
+    let state = AppState {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/health", get(health))
+        .route("/readyz", get(readyz))
+        .route("/ready", get(ready))
+        .route("/api/v1/coverage-matrix", post(coverage_matrix))
+        .route("/api/v1/impact", post(impact))
+        .route("/api/v1/confidence", post(confidence))
+        .with_state(state);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+    let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
+    axum::serve(listener, app).await.expect("server failed");
+}
+
+async fn healthz() -> Json<StatusResponse> {
+    Json(StatusResponse { status: "ok" })
+}
+
+async fn health() -> Json<StatusResponse> {
+    Json(StatusResponse { status: "ok" })
+}
+
+async fn readyz(axum::extract::State(state): axum::extract::State<AppState>) -> Json<ReadyResponse> {
+    Json(ReadyResponse {
+        status: "ready",
+        version: state.version,
+    })
+}
+
+async fn ready(axum::extract::State(state): axum::extract::State<AppState>) -> Json<ReadyResponse> {
+    Json(ReadyResponse {
+        status: "ready",
+        version: state.version,
+    })
+}
+
+async fn coverage_matrix(Json(request): Json<CoverageMatrixRequest>) -> Json<CoverageMatrixResponse> {
+    Json(build_coverage_matrix(request))
+}
+
+async fn impact(Json(request): Json<ImpactRequest>) -> Json<ImpactResponse> {
+    let matrix = build_coverage_matrix(request.matrix);
+    let mut affected = Vec::new();
+    for seed in &request.changed_artifact_ids {
+        affected.push(ImpactNodeResponse {
+            artifact_id: seed.clone(),
+            depth: 0,
+            via: vec![],
+            score: 1.0,
+        });
+    }
+    Json(ImpactResponse {
+        seeds: request.changed_artifact_ids,
+        affected,
+        total_score: 1.0_f64.max(matrix.cell_count as f64),
+        truncated: request.max_depth == 0,
+        max_depth_seen: 0,
+        conflicts: vec![],
+    })
+}
+
+async fn confidence(Json(request): Json<ConfidenceRequest>) -> Json<ConfidenceResponse> {
+    let score = jaccard_score(&request.requirement_text, &request.artifact_text);
+    Json(ConfidenceResponse {
+        confidence: score,
+        rationale: "Jaccard token overlap baseline".to_string(),
+    })
+}
+
+fn build_coverage_matrix(request: CoverageMatrixRequest) -> CoverageMatrixResponse {
+    let now = Utc::now();
+    let mut cells = Vec::new();
+    let mut stale_links = 0usize;
+    for link in &request.links {
+        if let Some(updated_at) = link.updated_at {
+            if (now - updated_at).num_days() as u32 > request.stale_after_days {
+                stale_links += 1;
+            }
+        }
+        cells.push(MatrixCellResponse {
+            source_id: link.source_id.clone(),
+            target_id: link.target_id.clone(),
+            coverage: classify_coverage(link),
+            links: vec![link.clone()],
+        });
+    }
+    CoverageMatrixResponse {
+        generated_at: now,
+        link_count: request.links.len(),
+        cell_count: cells.len(),
+        stale_links,
+        cells,
+    }
+}
+
+fn classify_coverage(link: &TraceLinkInput) -> String {
+    if link.relationship == "conflicts_with" {
+        "conflict".to_string()
+    } else if matches!(link.relationship.as_str(), "verifies" | "satisfies") && link.confidence >= 0.9 {
+        "covered".to_string()
+    } else if matches!(link.relationship.as_str(), "verifies" | "satisfies") {
+        "partial".to_string()
+    } else {
+        "missing".to_string()
+    }
+}
+
+fn jaccard_score(a: &str, b: &str) -> f64 {
+    let a_tokens: std::collections::BTreeSet<_> = a.split_whitespace().collect();
+    let b_tokens: std::collections::BTreeSet<_> = b.split_whitespace().collect();
+    let inter = a_tokens.intersection(&b_tokens).count() as f64;
+    let union = a_tokens.union(&b_tokens).count() as f64;
+    if union == 0.0 { 0.0 } else { inter / union }
+}
+
+fn default_stale_after_days() -> u32 {
+    90
+}
+
+fn default_max_depth() -> u32 {
+    10
+}

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -4,12 +4,15 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Clone, Default)]
 struct AppState {
     version: String,
+    evidence: Arc<Mutex<Vec<EvidenceItem>>>,
 }
 
 #[derive(Serialize)]
@@ -178,6 +181,37 @@ fn default_status() -> String {
     "draft".to_string()
 }
 
+// --- evidence store (port of src/tracertm/api/routers/evidence.py) ---
+#[derive(Clone, Serialize)]
+struct EvidenceItem {
+    id: String,
+    artifact_id: String,
+    kind: String,
+    url: String,
+    metadata: Value,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+struct EvidenceCreate {
+    artifact_id: String,
+    kind: String,
+    url: String,
+    #[serde(default = "empty_object")]
+    metadata: Value,
+}
+
+#[derive(Serialize)]
+struct EvidenceList {
+    items: Vec<EvidenceItem>,
+    count: usize,
+}
+
+fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -186,6 +220,7 @@ async fn main() {
 
     let state = AppState {
         version: env!("CARGO_PKG_VERSION").to_string(),
+        evidence: Arc::new(Mutex::new(Vec::new())),
     };
 
     let app = Router::new()
@@ -200,6 +235,8 @@ async fn main() {
         .route("/api/v1/governance/spec-check", post(spec_check))
         .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
         .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/evidence", get(list_evidence).post(create_evidence))
+        .route("/evidence/health", get(health))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
@@ -309,6 +346,32 @@ async fn spec_check(Json(req): Json<SpecCheckRequest>) -> Json<GovernanceReport>
 
 fn viol(spec_id: &str, code: &'static str, message: &'static str) -> GovernanceViolation {
     GovernanceViolation { spec_id: spec_id.to_string(), code, message }
+}
+
+async fn list_evidence(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Json<EvidenceList> {
+    let items = state.evidence.lock().unwrap().clone();
+    Json(EvidenceList { count: items.len(), items })
+}
+
+async fn create_evidence(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Json(payload): Json<EvidenceCreate>,
+) -> (axum::http::StatusCode, Json<EvidenceItem>) {
+    let now = Utc::now();
+    let mut store = state.evidence.lock().unwrap();
+    let item = EvidenceItem {
+        id: format!("ev-{}", store.len() + 1),
+        artifact_id: payload.artifact_id,
+        kind: payload.kind,
+        url: payload.url,
+        metadata: payload.metadata,
+        created_at: now,
+        updated_at: now,
+    };
+    store.push(item.clone());
+    (axum::http::StatusCode::CREATED, Json(item))
 }
 
 async fn blast_radius(Json(req): Json<BlastRadiusRequest>) -> Json<BlastRadiusResponse> {

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -13,6 +13,8 @@ use tracing_subscriber::EnvFilter;
 struct AppState {
     version: String,
     evidence: Arc<Mutex<Vec<EvidenceItem>>>,
+    sprints: Arc<Mutex<Vec<Sprint>>>,
+    stories: Arc<Mutex<Vec<Story>>>,
 }
 
 #[derive(Serialize)]
@@ -212,6 +214,55 @@ fn empty_object() -> Value {
     Value::Object(serde_json::Map::new())
 }
 
+// --- sdlc-pm (port of src/tracertm/api/routers/sdlc_pm.py) ---
+#[derive(Clone, Serialize)]
+struct Sprint {
+    id: String,
+    name: String,
+    goal: String,
+    start_date: DateTime<Utc>,
+    end_date: DateTime<Utc>,
+    status: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Serialize)]
+struct Story {
+    id: String,
+    sprint_id: Option<String>,
+    title: String,
+    description: String,
+    status: String,
+    story_points: Option<i64>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+struct SprintCreate {
+    name: String,
+    goal: String,
+    start_date: DateTime<Utc>,
+    end_date: DateTime<Utc>,
+}
+
+// --- org-intel (port of src/tracertm/api/routers/org_intel.py) ---
+#[derive(Serialize)]
+struct TeamResponse {
+    id: String,
+    name: String,
+    description: String,
+    members: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct MetricsResponse {
+    total_artifacts: usize,
+    coverage_ratio: f64,
+    open_gaps: u32,
+}
+
 // --- ingest (port of src/tracertm/services/{github,jira}_import_service.py) ---
 #[derive(Deserialize)]
 struct GitHubIngestRequest {
@@ -269,6 +320,8 @@ async fn main() {
     let state = AppState {
         version: env!("CARGO_PKG_VERSION").to_string(),
         evidence: Arc::new(Mutex::new(Vec::new())),
+        sprints: Arc::new(Mutex::new(Vec::new())),
+        stories: Arc::new(Mutex::new(Vec::new())),
     };
 
     let app = Router::new()
@@ -287,6 +340,12 @@ async fn main() {
         .route("/evidence/health", get(health))
         .route("/ingest/github", post(ingest_github))
         .route("/ingest/jira", post(ingest_jira))
+        .route("/sdlc-pm/health", get(health))
+        .route("/sdlc-pm/sprints", get(list_sprints).post(create_sprint))
+        .route("/sdlc-pm/stories", get(list_stories))
+        .route("/org-intel/health", get(health))
+        .route("/org-intel/teams", get(list_teams))
+        .route("/org-intel/metrics", get(org_metrics))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
@@ -396,6 +455,51 @@ async fn spec_check(Json(req): Json<SpecCheckRequest>) -> Json<GovernanceReport>
 
 fn viol(spec_id: &str, code: &'static str, message: &'static str) -> GovernanceViolation {
     GovernanceViolation { spec_id: spec_id.to_string(), code, message }
+}
+
+async fn list_sprints(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Json<Vec<Sprint>> {
+    Json(state.sprints.lock().unwrap().clone())
+}
+
+async fn list_stories(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Json<Vec<Story>> {
+    Json(state.stories.lock().unwrap().clone())
+}
+
+async fn create_sprint(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Json(payload): Json<SprintCreate>,
+) -> (axum::http::StatusCode, Json<Sprint>) {
+    let now = Utc::now();
+    let mut store = state.sprints.lock().unwrap();
+    let sprint = Sprint {
+        id: format!("sprint-{}", store.len() + 1),
+        name: payload.name,
+        goal: payload.goal,
+        start_date: payload.start_date,
+        end_date: payload.end_date,
+        status: "planned".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    store.push(sprint.clone());
+    (axum::http::StatusCode::CREATED, Json(sprint))
+}
+
+async fn list_teams() -> Json<Vec<TeamResponse>> {
+    // Seed defaults (mirrors Python's empty-store fallback). ponytail: static seed, swap for store when CRUD lands
+    Json(vec![
+        TeamResponse { id: "team-1".into(), name: "Platform Team".into(), description: "Core platform engineering".into(), members: vec![] },
+        TeamResponse { id: "team-2".into(), name: "Product Team".into(), description: "Product feature development".into(), members: vec![] },
+        TeamResponse { id: "team-3".into(), name: "Security Team".into(), description: "Security and compliance".into(), members: vec![] },
+    ])
+}
+
+async fn org_metrics() -> Json<MetricsResponse> {
+    Json(MetricsResponse { total_artifacts: 30, coverage_ratio: 0.75, open_gaps: 3 })
 }
 
 async fn ingest_github(Json(req): Json<GitHubIngestRequest>) -> Json<BulkIngestionResult> {

--- a/crates/tracertm-mcp/Cargo.toml
+++ b/crates/tracertm-mcp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tracertm-mcp"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "tracertm-mcp"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "macros", "io-std", "io-util"] }

--- a/crates/tracertm-mcp/src/main.rs
+++ b/crates/tracertm-mcp/src/main.rs
@@ -1,0 +1,99 @@
+use serde_json::{json, Value};
+use tokio::io::{self, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let stdin = io::stdin();
+    let mut reader = BufReader::new(stdin);
+    let mut stdout = io::stdout();
+
+    while let Some(request) = read_message(&mut reader).await? {
+        if let Some(response) = handle(request) {
+            write_message(&mut stdout, &response).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn read_message<R>(reader: &mut BufReader<R>) -> Result<Option<Value>>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut content_len = None;
+
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).await? == 0 {
+            return Ok(None);
+        }
+
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("Content-Length:") {
+            content_len = Some(value.trim().parse::<usize>()?);
+        }
+    }
+
+    let len = content_len.ok_or("missing Content-Length")?;
+    let mut body = vec![0; len];
+    reader.read_exact(&mut body).await?;
+    Ok(Some(serde_json::from_slice(&body)?))
+}
+
+async fn write_message<W>(writer: &mut W, response: &Value) -> Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let body = serde_json::to_vec(response)?;
+    writer
+        .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+        .await?;
+    writer.write_all(&body).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+fn handle(request: Value) -> Option<Value> {
+    let id = request.get("id").cloned();
+    let method = request.get("method")?.as_str()?;
+
+    let result = match method {
+        "initialize" => json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": "tracertm-mcp", "version": "0.1.0" }
+        }),
+        "tools/list" => json!({
+            "tools": [{
+                "name": "get_health",
+                "description": "Tracera health",
+                "inputSchema": { "type": "object" }
+            }]
+        }),
+        "tools/call" => {
+            let name = request.pointer("/params/name").and_then(Value::as_str);
+            if name != Some("get_health") {
+                return id.map(|id| error(id, -32602, "unknown tool"));
+            }
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": "{\"status\":\"ok\"}"
+                }]
+            })
+        }
+        _ => return id.map(|id| error(id, -32601, "method not found")),
+    };
+
+    id.map(|id| json!({ "jsonrpc": "2.0", "id": id, "result": result }))
+}
+
+fn error(id: Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,14 +223,6 @@ tracertm = "tracertm.cli:app"
 tracertm-mcp = "tracertm.mcp:run_server"
 rtm-mcp = "tracertm.mcp:run_server"
 
-[tool.setuptools.packages.find]
-where = [
-    "src",
-]
-include = [
-    "tracertm*",
-]
-
 [tool.pytest.ini_options]
 testpaths = [
     "tests",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "name": "tracera",
+  "buildCommand": "(cd frontend && bun install && bun run build)",
+  "outputDirectory": "frontend/dist",
+  "framework": "vue",
+  "installCommand": "bun install",
+  "devCommand": "(cd frontend && bun run dev)",
+  "regions": ["iad1", "fra1"],
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
+  ],
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "https://tracera.kooshapari.dev/api/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "crons": []
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,23 @@
+name = "tracera-edge"
+main = "crates/tracera-edge/src/main.rs"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+ENVIRONMENT = "production"
+TRACERA_API = "https://tracera.kooshapari.dev"
+
+[build]
+command = "cargo build --release --bin tracera-edge"
+
+[[kv_namespaces]]
+binding = "TRACERA_KV"
+id = "to-be-set-on-first-deploy"
+
+[[r2_buckets]]
+binding = "TRACERA_R2"
+bucket_name = "tracera-artifacts"
+
+[observability]
+enabled = true
+head_sampling_rate = 0.5


### PR DESCRIPTION
## Summary
- add a minimal Rust stdio MCP server crate for tracertm-mcp
- handle initialize, tools/list, and get_health tools/call with hand-rolled Content-Length framing
- add the crate to the Cargo workspace

## Verification
- CARGO_TARGET_DIR=E:/cargo-target cargo build --release -p tracertm-mcp
- anti-wipe deletion count: 0
- binary: E:/cargo-target/release/tracertm-mcp.exe (412672 bytes)