### PR TITLE
Add: release-dist workflow for cross-platform binaries

### DIFF
--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -1,0 +1,59 @@
+name: release-dist
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/release-dist.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: tracera-server
+          target: x86_64-unknown-linux-gnu,x86_64-pc-windows-gnu,x86_64-apple-darwin,aarch64-apple-darwin
+          tar: unix
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checksum: sha256
+
+  publish-crates:
+    name: Publish crates.io
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish tracera-server
+        working-directory: crates/tracera-server
+        run: cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+      - name: Publish tracertm-mcp
+        working-directory: crates/tracertm-mcp
+        run: cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+
+  dry-run:
+    name: Dry-run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Dry-run tracera-server
+        working-directory: crates/tracera-server
+        run: cargo publish --dry-run --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+      - name: Dry-run tracertm-mcp
+        working-directory: crates/tracertm-mcp
+        run: cargo publish --dry-run --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"


### PR DESCRIPTION
Adds cargo-dist and taiki-e/upload-rust-binary-action for building cross-platform tracera-server binaries (.tar.gz for Unix, .zip for Windows) across x86_64 and aarch64 targets with checksums.