### PR TITLE
feat(frontend): real Vite+React dashboard replacing placeholder

### DIFF
--- a/frontend/apps/web/index.html
+++ b/frontend/apps/web/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tracera - Traceability Platform</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+          'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+          sans-serif;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        background: linear-gradient(135deg, #090a0c 0%, #1a1d2e 100%);
+        color: #ffffff;
+        min-height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "web-app",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/apps/web/src/App.css
+++ b/frontend/apps/web/src/App.css
@@ -1,0 +1,5 @@
+.app {
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--color-midnight) 0%, var(--color-dark-bg) 100%);
+  color: var(--color-text-primary);
+}

--- a/frontend/apps/web/src/App.jsx
+++ b/frontend/apps/web/src/App.jsx
@@ -1,0 +1,13 @@
+import { useState, useEffect } from 'react'
+import './App.css'
+import Dashboard from './components/Dashboard'
+
+function App() {
+  return (
+    <div className="app">
+      <Dashboard />
+    </div>
+  )
+}
+
+export default App

--- a/frontend/apps/web/src/components/Dashboard.css
+++ b/frontend/apps/web/src/components/Dashboard.css
@@ -1,0 +1,340 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--color-midnight) 0%, var(--color-dark-bg) 100%);
+  color: var(--color-text-primary);
+}
+
+.dashboard-header {
+  background: linear-gradient(135deg, var(--color-midnight) 0%, rgba(126, 186, 181, 0.1) 100%);
+  border-bottom: 2px solid var(--color-teal);
+  padding: 3rem 2rem;
+  text-align: center;
+  position: relative;
+}
+
+.header-content h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--color-teal);
+  margin-bottom: 0.5rem;
+  text-shadow: 0 2px 10px rgba(126, 186, 181, 0.3);
+}
+
+.header-content .subtitle {
+  font-size: 1.1rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 1px;
+}
+
+.dashboard-main {
+  flex: 1;
+  padding: 3rem 2rem;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  gap: 2rem;
+}
+
+.spinner {
+  width: 50px;
+  height: 50px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-teal);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-banner {
+  background-color: rgba(239, 68, 68, 0.1);
+  border-left: 4px solid var(--color-error);
+  padding: 1rem 1.5rem;
+  margin-bottom: 2rem;
+  border-radius: 4px;
+  color: #fca5a5;
+}
+
+/* Status Section */
+.status-section {
+  margin-bottom: 3rem;
+}
+
+.status-section h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--color-teal);
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.status-card {
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.status-card:hover {
+  border-color: var(--color-teal);
+  box-shadow: 0 8px 24px rgba(126, 186, 181, 0.15);
+  transform: translateY(-2px);
+}
+
+.status-icon {
+  width: 60px;
+  height: 60px;
+  background: linear-gradient(135deg, var(--color-teal), rgba(126, 186, 181, 0.5));
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.status-info h3 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.status-info p {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.status-ok {
+  color: var(--color-success) !important;
+}
+
+.status-unknown {
+  color: var(--color-warning) !important;
+}
+
+/* Data Sections */
+.data-section {
+  margin-bottom: 3rem;
+}
+
+.data-section h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--color-teal);
+}
+
+.empty-state {
+  background: var(--color-card-bg);
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+  padding: 3rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+/* Teams Grid */
+.teams-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.team-card {
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.team-card:hover {
+  border-color: var(--color-teal);
+  box-shadow: 0 8px 24px rgba(126, 186, 181, 0.15);
+  transform: translateY(-2px);
+}
+
+.team-card h3 {
+  color: var(--color-teal);
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.team-card p {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
+.team-meta {
+  display: flex;
+  gap: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.85rem;
+}
+
+.team-id,
+.team-members {
+  color: var(--color-text-secondary);
+}
+
+/* Sprints List */
+.sprints-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sprint-card {
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.sprint-card:hover {
+  border-color: var(--color-teal);
+  box-shadow: 0 8px 24px rgba(126, 186, 181, 0.15);
+  transform: translateX(4px);
+}
+
+.sprint-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.sprint-header h3 {
+  color: var(--color-teal);
+  font-size: 1.2rem;
+}
+
+.sprint-status {
+  padding: 0.4rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.sprint-status.planned {
+  background: rgba(59, 130, 246, 0.2);
+  color: #60a5fa;
+}
+
+.sprint-status.active {
+  background: rgba(34, 197, 94, 0.2);
+  color: var(--color-success);
+}
+
+.sprint-status.completed {
+  background: rgba(107, 114, 128, 0.2);
+  color: #9ca3af;
+}
+
+.sprint-goal {
+  color: var(--color-text-secondary);
+  margin-bottom: 1rem;
+  font-style: italic;
+}
+
+.sprint-dates {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+/* Info Section */
+.info-section {
+  margin-bottom: 2rem;
+}
+
+.info-section h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--color-teal);
+}
+
+.info-card {
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.info-card p {
+  margin-bottom: 0.5rem;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+}
+
+.info-card strong {
+  color: var(--color-teal);
+}
+
+.api-note {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  font-size: 0.85rem !important;
+  font-style: italic;
+}
+
+/* Footer */
+.dashboard-footer {
+  border-top: 1px solid var(--color-border);
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .dashboard-header {
+    padding: 2rem 1rem;
+  }
+
+  .header-content h1 {
+    font-size: 2rem;
+  }
+
+  .dashboard-main {
+    padding: 1.5rem 1rem;
+  }
+
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .teams-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/apps/web/src/components/Dashboard.jsx
+++ b/frontend/apps/web/src/components/Dashboard.jsx
@@ -1,0 +1,204 @@
+import { useState, useEffect } from 'react'
+import './Dashboard.css'
+
+function Dashboard() {
+  const [health, setHealth] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [sprints, setSprints] = useState([])
+  const [teams, setTeams] = useState([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+
+        const apiBase = import.meta.env.VITE_API_BASE || 'http://localhost:8080'
+
+        // Fetch health status
+        try {
+          const healthRes = await fetch(`${apiBase}/health`)
+          if (healthRes.ok) {
+            const healthData = await healthRes.json()
+            setHealth(healthData)
+          }
+        } catch (err) {
+          console.warn('Health endpoint unavailable:', err.message)
+        }
+
+        // Fetch sprints
+        try {
+          const sprintsRes = await fetch(`${apiBase}/sdlc-pm/sprints`)
+          if (sprintsRes.ok) {
+            const sprintsData = await sprintsRes.json()
+            setSprints(sprintsData || [])
+          }
+        } catch (err) {
+          console.warn('Sprints endpoint unavailable:', err.message)
+        }
+
+        // Fetch teams
+        try {
+          const teamsRes = await fetch(`${apiBase}/org-intel/teams`)
+          if (teamsRes.ok) {
+            const teamsData = await teamsRes.json()
+            setTeams(teamsData || [])
+          }
+        } catch (err) {
+          console.warn('Teams endpoint unavailable:', err.message)
+        }
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+    // Refresh every 30 seconds
+    const interval = setInterval(fetchData, 30000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard-header">
+        <div className="header-content">
+          <h1>Tracera</h1>
+          <p className="subtitle">Traceability & Evidence Platform</p>
+        </div>
+      </header>
+
+      <main className="dashboard-main">
+        <div className="container">
+          {loading && (
+            <div className="loading">
+              <div className="spinner"></div>
+              <p>Loading data...</p>
+            </div>
+          )}
+
+          {error && (
+            <div className="error-banner">
+              <strong>Error:</strong> {error}
+            </div>
+          )}
+
+          {!loading && (
+            <>
+              {/* Status Section */}
+              <section className="status-section">
+                <h2>System Status</h2>
+                <div className="status-grid">
+                  <div className="status-card">
+                    <div className="status-icon">
+                      {health?.status === 'ok' ? '✓' : '?'}
+                    </div>
+                    <div className="status-info">
+                      <h3>Backend Health</h3>
+                      <p className={health?.status === 'ok' ? 'status-ok' : 'status-unknown'}>
+                        {health?.status === 'ok' ? 'Healthy' : 'Checking...'}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="status-card">
+                    <div className="status-icon">{teams.length}</div>
+                    <div className="status-info">
+                      <h3>Teams</h3>
+                      <p>{teams.length} team{teams.length !== 1 ? 's' : ''} registered</p>
+                    </div>
+                  </div>
+
+                  <div className="status-card">
+                    <div className="status-icon">{sprints.length}</div>
+                    <div className="status-info">
+                      <h3>Active Sprints</h3>
+                      <p>{sprints.length} sprint{sprints.length !== 1 ? 's' : ''} configured</p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              {/* Teams Section */}
+              <section className="data-section">
+                <h2>Teams</h2>
+                {teams.length > 0 ? (
+                  <div className="teams-grid">
+                    {teams.map((team) => (
+                      <div key={team.id} className="team-card">
+                        <h3>{team.name}</h3>
+                        <p>{team.description}</p>
+                        <div className="team-meta">
+                          <span className="team-id">{team.id}</span>
+                          <span className="team-members">
+                            {team.members?.length || 0} members
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="empty-state">
+                    <p>No teams configured yet</p>
+                  </div>
+                )}
+              </section>
+
+              {/* Sprints Section */}
+              <section className="data-section">
+                <h2>Sprints</h2>
+                {sprints.length > 0 ? (
+                  <div className="sprints-list">
+                    {sprints.map((sprint) => (
+                      <div key={sprint.id} className="sprint-card">
+                        <div className="sprint-header">
+                          <h3>{sprint.name}</h3>
+                          <span className={`sprint-status ${sprint.status}`}>
+                            {sprint.status}
+                          </span>
+                        </div>
+                        <p className="sprint-goal">{sprint.goal}</p>
+                        <div className="sprint-dates">
+                          <span>
+                            {new Date(sprint.start_date).toLocaleDateString()}
+                            {' '}-{' '}
+                            {new Date(sprint.end_date).toLocaleDateString()}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="empty-state">
+                    <p>No sprints configured yet</p>
+                  </div>
+                )}
+              </section>
+
+              {/* API Info */}
+              <section className="info-section">
+                <h2>API Configuration</h2>
+                <div className="info-card">
+                  <p>
+                    <strong>API Base:</strong> {import.meta.env.VITE_API_BASE || 'http://localhost:8080'}
+                  </p>
+                  <p className="api-note">
+                    Available endpoints: /health, /sdlc-pm/sprints, /org-intel/teams, /api/v1/coverage-matrix
+                  </p>
+                </div>
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+
+      <footer className="dashboard-footer">
+        <p>Tracera © 2024 - Traceability & Governance Platform</p>
+      </footer>
+    </div>
+  )
+}
+
+export default Dashboard

--- a/frontend/apps/web/src/index.css
+++ b/frontend/apps/web/src/index.css
@@ -1,0 +1,38 @@
+:root {
+  --color-teal: #7ebab5;
+  --color-midnight: #090a0c;
+  --color-dark-bg: #1a1d2e;
+  --color-card-bg: #252a3f;
+  --color-border: #3a4156;
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #c0c5d9;
+  --color-success: #4ade80;
+  --color-warning: #facc15;
+  --color-error: #ef4444;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: linear-gradient(135deg, var(--color-midnight) 0%, var(--color-dark-bg) 100%);
+  color: var(--color-text-primary);
+  min-height: 100vh;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/frontend/apps/web/src/main.jsx
+++ b/frontend/apps/web/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/apps/web/vite.config.js
+++ b/frontend/apps/web/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: '../../dist',
+    emptyOutDir: true,
+  },
+  server: {
+    port: 3000,
+  },
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tracera-frontend",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "apps/web"
+  ],
+  "scripts": {
+    "build": "npm run build --prefix apps/web",
+    "build:full": "npm run build --prefix packages/types && npm run build --prefix packages/api-client && npm run build --prefix apps/web",
+    "dev": "npm run dev --prefix apps/web",
+    "typecheck": "npm run typecheck --prefix packages/types && npm run typecheck --prefix packages/api-client"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^6.0.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "vite": "^8.1.3"
+  }
+}


### PR DESCRIPTION
Replace frontend scaffolding with working Vite+React dashboard built locally. Includes:

- Vite configuration with React plugin
- React components (App, Dashboard) with Phenotype design system colors
- Dashboard component with health status, teams, and sprints sections
- Responsive CSS with glassmorphic styling
- API integration endpoints (health, sprints, teams)

Build verified: npm run build produces dist/ successfully.