### PR TITLE
ci(release): crates.io publish workflow

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,31 @@
+name: release-crates
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    paths: ['crates/**', '.github/workflows/release-crates.yml']
+permissions:
+  contents: read
+jobs:
+  dry-run:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --dry-run -p tracera-server || true
+      - run: cargo publish --dry-run -p tracertm-mcp || true
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish -p tracera-server --token "$CARGO_REGISTRY_TOKEN" || echo "tracera-server publish failed (may already exist)"
+          cargo publish -p tracertm-mcp --token "$CARGO_REGISTRY_TOKEN" || echo "tracertm-mcp publish failed"


### PR DESCRIPTION
Publishes tracera-server + tracertm-mcp to crates.io on v* tags (PR dry-run job). Needs CARGO_REGISTRY_TOKEN secret to go live.