### PR TITLE
fix(ci): correct Pages deploy build recursion + dist path

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,17 +32,19 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: cd frontend && bun install
+        run: bun install
+        working-directory: frontend/apps/web
 
       - name: Build frontend
         env:
           VITE_BASE: /Tracera/
-        run: cd frontend && bun run build
+        run: bun run vite build
+        working-directory: frontend/apps/web
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'dist'
+          path: 'frontend/dist'
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

The `deploy-pages.yml` workflow added in #703 merged successfully but the **"Deploy to GitHub Pages" run failed** ([run 28643688547](https://github.com/KooshaPari/Tracera/actions/runs/28643688547)). This PR fixes the two root-cause bugs.

## Root cause

**Bug 1 — infinite build recursion.** The workflow ran `cd frontend && bun run build`, which invokes `frontend/package.json`'s `build` script (`npm run build --prefix apps/web`). Bun rewrites `npm run` → `bun run`, but does **not** resolve `--prefix` the way npm does. So the `apps/web` `build` script re-invoked itself indefinitely:

```
$ bun run build --prefix apps/web
$ bun run build --prefix apps/web --prefix apps/web
$ bun run build --prefix apps/web --prefix apps/web --prefix apps/web
... (forever)
```

The runner crashed before vite ever ran.

**Bug 2 — `dist` path mismatch.** `vite.config.js` sets `outDir: '../../dist'` (relative to `frontend/apps/web/` = `frontend/dist`), but the workflow uploaded `path: 'dist'` (repo-root `dist`), which does not exist:

```
tar: dist: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

## Fix

- Install + build directly in `frontend/apps/web` via `working-directory`, invoking `bun run vite build` (bypasses the recursive npm-script shim entirely).
- Upload `frontend/dist` (the actual build output) instead of repo-root `dist`.

## Verification

Reproduced both failures locally and confirmed the fix:

- ✅ `bun run vite build` in `frontend/apps/web` succeeds, output lands in `frontend/dist`
- ✅ `index.html` references assets as `/Tracera/assets/index-*.js` and `/Tracera/assets/index-*.css` (correct subpath base)
- ✅ No recursion

```diff
       - name: Install dependencies
-        run: cd frontend && bun install
+        run: bun install
+        working-directory: frontend/apps/web

       - name: Build frontend
         env:
           VITE_BASE: /Tracera/
-        run: cd frontend && bun run build
+        run: bun run vite build
+        working-directory: frontend/apps/web

       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'dist'
+          path: 'frontend/dist'
```

## Test plan

- [ ] This PR's `build` job passes (it runs on PRs to main per the workflow trigger)
- [ ] After merge, the `deploy` job publishes to GitHub Pages
- [ ] `https://kooshapari.github.io/Tracera/` loads with no asset 404s