### PR TITLE
[codex] feat(deploy): self-host stack (compose + Caddy + cloudflared tunnel)

### DIFF
--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -5,6 +5,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::env;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use tracing_subscriber::EnvFilter;
@@ -348,7 +349,10 @@ async fn main() {
         .route("/org-intel/metrics", get(org_metrics))
         .with_state(state);
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+    let addr = env::var("TRACERA_BIND_ADDR")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 8080)));
     let listener = tokio::net::TcpListener::bind(addr).await.expect("bind");
     axum::serve(listener, app).await.expect("server failed");
 }

--- a/deploy/selfhost/Caddyfile
+++ b/deploy/selfhost/Caddyfile
@@ -1,65 +1,20 @@
-{$HOSTNAME} {
-	# Security headers
-	header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-	header X-Content-Type-Options "nosniff"
-	header X-Frame-Options "DENY"
-	header X-XSS-Protection "1; mode=block"
-	header Referrer-Policy "strict-origin-when-cross-origin"
-	header Permissions-Policy "geolocation=(), microphone=(), camera=()"
-	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'"
+http://{$TRACERA_PUBLIC_HOSTNAME}, :80 {
+	encode zstd gzip
 
-	# Reverse proxy to tracera-server
-	reverse_proxy {$TRACERA_SERVER} {
-		header_up X-Forwarded-Proto {scheme}
-		header_up X-Forwarded-Host {host}
-		header_up X-Forwarded-Port {port}
-		header_up X-Real-IP {remote_host}
-
-		# Enable WebSocket support
-		header_up Connection "upgrade"
-		header_up Upgrade "websocket"
-	}
-
-	# Optional: WorkOS AuthKit forward_auth integration
-	# Uncomment and configure for centralized authentication
-	#
-	# @protected {
-	#     path /api/* /projects/* /admin*
+	# WorkOS AuthKit middleware would be inserted here before the app proxy.
+	# forward_auth workos-authkit:3000 {
+	# 	uri /api/auth/caddy
+	# 	copy_headers X-WorkOS-User-Id X-WorkOS-Email X-WorkOS-Organization-Id
 	# }
-	#
-	# route @protected {
-	#     forward_auth localhost:9091 {
-	#         uri /auth
-	#         copy_headers Authorization Cookie
-	#         rewrite_uri /auth
-	#     }
-	# }
-	#
-	# This requires a separate authentication sidecar service.
-	# See deploy/selfhost/README.md for setup instructions.
 
-	# Health check endpoint (passthrough to backend)
-	handle /health {
-		reverse_proxy {$TRACERA_SERVER}
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "no-referrer"
+		Permissions-Policy "geolocation=(), microphone=(), camera=()"
+		-Server
 	}
 
-	# Metrics endpoint (optional, can be protected)
-	handle /metrics {
-		reverse_proxy {$TRACERA_SERVER}
-	}
-
-	# Log access
-	log {
-		output stdout
-		format json
-	}
-}
-
-# Localhost alias for development
-localhost:8081 {
-	reverse_proxy {$TRACERA_SERVER} {
-		header_up X-Forwarded-Proto http
-		header_up X-Forwarded-Host localhost
-		header_up X-Forwarded-Port 8081
-	}
+	reverse_proxy tracera-server:8080
 }

--- a/deploy/selfhost/Caddyfile
+++ b/deploy/selfhost/Caddyfile
@@ -1,0 +1,65 @@
+{$HOSTNAME} {
+	# Security headers
+	header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+	header X-Content-Type-Options "nosniff"
+	header X-Frame-Options "DENY"
+	header X-XSS-Protection "1; mode=block"
+	header Referrer-Policy "strict-origin-when-cross-origin"
+	header Permissions-Policy "geolocation=(), microphone=(), camera=()"
+	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'"
+
+	# Reverse proxy to tracera-server
+	reverse_proxy {$TRACERA_SERVER} {
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+		header_up X-Forwarded-Port {port}
+		header_up X-Real-IP {remote_host}
+
+		# Enable WebSocket support
+		header_up Connection "upgrade"
+		header_up Upgrade "websocket"
+	}
+
+	# Optional: WorkOS AuthKit forward_auth integration
+	# Uncomment and configure for centralized authentication
+	#
+	# @protected {
+	#     path /api/* /projects/* /admin*
+	# }
+	#
+	# route @protected {
+	#     forward_auth localhost:9091 {
+	#         uri /auth
+	#         copy_headers Authorization Cookie
+	#         rewrite_uri /auth
+	#     }
+	# }
+	#
+	# This requires a separate authentication sidecar service.
+	# See deploy/selfhost/README.md for setup instructions.
+
+	# Health check endpoint (passthrough to backend)
+	handle /health {
+		reverse_proxy {$TRACERA_SERVER}
+	}
+
+	# Metrics endpoint (optional, can be protected)
+	handle /metrics {
+		reverse_proxy {$TRACERA_SERVER}
+	}
+
+	# Log access
+	log {
+		output stdout
+		format json
+	}
+}
+
+# Localhost alias for development
+localhost:8081 {
+	reverse_proxy {$TRACERA_SERVER} {
+		header_up X-Forwarded-Proto http
+		header_up X-Forwarded-Host localhost
+		header_up X-Forwarded-Port 8081
+	}
+}

