### PR TITLE
Fix: release-dist Windows archive path for gh-release action

### DIFF
--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -50,8 +50,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           mkdir dist
-          cd target/${{ matrix.target }}/release
-          7z a ../../../../dist/${{ matrix.archive }} tracera-server.exe
+          7z a dist/${{ matrix.archive }} target/${{ matrix.target }}/release/tracera-server.exe
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

The Windows archive step was changing directories and using relative paths, which caused `softprops/action-gh-release` to fail finding the file. The action looks for files relative to the repo root.

## Issue

The workflow was running:
\`\`\`bash
cd target/${{ matrix.target }}/release
7z a ../../../../dist/tracera-server-x86_64-windows.zip tracera-server.exe
\`\`\`

When softprops tries to find `dist/tracera-server-x86_64-windows.zip` relative to the repo root, the file exists but it can't locate it because the shell state (working directory) doesn't persist across action steps.

## Fix

Changed to:
\`\`\`bash
7z a dist/${{ matrix.archive }} target/${{ matrix.target }}/release/tracera-server.exe
\`\`\`

This creates the archive at the correct path that softprops can find relative to the repo root.

## Testing

- [x] Previous run showed 7z successfully created the archive
- [x] Issue was only the file path for gh-release action
- [ ] New workflow should successfully upload Windows binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)