### PR TITLE
feat(deploy): re-derive k8s chart + PWA manifest from #668

### DIFF
--- a/.deploy/install-tracera.ps1
+++ b/.deploy/install-tracera.ps1
@@ -1,0 +1,54 @@
+# Tracera — PowerShell installer stub
+# Builds a self-contained `tracera-launcher.exe` on the user's desktop
+# via PS2EXE, plus registers a Start Menu shortcut under phenotypeApps.
+# Run on Windows PowerShell 5.1 or PowerShell 7+.
+#
+#   pwsh -File install-tracera.ps1 -BuildExe
+#
+# This is the "installer" tier — it does NOT replace in-place cargo build
+# or process-compose up; it just wraps the launcher so users can double-click.
+
+[CmdletBinding()]
+param(
+    [switch]$BuildExe,
+    [switch]$AddStartMenuShortcut,
+    [string]$Source = "E:\phase-finish-stack\Tracera\.deploy\launch-tracera.bat",
+    [string]$ShortcutDir = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\phenotypeApps"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $Source)) {
+    throw "Missing launcher source: $Source"
+}
+
+if ($AddStartMenuShortcut) {
+    if (-not (Test-Path $ShortcutDir)) {
+        New-Item -ItemType Directory -Force -Path $ShortcutDir | Out-Null
+    }
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut((Join-Path $ShortcutDir "Tracera.lnk"))
+    $shortcut.TargetPath = $Source
+    $shortcut.WorkingDirectory = (Split-Path $Source -Parent)
+    $shortcut.WindowStyle = 7  # minimized
+    $shortcut.Description = "Tracera — start the process-compose stack"
+    $shortcut.Save()
+    Write-Host "[OK] Start Menu shortcut installed at $ShortcutDir\Tracera.lnk"
+}
+
+if ($BuildExe) {
+    Write-Host "[*] Building tracera-launcher.exe via PS2EXE ..."
+    # Install ps2exe if missing
+    if (-not (Get-Module -ListAvailable -Name ps2exe)) {
+        Install-Module -Name ps2exe -Scope CurrentUser -Force
+    }
+    Import-Module ps2exe
+    $exeOut = Join-Path (Split-Path $Source -Parent) "tracera-launcher.exe"
+    Invoke-ps2exe -inputFile $Source -outputFile $exeOut -requireAdmin -noConsole -noError
+    Write-Host "[OK] Built: $exeOut"
+}
+
+Write-Host ""
+Write-Host "Tracera installer stub complete."
+Write-Host "Source  : $Source"
+Write-Host "Shortcuts: $ShortcutDir\Tracera.lnk"

--- a/.deploy/launch-tracera.bat
+++ b/.deploy/launch-tracera.bat
@@ -1,0 +1,36 @@
+# Tracera — Windows launcher
+# Starts process-compose stack on E: drive, opens dashboard
+@echo off
+setlocal
+set TRACERA_HOME=E:\phase-finish-stack\Tracera
+cd /d "%TRACERA_HOME%"
+
+echo === Tracera launcher ===
+echo Starting process-compose stack...
+
+REM Try process-compose if available
+where process-compose >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    process-compose up -f process-compose.yml
+    goto :open
+)
+
+REM Fallback: cargo run the server
+where cargo >nul 2>&1
+if %ERRORLEVEL% EQU 0 (
+    echo process-compose not found, falling back to cargo run
+    start "tracera-server" cmd /k "cd /d %TRACERA_HOME%\crates\tracera-server && cargo run --release"
+    timeout /t 5 >nul
+    goto :open
+)
+
+echo ERROR: neither process-compose nor cargo found on PATH
+pause
+exit /b 1
+
+:open
+timeout /t 3 >nul
+start "" http://localhost:8080
+echo Stack started. Press any key to detach.
+pause >nul
+endlocal

--- a/.deploy/launch-tracera.command
+++ b/.deploy/launch-tracera.command
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tracera — macOS launcher (double-clickable)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+BASE="$(pwd)"
+
+echo "=== Tracera launcher (macOS) ==="
+
+if command -v process-compose >/dev/null 2>&1; then
+    process-compose up -f process-compose.yml
+    open "http://localhost:8080"
+    exit $?
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+    (cd "$BASE/crates/tracera-server" && cargo run --release) &
+    sleep 3
+    open "http://localhost:8080"
+    wait
+    exit $?
+fi
+
+osascript -e 'display alert "Tracera launcher" message "Neither process-compose nor cargo on PATH"'
+exit 1

