### PR TITLE
ci(release): crates.io publish (tracera-server, tracertm-mcp)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,47 @@
+name: release-crates
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "crates/tracera-server/**"
+      - "crates/tracertm-mcp/**"
+      - ".github/workflows/release-crates.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish tracera-server
+        working-directory: crates/tracera-server
+        run: cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+      - name: Publish tracertm-mcp
+        working-directory: crates/tracertm-mcp
+        run: cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+
+  dry-run:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Dry-run tracera-server
+        working-directory: crates/tracera-server
+        run: cargo publish --dry-run --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+      - name: Dry-run tracertm-mcp
+        working-directory: crates/tracertm-mcp
+        run: cargo publish --dry-run --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"

--- a/crates/tracera-server/Cargo.toml
+++ b/crates/tracera-server/Cargo.toml
@@ -2,7 +2,9 @@
 name = "tracera-server"
 version = "0.1.0"
 edition = "2021"
-publish = false
+description = "Tracera server crate"
+repository = "https://github.com/KooshaPari/Tracera"
+license = "MIT"
 
 [dependencies]
 axum = "0.7"
@@ -13,4 +15,3 @@ serde_json = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
-


### PR DESCRIPTION
Adds crates.io publish metadata and a release workflow for tracera-server and tracertm-mcp.\n\nCARGO_REGISTRY_TOKEN is required for publish and dry-run jobs.