### PR TITLE
Fix Vercel deployment config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "version": 2,
   "name": "tracera",
-  "outputDirectory": "public",
+  "buildCommand": "cd frontend && npm ci && npm run build",
+  "outputDirectory": "frontend/dist",
   "regions": ["iad1"],
   "headers": [
     {


### PR DESCRIPTION
## Summary
Fixed Vercel deployment configuration to build and serve the real Vite+React app instead of the placeholder.

## Changes
- Added `buildCommand` to run `cd frontend && npm ci && npm run build`
- Changed `outputDirectory` from `public` (static placeholder) to `frontend/dist` (real build output)

## Verification Plan
- [ ] Merge PR
- [ ] Trigger deploy-vercel.yml workflow
- [ ] Verify https://tracera-kappa.vercel.app serves React app (not placeholder)
- [ ] Check browser console for no critical errors

🤖 Generated with Claude Code