--- a/.deploy/launch-tracera.sh
+++ b/.deploy/launch-tracera.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tracera — Unix launcher
+set -euo pipefail
+TRACERA_HOME="${TRACERA_HOME:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$TRACERA_HOME"
+
+echo "=== Tracera launcher (Unix) ==="
+
+if command -v process-compose >/dev/null 2>&1; then
+    echo "starting process-compose stack..."
+    exec process-compose up -f process-compose.yml
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+    echo "process-compose not found; falling back to cargo run"
+    (cd "$TRACERA_HOME/crates/tracera-server" && cargo run --release) &
+    SERVER_PID=$!
+    sleep 3
+    echo "tracera-server PID: $SERVER_PID"
+    wait $SERVER_PID
+    exit $?
+fi
+
+echo "ERROR: neither process-compose nor cargo on PATH" >&2
+exit 1

--- a/deploy/kubernetes/Chart.yaml
+++ b/deploy/kubernetes/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: tracera
+description: |
+  Tracera - graph-driven task runner (axum server + Go backend + Vue frontend).
+  Helm chart for desktop-as-dedicated-backend-server deployment.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/KooshaPari/Tracera
+sources:
+  - https://github.com/KooshaPari/Tracera
+maintainers:
+  - name: KooshaPari
+    email: kooshapari@gmail.com
+keywords:
+  - tracera
+  - graph
+  - task-runner
+  - axum
+  - desktop-backend
+annotations:
+  category: TaskManagement

--- a/deploy/kubernetes/templates/_helpers.tpl
+++ b/deploy/kubernetes/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{- /*
+Common labels + name expansion.
+Used by every chart resource for consistent labelling.
+*/ -}}
+{{- define "phase-finish-stack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "phase-finish-stack.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "phase-finish-stack.labels" -}}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+app.kubernetes.io/name: {{ include "phase-finish-stack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/deploy/kubernetes/templates/configmap.yaml
+++ b/deploy/kubernetes/templates/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: phase-finish-stack-env
+  labels:
+    app.kubernetes.io/part-of: phase-finish-stack
+data:
+  # Top-level runtime config — same across both repos
+  ENVIRONMENT: "production"
+  TRACE_LOG_LEVEL: "info"
+  AGILE_LOG_LEVEL: "info"
+  RUST_LOG: "info,tracera_server=info"
+  # Inter-service discovery (ClusterDNS names)
+  TRACERA_BACKEND_URL: "http://phase-finish-stack-agile-backend:8080"
+  AGILE_FRONTEND_URL: "http://phase-finish-stack-agile-frontend:3000"
+  REGISTRY_URL: "http://phase-finish-stack-registry:7700"
+  # Feature flags
+  ENABLE_DAG_ORCHESTRATION: "true"
+  ENABLE_OTEL: "true"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://phase-finish-stack-otel-collector:4317"
+
+---
+# Secret placeholders — populate via `kubectl create secret` or ExternalSecret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: phase-finish-stack-secrets
+  labels:
+    app.kubernetes.io/part-of: phase-finish-stack
+type: Opaque
+stringData:
+  TRACE_API_KEY: "REPLACE_ME"
+  CIVIS_PROVIDER_TOKEN: "REPLACE_ME"
+  PHENOTYPE_REGISTRY_TOKEN: "REPLACE_ME"
+  GITHUB_PAT: "REPLACE_ME"
+  POSTGRES_PASSWORD: "REPLACE_ME"
+  NEO4J_PASSWORD: "REPLACE_ME"
+  NATS_TOKEN: "REPLACE_ME"
+  DRAGONFLY_PASSWORD: "REPLACE_ME"
+  MINIO_ROOT_PASSWORD: "REPLACE_ME"

--- a/deploy/kubernetes/templates/pvc.yaml
+++ b/deploy/kubernetes/templates/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "phase-finish-stack.fullname" . }}-data
+  labels:
+    app.kubernetes.io/part-of: phase-finish-stack
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | default "50Gi" }}

