### PR TITLE
Fix: remove non-existent tracera-core from workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tracera-core", "crates/tracera-server", "crates/tracertm-mcp"]
+members = ["crates/tracera-server", "crates/tracertm-mcp", "crates/tracera-edge"]
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
Workspace members list referenced tracera-core crate which no longer exists, causing publish to fail. Removed it and added tracera-edge which is present.