### PR TITLE
chore: gitignore bloat guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Bloat guard (2026-06-28): electron build binaries + caches that bloated .git
+**/app-builder-bin*/
+**/app-builder*
+node_modules/
+dist/
+.cache/
+target/
+*.pack
+.venv/
+__pycache__/
+.astro/


### PR DESCRIPTION
main had NO .gitignore → electron app-builder-bin (~18MB x arches) + caches bloated .git to 520MB. Adds the guard. Rebased clean (supersedes #670).