--- a/deploy/selfhost/README.md
+++ b/deploy/selfhost/README.md
@@ -1,477 +1,56 @@
-# Tracera Self-Hosted Deployment
+# Tracera self-host stack
 
-Complete Docker Compose stack for self-hosting Tracera with reverse proxy (Caddy) and optional Cloudflare Tunnel support.
+This stack runs Tracera on your desktop, publishes it through Caddy, and exposes it globally with a Cloudflare Tunnel.
 
-## Architecture
+## Layout
 
-```
-┌─────────────┐
-│   Clients   │
-└──────┬──────┘
-       │ HTTPS (80/443)
-       ▼
-┌─────────────────────────────────────┐
-│ Caddy (Reverse Proxy + TLS)         │
-│ - Security headers                  │
-│ - WebSocket support                 │
-│ - Forward auth placeholder          │
-└──────┬──────────────────────────────┘
-       │ HTTP (8080)
-       ▼
-┌─────────────────────────────────────┐
-│ Tracera Server                      │
-│ - REST API                          │
-│ - WebSocket (real-time updates)     │
-│ - Health check endpoint (/health)   │
-└─────────────────────────────────────┘
-       │
-       ▼
-[Database] [External Services]
+- `docker-compose.selfhost.yml`: Tracera server, Caddy, and cloudflared tunnel
+- `Caddyfile`: local reverse proxy plus security headers
+- `README.md`: runbook and environment variables
 
+## Prerequisites
 
-Optional Cloudflare Tunnel (for global ingress):
-┌──────────────────────────┐
-│ Cloudflare Tunnel        │
-│ (cloudflared daemon)     │
-└──────────┬───────────────┘
-           │
-           ▼
-    [Cloudflare Edge]
-```
+- Docker Desktop or a compatible Docker Engine
+- A Cloudflare Tunnel already created for your hostname
+- `cloudflared` tunnel token for that tunnel
+- Optional: Tailscale installed on the desktop for private tailnet access
 
-## Quick Start
+## Environment variables
 
-### 1. Build the Tracera Server Image
+Set these before starting the stack:
 
-Ensure you have a Dockerfile or pre-built image. If building locally:
+- `CF_TUNNEL_TOKEN`: Cloudflare Tunnel token for the named tunnel
+- `TRACERA_PUBLIC_HOSTNAME`: public hostname served by the tunnel, for example `tracera.pheno.studio`
 
-```bash
-cd /path/to/tracera
-docker build -t tracera:latest .
+WorkOS AuthKit is not wired in yet, but these placeholders show where its settings would live:
+
+- `WORKOS_API_KEY`
+- `WORKOS_CLIENT_ID`
+- `WORKOS_COOKIE_SECRET`
+- `WORKOS_REDIRECT_URI`
+- `WORKOS_BASE_URL`
+- Any other `WORKOS_*` values required by your AuthKit middleware
+
+## Run
+
+From the repo root:
+
+```powershell
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml up
 ```
 
-### 2. Create `.env.selfhost` Configuration
+The stack does three things:
 
-Copy this template and fill in your values:
+1. Builds and runs `tracera-server` from the repo on `0.0.0.0:8080`
+2. Lets Caddy reverse proxy `http://tracera.pheno.studio` to `tracera-server:8080`
+3. Attaches cloudflared to the tunnel token so the hostname is reachable globally through Cloudflare
 