--- a/deploy/kubernetes/templates/tracera.yaml
+++ b/deploy/kubernetes/templates/tracera.yaml
@@ -1,0 +1,89 @@
+{{- /*
+Tracera deployment — Rust/axum native server.
+Runs as a single replica unless replicas > 1 in values.yaml.
+*/ -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "phase-finish-stack.fullname" . }}-tracera
+  labels:
+    app.kubernetes.io/name: tracera
+    app.kubernetes.io/part-of: phase-finish-stack
+    app.kubernetes.io/component: backend
+spec:
+  {{- if not .Values.tracera.autoscaling.enabled }}
+  replicas: {{ .Values.tracera.replicaCount | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tracera
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tracera
+        app.kubernetes.io/part-of: phase-finish-stack
+    spec:
+      containers:
+        - name: tracera-server
+          image: "{{ .Values.tracera.image.repository }}:{{ .Values.tracera.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.tracera.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: RUST_LOG
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "phase-finish-stack.fullname" . }}-env
+                  key: RUST_LOG
+            - name: TRACE_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "phase-finish-stack.fullname" . }}-env
+                  key: TRACE_LOG_LEVEL
+            - name: TRACERA_BACKEND_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "phase-finish-stack.fullname" . }}-env
+                  key: TRACERA_BACKEND_URL
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "phase-finish-stack.fullname" . }}-env
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+          envFrom:
+            - secretRef:
+                name: {{ include "phase-finish-stack.fullname" . }}-secrets
+          livenessProbe:
+            httpGet: { path: /health, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /health/ready, port: http }
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.tracera.resources | nindent 12 }}
+      {{- with .Values.tracera.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "phase-finish-stack.fullname" . }}-tracera
+  labels:
+    app.kubernetes.io/name: tracera
+    app.kubernetes.io/part-of: phase-finish-stack
+spec:
+  type: {{ .Values.tracera.service.type | default "ClusterIP" }}
+  ports:
+    - name: http
+      port: {{ .Values.tracera.service.port | default 8080 }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: tracera

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -1,0 +1,81 @@
+# -- Tracera Helm values (default; override per environment) --
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/kooshapari/tracera
+  pullPolicy: IfNotPresent
+  tag: "v0.1.0-native-exe"
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: LoadBalancer
+  port: 38123
+  targetPort: 38123
+  nodePort: 30123
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: tracera.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+persistence:
+  enabled: true
+  size: 10Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+env:
+  - name: TRACERA_PORT
+    value: "38123"
+  - name: RUST_LOG
+    value: "info"
+  - name: DATA_DIR
+    value: /data
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 38123
+  initialDelaySeconds: 10
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 38123
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# Desktop-as-backend-server: bind to host network namespace for low-latency
+hostNetwork: false
+dnsPolicy: ClusterFirst
+
+# Annotations for desktop deployment (single-node kind/k3s clusters)
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "38123"
+  prometheus.io/path: "/metrics"

--- a/workspace/manifest.json
+++ b/workspace/manifest.json
@@ -1,0 +1,75 @@
+{
+  "name": "Tracera — Distributed Trace Workbench",
+  "short_name": "Tracera",
+  "description": "Polyglot trace analysis, telemetry routing, and observability replay. Backend on Rust/axum (tracera-server.exe) + Go + Python; frontend via Vite + Vue 3 + TypeScript.",
+  "id": "/?source=pwa",
+  "scope": "/",
+  "start_url": "/?source=pwa",
+  "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone"],
+  "orientation": "any",
+  "background_color": "#0b1020",
+  "theme_color": "#0b1020",
+  "categories": ["developer", "productivity", "utilities"],
+  "lang": "en-US",
+  "dir": "ltr",
+  "prefer_related_applications": false,
+  "icons": [
+    {
+      "src": "icons/tracera-icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/tracera-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/tracera-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Open Trace Replay",
+      "short_name": "Replay",
+      "url": "/replay?source=pwa",
+      "icons": [{ "src": "icons/tracera-icon-192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "Live Tail",
+      "short_name": "Tail",
+      "url": "/live?source=pwa",
+      "icons": [{ "src": "icons/tracera-icon-192.png", "sizes": "192x192" }]
+    }
+  ],
+  "share_target": {
+    "action": "/ingest",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "files": [
+        { "name": "trace", "accept": ["application/json", "application/octet-stream", ".json", ".ndjson", ".log"] }
+      ]
+    }
+  },
+  "screenshots": [
+    {
+      "src": "screenshots/tracera-home.png",
+      "sizes": "1280x720",
+      "type": "image/png",
+      "form_factor": "wide"
+    },
+    {
+      "src": "screenshots/tracera-home-mobile.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow"
+    }
+  ]
+}

--- a/workspace/sw.js
+++ b/workspace/sw.js
@@ -1,0 +1,88 @@
+/* Tracera PWA service worker
+ * Strategy:
+ *   - HTML navigations:        network-first, fall back to /index.html
+ *   - Built assets (/assets/): stale-while-revalidate
+ *   - GET /v1/*:               network-only (auth-gated, must be fresh)
+ *   - POST/PUT/DELETE:         network-only (never cache)
+ *   - Other GETs:              cache-first then network
+ *
+ * Bump CACHE_VERSION on breaking schema or asset graph changes.
+ */
+const CACHE_VERSION = 'tracera-pwa-v0.1.0-native-exe';
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/icons/tracera-icon-192.png',
+  '/icons/tracera-icon-512.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_VERSION);
+    try { await cache.addAll(CORE_ASSETS); } catch (_) { /* optional assets */ }
+    await self.skipWaiting();
+  })());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((k) => k !== CACHE_VERSION).map((k) => caches.delete(k)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;            // network-only for mutations
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname.startsWith('/v1/')) return; // don't cache auth-gated API
+
+  // Navigations: network-first
+  if (req.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        const fresh = await fetch(req);
+        const cache = await caches.open(CACHE_VERSION);
+        cache.put(req, fresh.clone());
+        return fresh;
+      } catch (_) {
+        const cache = await caches.open(CACHE_VERSION);
+        return (await cache.match(req)) || (await cache.match('/index.html')) || Response.error();
+      }
+    })());
+    return;
+  }
+
+  // Built assets: stale-while-revalidate
+  if (url.pathname.startsWith('/assets/') || /\.(js|mjs|css|woff2?|ttf|svg|png|jpg|webp|avif)$/.test(url.pathname)) {
+    event.respondWith((async () => {
+      const cache = await caches.open(CACHE_VERSION);
+      const cached = await cache.match(req);
+      const network = fetch(req).then((res) => { cache.put(req, res.clone()); return res; }).catch(() => cached);
+      return cached || network;
+    })());
+    return;
+  }
+
+  // Other GET: cache-first then network
+  event.respondWith((async () => {
+    const cache = await caches.open(CACHE_VERSION);
+    const cached = await cache.match(req);
+    if (cached) return cached;
+    try {
+      const res = await fetch(req);
+      if (res.ok) cache.put(req, res.clone());
+      return res;
+    } catch (_) { return Response.error(); }
+  })());
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
+  if (event.data && event.data.type === 'CLEAR_CACHE') {
+    caches.keys().then((keys) => Promise.all(keys.map((k) => caches.delete(k))));
+  }
+});


### PR DESCRIPTION
## Summary

Re-derive valuable deployment infrastructure from closed PR #668 (`phase-finish-stack: deploy workflows + PWA + k8s chart + CF secrets + release pipeline`).

**Re-derived:**
- `deploy/kubernetes/` — Helm chart (Chart.yaml, values.yaml, templates for Deployment/ConfigMap/PVC)
- `workspace/manifest.json` — PWA web app manifest with offline icon strategy, trace replay/tail shortcuts, and file-share target
- `workspace/sw.js` — Service worker (network-first navigations, stale-while-revalidate assets, API bypass)
- `.deploy/` scripts — OS-specific launch helpers (PowerShell, bash, macOS .command, Windows .bat)

**Skipped (conflict/dependency risks):**
- pyproject.toml, Cargo.toml, Cargo.lock (Rust/Python dep management; would conflict with main)
- wrangler.toml, vercel.json, .github/workflows (edge/CI config already on main)
- wrangler.secrets.toml (credentials)
- README.md (doc merge conflict likely)

**Anti-wipe:** 0 files deleted, 12 new files added.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>