### PR TITLE
fix(deploy): wrangler origin -> pheno.studio

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 ENVIRONMENT = "production"
-TRACERA_API = "https://tracera.kooshapari.dev"
+TRACERA_API = "https://tracera.pheno.studio"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
Last deploy-origin fix: wrangler.toml TRACERA_API off dead kooshapari.dev -> pheno.studio (vercel.json already clean on main).