-```bash
-cat > .env.selfhost << 'EOF'
-# Reverse proxy hostname (Caddy will listen on this)
-HOSTNAME=tracera.your-domain.com
+## Public and private access
 
-# Database connection string
-# Example: postgresql://user:password@db.example.com:5432/tracera
-DATABASE_URL=
+- Public access: Cloudflare Tunnel exposes the hostname you set in `TRACERA_PUBLIC_HOSTNAME`
+- Private access: Tailscale can reach the same desktop and Caddy listener over the tailnet, so you can keep a private path even if the public tunnel is disabled
 
-# WorkOS authentication (optional but recommended)
-WORKOS_API_KEY=your_workos_api_key
-WORKOS_CLIENT_ID=your_workos_client_id
+## WorkOS AuthKit
 
-# Cloudflare Tunnel token (only if using cloudflared)
-# Leave empty to disable Cloudflare Tunnel
-CF_TUNNEL_TOKEN=
-
-# Optional: Slack, GitHub, or other integrations
-# SLACK_BOT_TOKEN=
-# GITHUB_PAT=
-EOF
-```
-
-**Important:** Never commit `.env.selfhost` to version control. Add to `.gitignore`:
-
-```
-.env.selfhost
-.env.*.local
-```
-
-### 3. Start the Stack
-
-```bash
-# Start all services (Caddy + Tracera)
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml \
-  --env-file .env.selfhost up -d
-
-# Or, include Cloudflare Tunnel:
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml \
-  --env-file .env.selfhost \
-  --profile cloudflare up -d
-```
-
-### 4. Verify Health
-
-```bash
-# Check if all containers are running
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml ps
-
-# View Caddy logs
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml logs -f caddy
-
-# Check Tracera health
-curl https://tracera.your-domain.com/health
-```
-
-### 5. Manage Services
-
-```bash
-# Stop the stack
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml down
-
-# Restart Tracera only
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml restart tracera-server
-
-# View all logs
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml logs -f
-
-# Clean up volumes (WARNING: deletes data!)
-docker compose -f deploy/selfhost/docker-compose.selfhost.yml down -v
-```
-
-## Environment Variables
-
-### Required
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `HOSTNAME` | Domain name for Caddy to listen on | `tracera.pheno.studio` |
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@pg.example.com:5432/tracera` |
-
-### Optional (Authentication)
-
-| Variable | Description | Source |
-|----------|-------------|--------|
-| `WORKOS_API_KEY` | WorkOS API secret key | [WorkOS Dashboard](https://dashboard.workos.com) |
-| `WORKOS_CLIENT_ID` | WorkOS client ID for your deployment | [WorkOS Dashboard](https://dashboard.workos.com) |
-
-### Optional (Integrations)
-
-| Variable | Description |
-|----------|-------------|
-| `SLACK_BOT_TOKEN` | Slack bot token for notifications |
-| `GITHUB_PAT` | GitHub personal access token for sync |
-
-### Cloudflare Tunnel
-
-| Variable | Description |
-|----------|-------------|
-| `CF_TUNNEL_TOKEN` | Cloudflare Tunnel token (leave empty to disable) |
-
-Generate a token:
-
-```bash
-# Install cloudflared CLI
-curl -L https://pkg.cloudflare.com/cloudflare-release-key.gpg | sudo apt-key add -
-sudo apt-get install cloudflared
-
-# Authenticate and create a tunnel
-cloudflared tunnel login
-cloudflared tunnel create tracera
-cloudflared tunnel token tracera
-
-# Copy the token to .env.selfhost
-```
-
-## Networking
-
-### Local Development
-
-For testing without a registered domain:
-
-```bash
-# Use Docker's internal DNS
-curl http://tracera-server:8080/health
-
-# Or localhost via Caddy's secondary listener
-curl http://localhost:8081/
-```
-
-### Private Network (Tailscale)
-
-Tracera is reachable via Tailscale if both client and server are on the same Tailscale network:
-
-1. Install Tailscale on the server running Docker
-2. Add Tailscale IP to `/etc/hosts` or use DNS:
-   ```bash
-   curl https://tracera-server.tailXXXX.ts.net/health
-   ```
-
-3. Clients must be on the same Tailscale network
-
-### Public Access (Cloudflare Tunnel)
-
-With `CF_TUNNEL_TOKEN` set:
-
-1. Tunnel is globally accessible via Cloudflare edge
-2. Your domain is automatically proxied through Cloudflare
-3. No static IP or port forwarding required
-4. Zero-trust policies can be applied in Cloudflare dashboard
-
-## Security
-
-### Caddy Security Headers
-
-The `Caddyfile` enforces:
-
-- **HSTS**: Forces HTTPS for 1 year
-- **X-Content-Type-Options**: Prevents MIME sniffing
-- **X-Frame-Options**: Disables framing (clickjacking protection)
-- **CSP**: Restricts inline scripts and external resources
-- **Permissions-Policy**: Disables geo, mic, camera by default
-
-### TLS Certificates
-
-Caddy automatically provisions Let's Encrypt certificates. To use a custom certificate:
-
-```bash
-docker run -v caddy-config:/config caddy caddy untrust
-# Manual config in Caddyfile:
-# tls /path/to/cert.pem /path/to/key.pem
-```
-
-### Database Security
-
-**Always:**
-
-- Use strong passwords
-- Restrict database access to internal Docker network
-- Enable SSL/TLS for PostgreSQL connections
-- Use read-only database replicas if available
-- Rotate credentials regularly
-
-### API Authentication
-
-**Recommended:**
-
-- Enable WorkOS for human user authentication
-- Use API keys or OAuth for service-to-service calls
-- Rotate API keys monthly
-- Monitor access logs for suspicious activity
-
-## Forward Auth Integration (Optional)
-
-To add centralized authentication with WorkOS AuthKit:
-
-1. **Set up an auth sidecar** (outside this stack):
-
-```yaml
-# In your main docker-compose (NOT in selfhost stack)
-workos-authkit:
-  image: workos-authkit:latest
-  ports:
-    - "9091:9091"
-  environment:
-    WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID}
-    WORKOS_API_KEY: ${WORKOS_API_KEY}
-  networks:
-    - tracera-net
-```
-
-2. **Uncomment the forward_auth block in Caddyfile**:
-
-```caddy
-@protected {
-    path /api/* /projects/* /admin*
-}
-
-route @protected {
-    forward_auth workos-authkit:9091 {
-        uri /auth
-        copy_headers Authorization Cookie
-        rewrite_uri /auth
-    }
-}
-```
-
-3. **Restart Caddy**:
-
-```bash
-docker compose restart caddy
-```
-
-## Troubleshooting
-
-### Caddy won't start
-
-```bash
-# Check Caddyfile syntax
-docker run -v $(pwd)/deploy/selfhost:/etc/caddy caddy caddy validate
-
-# View detailed logs
-docker compose logs caddy
-```
-
-### Tracera server not responding
-
-```bash
-# Check if service is running
-docker compose ps tracera-server
-
-# View server logs
-docker compose logs tracera-server
-
-# Check health endpoint directly
-docker compose exec tracera-server curl http://localhost:8080/health
-```
-
-### Cloudflare Tunnel not connecting
-
-```bash
-# Check tunnel logs
-docker compose logs cloudflared
-
-# Verify CF_TUNNEL_TOKEN is set
-echo $CF_TUNNEL_TOKEN
-
-# List tunnels
-cloudflared tunnel list
-
-# Recreate tunnel token if needed
-cloudflared tunnel token tracera
-```
-
-### Database connection fails
-
-```bash
-# Test PostgreSQL connectivity
-docker compose exec tracera-server psql "$DATABASE_URL" -c "SELECT 1"
-
-# Check DATABASE_URL format
-# Should be: postgresql://user:password@host:5432/database
-```
-
-### Permission denied errors
-
-```bash
-# Ensure Docker daemon permissions
-sudo usermod -aG docker $USER
-newgrp docker
-
-# Or run with sudo
-sudo docker compose up
-```
-
-## Monitoring
-
-### Container Health Status
-
-```bash
-docker compose ps
-
-# STATUS column shows: Up (healthy) or Up (unhealthy)
-```
-
-### Log Aggregation
-
-```bash
-# Tail all services
-docker compose logs -f
-
-# Tail single service
-docker compose logs -f tracera-server
-
-# View last 100 lines
-docker compose logs --tail 100
-
-# Follow with timestamps
-docker compose logs --timestamps -f
-```
-
-### Metrics Endpoint
-
-If Tracera exposes metrics at `/metrics`:
-
-```bash
-curl https://tracera.your-domain.com/metrics
-```
-
-Use Prometheus + Grafana for persistent monitoring:
-
-```yaml
-# Add to docker-compose.selfhost.yml
-prometheus:
-  image: prom/prometheus:latest
-  volumes:
-    - ./prometheus.yml:/etc/prometheus/prometheus.yml
-  ports:
-    - "9090:9090"
-
-grafana:
-  image: grafana/grafana:latest
-  ports:
-    - "3000:3000"
-  environment:
-    GF_SECURITY_ADMIN_PASSWORD: admin
-```
-
-## Backups
-
-### Database Backup
-
-```bash
-# One-off backup
-docker compose exec tracera-db pg_dump -U postgres tracera > backup.sql
-
-# Automated daily backup (via cron or systemd timer)
-0 2 * * * docker compose exec tracera-db pg_dump -U postgres tracera > /backups/tracera-$(date +\%Y\%m\%d).sql
-```
-
-### Volume Backup
-
-```bash
-# Backup Tracera data volume
-docker run --rm -v tracera-data:/data -v $(pwd):/backup \
-  ubuntu tar czf /backup/tracera-data.tar.gz -C /data .
-
-# Restore from backup
-docker run --rm -v tracera-data:/data -v $(pwd):/backup \
-  ubuntu tar xzf /backup/tracera-data.tar.gz -C /data
-```
-
-## Updates
-
-### Update Tracera Server Image
-
-```bash
-# Pull latest image
-docker pull tracera:latest
-
-# Restart service
-docker compose up -d tracera-server
-
-# Verify
-docker compose logs tracera-server
-```
-
-### Update Caddy
-
-```bash
-docker compose pull caddy
-docker compose up -d caddy
-```
-
-## Production Checklist
-
-- [ ] Database backups automated and tested
-- [ ] HTTPS certificates auto-renewing (verify with Caddy logs)
-- [ ] Health checks passing (`/health` endpoint responsive)
-- [ ] Environment variables (.env.selfhost) in `.gitignore`
-- [ ] Secrets not logged or exposed (check container logs)
-- [ ] Rate limiting configured in Caddy or application
-- [ ] Monitoring/alerting set up (logs, metrics, uptime)
-- [ ] Regular security updates (Docker images, OS)
-- [ ] Disaster recovery plan documented
-- [ ] Access logs retained for compliance
-
-## Support
-
-For issues:
-
-1. Check logs: `docker compose logs -f`
-2. Verify configuration: `docker compose config`
-3. Test connectivity: `docker compose exec tracera-server curl http://localhost:8080/health`
-4. Review [Tracera docs](../../docs) and Caddy docs
-
----
-
-**Generated:** 2026-06-29  
-**Version:** 1.0  
-**Status:** Production-ready
+The `Caddyfile` includes a commented `forward_auth` block as the insertion point for WorkOS AuthKit middleware.
+When you are ready to enforce auth, replace the placeholder with the actual upstream service and headers for your AuthKit deployment.

--- a/deploy/selfhost/README.md
+++ b/deploy/selfhost/README.md
@@ -1,0 +1,477 @@
+# Tracera Self-Hosted Deployment
+
+Complete Docker Compose stack for self-hosting Tracera with reverse proxy (Caddy) and optional Cloudflare Tunnel support.
+
+## Architecture
+
+```
+┌─────────────┐
+│   Clients   │
+└──────┬──────┘
+       │ HTTPS (80/443)
+       ▼
+┌─────────────────────────────────────┐
+│ Caddy (Reverse Proxy + TLS)         │
+│ - Security headers                  │
+│ - WebSocket support                 │
+│ - Forward auth placeholder          │
+└──────┬──────────────────────────────┘
+       │ HTTP (8080)
+       ▼
+┌─────────────────────────────────────┐
+│ Tracera Server                      │
+│ - REST API                          │
+│ - WebSocket (real-time updates)     │
+│ - Health check endpoint (/health)   │
+└─────────────────────────────────────┘
+       │
+       ▼
+[Database] [External Services]
+
+
+Optional Cloudflare Tunnel (for global ingress):
+┌──────────────────────────┐
+│ Cloudflare Tunnel        │
+│ (cloudflared daemon)     │
+└──────────┬───────────────┘
+           │
+           ▼
+    [Cloudflare Edge]
+```
+
+## Quick Start
+
+### 1. Build the Tracera Server Image
+
+Ensure you have a Dockerfile or pre-built image. If building locally:
+
+```bash
+cd /path/to/tracera
+docker build -t tracera:latest .
+```
+
+### 2. Create `.env.selfhost` Configuration
+
+Copy this template and fill in your values:
+
+```bash
+cat > .env.selfhost << 'EOF'
+# Reverse proxy hostname (Caddy will listen on this)
+HOSTNAME=tracera.your-domain.com
+
+# Database connection string
+# Example: postgresql://user:password@db.example.com:5432/tracera
+DATABASE_URL=
+
+# WorkOS authentication (optional but recommended)
+WORKOS_API_KEY=your_workos_api_key
+WORKOS_CLIENT_ID=your_workos_client_id
+
+# Cloudflare Tunnel token (only if using cloudflared)
+# Leave empty to disable Cloudflare Tunnel
+CF_TUNNEL_TOKEN=
+
+# Optional: Slack, GitHub, or other integrations
+# SLACK_BOT_TOKEN=
+# GITHUB_PAT=
+EOF
+```
+
+**Important:** Never commit `.env.selfhost` to version control. Add to `.gitignore`:
+
+```
+.env.selfhost
+.env.*.local
+```
+
+### 3. Start the Stack
+
+```bash
+# Start all services (Caddy + Tracera)
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml \
+  --env-file .env.selfhost up -d
+
+# Or, include Cloudflare Tunnel:
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml \
+  --env-file .env.selfhost \
+  --profile cloudflare up -d
+```
+
+### 4. Verify Health
+
+```bash
+# Check if all containers are running
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml ps
+
+# View Caddy logs
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml logs -f caddy
+
+# Check Tracera health
+curl https://tracera.your-domain.com/health
+```
+
+### 5. Manage Services
+
+```bash
+# Stop the stack
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml down
+
+# Restart Tracera only
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml restart tracera-server
+
+# View all logs
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml logs -f
+
+# Clean up volumes (WARNING: deletes data!)
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml down -v
+```
+
+## Environment Variables
+
+### Required
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `HOSTNAME` | Domain name for Caddy to listen on | `tracera.pheno.studio` |
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@pg.example.com:5432/tracera` |
+
+### Optional (Authentication)
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `WORKOS_API_KEY` | WorkOS API secret key | [WorkOS Dashboard](https://dashboard.workos.com) |
+| `WORKOS_CLIENT_ID` | WorkOS client ID for your deployment | [WorkOS Dashboard](https://dashboard.workos.com) |
+
+### Optional (Integrations)
+
+| Variable | Description |
+|----------|-------------|
+| `SLACK_BOT_TOKEN` | Slack bot token for notifications |
+| `GITHUB_PAT` | GitHub personal access token for sync |
+
+### Cloudflare Tunnel
+
+| Variable | Description |
+|----------|-------------|
+| `CF_TUNNEL_TOKEN` | Cloudflare Tunnel token (leave empty to disable) |
+
+Generate a token:
+
+```bash
+# Install cloudflared CLI
+curl -L https://pkg.cloudflare.com/cloudflare-release-key.gpg | sudo apt-key add -
+sudo apt-get install cloudflared
+
+# Authenticate and create a tunnel
+cloudflared tunnel login
+cloudflared tunnel create tracera
+cloudflared tunnel token tracera
+
+# Copy the token to .env.selfhost
+```
+
+## Networking
+
+### Local Development
+
+For testing without a registered domain:
+
+```bash
+# Use Docker's internal DNS
+curl http://tracera-server:8080/health
+
+# Or localhost via Caddy's secondary listener
+curl http://localhost:8081/
+```
+
+### Private Network (Tailscale)
+
+Tracera is reachable via Tailscale if both client and server are on the same Tailscale network:
+
+1. Install Tailscale on the server running Docker
+2. Add Tailscale IP to `/etc/hosts` or use DNS:
+   ```bash
+   curl https://tracera-server.tailXXXX.ts.net/health
+   ```
+
+3. Clients must be on the same Tailscale network
+
+### Public Access (Cloudflare Tunnel)
+
+With `CF_TUNNEL_TOKEN` set:
+
+1. Tunnel is globally accessible via Cloudflare edge
+2. Your domain is automatically proxied through Cloudflare
+3. No static IP or port forwarding required
+4. Zero-trust policies can be applied in Cloudflare dashboard
+
+## Security
+
+### Caddy Security Headers
+
+The `Caddyfile` enforces:
+
+- **HSTS**: Forces HTTPS for 1 year
+- **X-Content-Type-Options**: Prevents MIME sniffing
+- **X-Frame-Options**: Disables framing (clickjacking protection)
+- **CSP**: Restricts inline scripts and external resources
+- **Permissions-Policy**: Disables geo, mic, camera by default
+
+### TLS Certificates
+
+Caddy automatically provisions Let's Encrypt certificates. To use a custom certificate:
+
+```bash
+docker run -v caddy-config:/config caddy caddy untrust
+# Manual config in Caddyfile:
+# tls /path/to/cert.pem /path/to/key.pem
+```
+
+### Database Security
+
+**Always:**
+
+- Use strong passwords
+- Restrict database access to internal Docker network
+- Enable SSL/TLS for PostgreSQL connections
+- Use read-only database replicas if available
+- Rotate credentials regularly
+
+### API Authentication
+
+**Recommended:**
+
+- Enable WorkOS for human user authentication
+- Use API keys or OAuth for service-to-service calls
+- Rotate API keys monthly
+- Monitor access logs for suspicious activity
+
+## Forward Auth Integration (Optional)
+
+To add centralized authentication with WorkOS AuthKit:
+
+1. **Set up an auth sidecar** (outside this stack):
+
+```yaml
+# In your main docker-compose (NOT in selfhost stack)
+workos-authkit:
+  image: workos-authkit:latest
+  ports:
+    - "9091:9091"
+  environment:
+    WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID}
+    WORKOS_API_KEY: ${WORKOS_API_KEY}
+  networks:
+    - tracera-net
+```
+
+2. **Uncomment the forward_auth block in Caddyfile**:
+
+```caddy
+@protected {
+    path /api/* /projects/* /admin*
+}
+
+route @protected {
+    forward_auth workos-authkit:9091 {
+        uri /auth
+        copy_headers Authorization Cookie
+        rewrite_uri /auth
+    }
+}
+```
+
+3. **Restart Caddy**:
+
+```bash
+docker compose restart caddy
+```
+
+## Troubleshooting
+
+### Caddy won't start
+
+```bash
+# Check Caddyfile syntax
+docker run -v $(pwd)/deploy/selfhost:/etc/caddy caddy caddy validate
+
+# View detailed logs
+docker compose logs caddy
+```
+
+### Tracera server not responding
+
+```bash
+# Check if service is running
+docker compose ps tracera-server
+
+# View server logs
+docker compose logs tracera-server
+
+# Check health endpoint directly
+docker compose exec tracera-server curl http://localhost:8080/health
+```
+
+### Cloudflare Tunnel not connecting
+
+```bash
+# Check tunnel logs
+docker compose logs cloudflared
+
+# Verify CF_TUNNEL_TOKEN is set
+echo $CF_TUNNEL_TOKEN
+
+# List tunnels
+cloudflared tunnel list
+
+# Recreate tunnel token if needed
+cloudflared tunnel token tracera
+```
+
+### Database connection fails
+
+```bash
+# Test PostgreSQL connectivity
+docker compose exec tracera-server psql "$DATABASE_URL" -c "SELECT 1"
+
+# Check DATABASE_URL format
+# Should be: postgresql://user:password@host:5432/database
+```
+
+### Permission denied errors
+
+```bash
+# Ensure Docker daemon permissions
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Or run with sudo
+sudo docker compose up
+```
+
+## Monitoring
+
+### Container Health Status
+
+```bash
+docker compose ps
+
+# STATUS column shows: Up (healthy) or Up (unhealthy)
+```
+
+### Log Aggregation
+
+```bash
+# Tail all services
+docker compose logs -f
+
+# Tail single service
+docker compose logs -f tracera-server
+
+# View last 100 lines
+docker compose logs --tail 100
+
+# Follow with timestamps
+docker compose logs --timestamps -f
+```
+
+### Metrics Endpoint
+
+If Tracera exposes metrics at `/metrics`:
+
+```bash
+curl https://tracera.your-domain.com/metrics
+```
+
+Use Prometheus + Grafana for persistent monitoring:
+
+```yaml
+# Add to docker-compose.selfhost.yml
+prometheus:
+  image: prom/prometheus:latest
+  volumes:
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml
+  ports:
+    - "9090:9090"
+
+grafana:
+  image: grafana/grafana:latest
+  ports:
+    - "3000:3000"
+  environment:
+    GF_SECURITY_ADMIN_PASSWORD: admin
+```
+
+## Backups
+
+### Database Backup
+
+```bash
+# One-off backup
+docker compose exec tracera-db pg_dump -U postgres tracera > backup.sql
+
+# Automated daily backup (via cron or systemd timer)
+0 2 * * * docker compose exec tracera-db pg_dump -U postgres tracera > /backups/tracera-$(date +\%Y\%m\%d).sql
+```
+
+### Volume Backup
+
+```bash
+# Backup Tracera data volume
+docker run --rm -v tracera-data:/data -v $(pwd):/backup \
+  ubuntu tar czf /backup/tracera-data.tar.gz -C /data .
+
+# Restore from backup
+docker run --rm -v tracera-data:/data -v $(pwd):/backup \
+  ubuntu tar xzf /backup/tracera-data.tar.gz -C /data
+```
+
+## Updates
+
+### Update Tracera Server Image
+
+```bash
+# Pull latest image
+docker pull tracera:latest
+
+# Restart service
+docker compose up -d tracera-server
+
+# Verify
+docker compose logs tracera-server
+```
+
+### Update Caddy
+
+```bash
+docker compose pull caddy
+docker compose up -d caddy
+```
+
+## Production Checklist
+
+- [ ] Database backups automated and tested
+- [ ] HTTPS certificates auto-renewing (verify with Caddy logs)
+- [ ] Health checks passing (`/health` endpoint responsive)
+- [ ] Environment variables (.env.selfhost) in `.gitignore`
+- [ ] Secrets not logged or exposed (check container logs)
+- [ ] Rate limiting configured in Caddy or application
+- [ ] Monitoring/alerting set up (logs, metrics, uptime)
+- [ ] Regular security updates (Docker images, OS)
+- [ ] Disaster recovery plan documented
+- [ ] Access logs retained for compliance
+
+## Support
+
+For issues:
+
+1. Check logs: `docker compose logs -f`
+2. Verify configuration: `docker compose config`
+3. Test connectivity: `docker compose exec tracera-server curl http://localhost:8080/health`
+4. Review [Tracera docs](../../docs) and Caddy docs
+
+---
+
+**Generated:** 2026-06-29  
+**Version:** 1.0  
+**Status:** Production-ready

--- a/deploy/selfhost/docker-compose.selfhost.yml
+++ b/deploy/selfhost/docker-compose.selfhost.yml
@@ -1,0 +1,81 @@
+version: '3.8'
+
+services:
+  tracera-server:
+    image: tracera:latest
+    container_name: tracera-server
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      # Tracera server configuration
+      PORT: "8080"
+      LOG_LEVEL: "info"
+
+      # Database connection
+      DATABASE_URL: ${DATABASE_URL:-}
+
+      # Authentication (WorkOS)
+      WORKOS_API_KEY: ${WORKOS_API_KEY:-}
+      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID:-}
+
+      # Optional: API keys and service integrations
+      # SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
+      # GITHUB_PAT: ${GITHUB_PAT:-}
+    volumes:
+      - tracera-data:/data
+    networks:
+      - tracera-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  caddy:
+    image: caddy:latest
+    container_name: tracera-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy-data:/data
+      - caddy-config:/config
+    environment:
+      HOSTNAME: ${HOSTNAME:-tracera.pheno.studio}
+      TRACERA_SERVER: tracera-server:8080
+    networks:
+      - tracera-net
+    depends_on:
+      - tracera-server
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: tracera-cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:-}
+    networks:
+      - tracera-net
+    depends_on:
+      - caddy
+    profiles:
+      - cloudflare
+
+volumes:
+  tracera-data:
+  caddy-data:
+  caddy-config:
+
+networks:
+  tracera-net:
+    driver: bridge

--- a/deploy/selfhost/docker-compose.selfhost.yml
+++ b/deploy/selfhost/docker-compose.selfhost.yml
@@ -1,81 +1,48 @@
-version: '3.8'
-
 services:
   tracera-server:
-    image: tracera:latest
-    container_name: tracera-server
-    restart: unless-stopped
-    ports:
-      - "8080:8080"
+    image: rust:1.82-bookworm
+    working_dir: /workspace
+    command: sh -lc "cargo run --release -p tracera-server"
     environment:
-      # Tracera server configuration
-      PORT: "8080"
-      LOG_LEVEL: "info"
-
-      # Database connection
-      DATABASE_URL: ${DATABASE_URL:-}
-
-      # Authentication (WorkOS)
-      WORKOS_API_KEY: ${WORKOS_API_KEY:-}
-      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID:-}
-
-      # Optional: API keys and service integrations
-      # SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
-      # GITHUB_PAT: ${GITHUB_PAT:-}
+      TRACERA_BIND_ADDR: 0.0.0.0:8080
     volumes:
-      - tracera-data:/data
-    networks:
-      - tracera-net
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+      - ../..:/workspace
+      - tracera-cargo-cache:/usr/local/cargo/registry
+      - tracera-target-cache:/workspace/target
+    expose:
+      - "8080"
+    restart: unless-stopped
 
   caddy:
-    image: caddy:latest
-    container_name: tracera-caddy
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy-data:/data
-      - caddy-config:/config
-    environment:
-      HOSTNAME: ${HOSTNAME:-tracera.pheno.studio}
-      TRACERA_SERVER: tracera-server:8080
-    networks:
-      - tracera-net
+    image: caddy:2.8-alpine
     depends_on:
       - tracera-server
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+    environment:
+      TRACERA_PUBLIC_HOSTNAME: ${TRACERA_PUBLIC_HOSTNAME:-tracera.pheno.studio}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    ports:
+      - "80:80"
+    restart: unless-stopped
 
   cloudflared:
     image: cloudflare/cloudflared:latest
-    container_name: tracera-cloudflared
-    restart: unless-stopped
-    command: tunnel --no-autoupdate run
-    environment:
-      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:-}
-    networks:
-      - tracera-net
     depends_on:
       - caddy
-    profiles:
-      - cloudflare
+    command:
+      - tunnel
+      - --no-autoupdate
+      - run
+      - --token
+      - ${CF_TUNNEL_TOKEN:?CF_TUNNEL_TOKEN is required}
+    environment:
+      CF_TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN}
+    restart: unless-stopped
 
 volumes:
-  tracera-data:
   caddy-data:
   caddy-config:
-
-networks:
-  tracera-net:
-    driver: bridge
+  tracera-cargo-cache:
+  tracera-target-cache:


### PR DESCRIPTION
## What changed
- Added a self-host deployment stack under `deploy/selfhost` with Tracera, Caddy, and cloudflared.
- Added a Caddy reverse-proxy config with security headers and a commented WorkOS AuthKit `forward_auth` insertion point.
- Documented required environment variables, the run command, and public/private access paths.
- Added a small server bind override so the app can listen on `0.0.0.0:8080` inside the container.

## Validation
- `python -c "import yaml;yaml.safe_load(open('deploy/selfhost/docker-compose.selfhost.yml'))"`
- `docker compose -f deploy/selfhost/docker-compose.selfhost.yml config`
- `caddy validate --config deploy/selfhost/Caddyfile --adapter caddyfile` via the official Caddy container
