### PR TITLE
Fix: use npm install for Vercel build (no lockfile)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,23 @@
 {
   "version": 2,
   "name": "tracera",
-  "buildCommand": "cd frontend && npm ci && npm run build",
+  "buildCommand": "cd frontend && npm install && npm run build",
   "outputDirectory": "frontend/dist",
-  "regions": ["iad1"],
+  "regions": [
+    "iad1"
+  ],
   "headers": [
     {
       "source": "/api/(.*)",
       "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Cache-Control", "value": "no-store" }
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Problem
The previous vercel.json used `npm ci` which requires a package-lock.json, but the frontend workspace doesn't have one. Build fails with:
```
npm error The 'npm ci' command can only install with an existing package-lock.json
```

## Solution
Changed buildCommand to use `npm install` which works without a lockfile.

## Test
- [x] Verified `npm install && npm run build` works locally
- [ ] Deploy workflow will confirm build succeeds on Vercel

🤖 Generated with Claude Code