### PR TITLE
feat(server): Store trait + SQLite on-device tier alongside Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/tracera-server/Cargo.toml
+++ b/crates/tracera-server/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { workspace = true, features = ["clock"] }
 http = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { version = "0.9", features = ["postgres", "runtime-tokio", "macros", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = ["postgres", "sqlite", "runtime-tokio", "macros", "uuid", "chrono", "migrate"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/crates/tracera-server/migrations-sqlite/0001_create_evidence.sql
+++ b/crates/tracera-server/migrations-sqlite/0001_create_evidence.sql
@@ -1,0 +1,11 @@
+-- SQLite-dialect evidence table (mirrors PG migration 0001).
+-- JSONB → TEXT (SQLite stores JSON as text), TIMESTAMPTZ → TEXT (ISO-8601).
+CREATE TABLE IF NOT EXISTS evidence (
+    id          TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    url         TEXT NOT NULL,
+    metadata    TEXT NOT NULL DEFAULT '{}',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);

--- a/crates/tracera-server/migrations-sqlite/0002_create_sprints.sql
+++ b/crates/tracera-server/migrations-sqlite/0002_create_sprints.sql
@@ -1,0 +1,11 @@
+-- SQLite-dialect sprints table (mirrors PG migration 0002).
+CREATE TABLE IF NOT EXISTS sprints (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    goal       TEXT NOT NULL DEFAULT '',
+    start_date TEXT NOT NULL,
+    end_date   TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'planned',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);

--- a/crates/tracera-server/migrations-sqlite/0003_create_stories.sql
+++ b/crates/tracera-server/migrations-sqlite/0003_create_stories.sql
@@ -1,0 +1,11 @@
+-- SQLite-dialect stories table (mirrors PG migration 0003).
+CREATE TABLE IF NOT EXISTS stories (
+    id           TEXT    PRIMARY KEY,
+    sprint_id    TEXT,
+    title        TEXT    NOT NULL,
+    description  TEXT    NOT NULL DEFAULT '',
+    status       TEXT    NOT NULL DEFAULT 'open',
+    story_points INTEGER,
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);

--- a/crates/tracera-server/migrations-sqlite/0004_create_teams.sql
+++ b/crates/tracera-server/migrations-sqlite/0004_create_teams.sql
@@ -1,0 +1,15 @@
+-- SQLite-dialect teams table (mirrors PG migration 0004).
+-- TEXT[] (Postgres array) → TEXT (JSON-encoded array in SQLite).
+CREATE TABLE IF NOT EXISTS teams (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    members     TEXT NOT NULL DEFAULT '[]',
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+INSERT OR IGNORE INTO teams (id, name, description) VALUES
+    ('team-1', 'Platform Team',  'Core platform engineering'),
+    ('team-2', 'Product Team',   'Product feature development'),
+    ('team-3', 'Security Team',  'Security and compliance');

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -1,3 +1,7 @@
+mod pg_store;
+mod sqlite_store;
+mod store;
+
 use axum::{
     routing::{get, post},
     Json, Router,
@@ -5,22 +9,27 @@ use axum::{
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::PgPool;
 use std::env;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
+use store::{EvidenceItem, Sprint, Story, Store, TeamRow};
+
 // ---------------------------------------------------------------------------
-// App state — PgPool replaces the in-memory Vec stores dropped in the
-// Python→Rust migration. DATABASE_URL is required; missing/unreachable DB is
-// a hard startup error with an actionable message.
+// App state — Arc<dyn Store> replaces the bare PgPool.
+// DATABASE_URL scheme determines which backend is initialised at startup:
+//   postgres://...   → PgStore  (server/hosted tier, Postgres)
+//   sqlite://...     → SqliteStore (on-device/per-project tier, SQLite)
+//   <path>.db        → SqliteStore (convenience: plain file path)
+// Both are fail-loud on missing/unreachable URL — no silent fallback.
 // ---------------------------------------------------------------------------
 #[derive(Clone)]
 struct AppState {
     version: String,
-    pool: PgPool,
+    store: Arc<dyn Store>,
 }
 
 // ---------------------------------------------------------------------------
@@ -197,19 +206,8 @@ fn default_status() -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Evidence store — restored from src/tracertm/api/routers/evidence.py
+// Evidence HTTP shapes (handlers delegate to store trait)
 // ---------------------------------------------------------------------------
-#[derive(Debug, Clone, Serialize)]
-struct EvidenceItem {
-    id: String,
-    artifact_id: String,
-    kind: String,
-    url: String,
-    metadata: Value,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
 #[derive(Deserialize)]
 struct EvidenceCreate {
     artifact_id: String,
@@ -230,32 +228,8 @@ fn empty_object() -> Value {
 }
 
 // ---------------------------------------------------------------------------
-// SDLC-PM — restored from src/tracertm/api/routers/sdlc_pm.py
+// SDLC-PM HTTP shapes
 // ---------------------------------------------------------------------------
-#[derive(Debug, Clone, Serialize)]
-struct Sprint {
-    id: String,
-    name: String,
-    goal: String,
-    start_date: DateTime<Utc>,
-    end_date: DateTime<Utc>,
-    status: String,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct Story {
-    id: String,
-    sprint_id: Option<String>,
-    title: String,
-    description: String,
-    status: String,
-    story_points: Option<i64>,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
 #[derive(Deserialize)]
 struct SprintCreate {
     name: String,
@@ -265,7 +239,7 @@ struct SprintCreate {
 }
 
 // --- org-intel (port of src/tracertm/api/routers/org_intel.py) ---
-#[derive(Debug, Clone, Serialize)]
+#[derive(Serialize)]
 struct TeamResponse {
     id: String,
     name: String,
@@ -303,8 +277,6 @@ struct BulkIngestionResult {
     errors: Vec<String>,
 }
 
-// One requirement + one trace link per issue that has a non-empty title;
-// title-less issues become errors.
 fn ingest_issues(issues: &[Value], ref_field: &str) -> BulkIngestionResult {
     let mut created = 0usize;
     let mut errors = Vec::new();
@@ -330,7 +302,7 @@ fn ingest_issues(issues: &[Value], ref_field: &str) -> BulkIngestionResult {
 }
 
 // ---------------------------------------------------------------------------
-// Startup
+// Startup — backend selection by DATABASE_URL scheme
 // ---------------------------------------------------------------------------
 #[tokio::main]
 async fn main() {
@@ -341,40 +313,73 @@ async fn main() {
         )
         .init();
 
-    // DATABASE_URL is required. Missing or unreachable DB is a hard error —
-    // no silent in-memory fallback.
     let database_url = env::var("DATABASE_URL").unwrap_or_else(|_| {
         eprintln!(
             "FATAL: DATABASE_URL environment variable is not set.\n\
-             Set it to a Postgres connection string, e.g.:\n\
-             DATABASE_URL=postgres://user:pass@localhost:5432/tracera"
+             Set it to a connection string, e.g.:\n\
+             DATABASE_URL=postgres://user:pass@localhost:5432/tracera\n\
+             DATABASE_URL=sqlite:///path/to/tracera.db\n\
+             DATABASE_URL=sqlite::memory:"
         );
         std::process::exit(1);
     });
 
-    let pool = PgPool::connect(&database_url).await.unwrap_or_else(|e| {
-        eprintln!(
-            "FATAL: Cannot connect to Postgres at the provided DATABASE_URL.\n\
-             Error: {e}\n\
-             Ensure Postgres is running and DATABASE_URL is correct."
-        );
-        std::process::exit(1);
-    });
-
-    // Run pending migrations at startup.
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .unwrap_or_else(|e| {
-            eprintln!("FATAL: Database migration failed: {e}");
+    let store: Arc<dyn Store> = if database_url.starts_with("postgres://")
+        || database_url.starts_with("postgresql://")
+    {
+        info!("Backend: Postgres (server tier)");
+        let pool = sqlx::PgPool::connect(&database_url).await.unwrap_or_else(|e| {
+            eprintln!(
+                "FATAL: Cannot connect to Postgres at the provided DATABASE_URL.\n\
+                 Error: {e}\n\
+                 Ensure Postgres is running and DATABASE_URL is correct."
+            );
             std::process::exit(1);
         });
-
-    info!("Database migrations applied successfully");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("FATAL: Postgres migration failed: {e}");
+                std::process::exit(1);
+            });
+        info!("Postgres migrations applied successfully");
+        Arc::new(pg_store::PgStore::new(pool))
+    } else if database_url.starts_with("sqlite://")
+        || database_url.starts_with("sqlite:")
+        || database_url.ends_with(".db")
+    {
+        info!("Backend: SQLite (on-device tier)");
+        let pool = sqlx::SqlitePool::connect(&database_url)
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!(
+                    "FATAL: Cannot open SQLite database at the provided DATABASE_URL.\n\
+                     Error: {e}\n\
+                     Use DATABASE_URL=sqlite:///path/to/file.db or DATABASE_URL=sqlite::memory:"
+                );
+                std::process::exit(1);
+            });
+        sqlx::migrate!("./migrations-sqlite")
+            .run(&pool)
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("FATAL: SQLite migration failed: {e}");
+                std::process::exit(1);
+            });
+        info!("SQLite migrations applied successfully");
+        Arc::new(sqlite_store::SqliteStore::new(pool))
+    } else {
+        eprintln!(
+            "FATAL: Unrecognised DATABASE_URL scheme.\n\
+             Use postgres:// for Postgres or sqlite:// for SQLite on-device tier."
+        );
+        std::process::exit(1);
+    };
 
     let state = AppState {
         version: env!("CARGO_PKG_VERSION").to_string(),
-        pool,
+        store,
     };
 
     let app = Router::new()
@@ -455,14 +460,12 @@ async fn impact(Json(request): Json<ImpactRequest>) -> Json<ImpactResponse> {
     let links: Vec<TraceLinkInput> = request.matrix.links.clone();
     let adj = build_adjacency(&links);
 
-    // Collect conflicts from the link set
     let conflicts: Vec<TraceLinkInput> = links
         .iter()
         .filter(|l| l.relationship == "conflicts_with")
         .cloned()
         .collect();
 
-    // Seeds are always included at depth=0
     let mut affected: Vec<ImpactNodeResponse> = request
         .changed_artifact_ids
         .iter()
@@ -474,7 +477,6 @@ async fn impact(Json(request): Json<ImpactRequest>) -> Json<ImpactResponse> {
         })
         .collect();
 
-    // BFS over the adjacency graph, clamped to max_depth
     let reachable = bfs_distances(&adj, &request.changed_artifact_ids);
     let mut truncated = false;
     let mut max_depth_seen: u32 = 0;
@@ -487,9 +489,7 @@ async fn impact(Json(request): Json<ImpactRequest>) -> Json<ImpactResponse> {
         if dist > max_depth_seen {
             max_depth_seen = dist;
         }
-        // Confidence-weighted score: decays by depth (halved per hop, floored at 0.1)
         let score = (0.5_f64.powi(dist as i32)).max(0.1);
-        // via: immediate predecessors of this node in the link set
         let via: Vec<String> = links
             .iter()
             .filter(|l| l.target_id == node)
@@ -632,36 +632,15 @@ async fn trace_reverse(
 }
 
 // ---------------------------------------------------------------------------
-// Evidence handlers — backed by `evidence` table
+// Evidence handlers — delegate to store trait
 // ---------------------------------------------------------------------------
 async fn list_evidence(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Json<EvidenceList> {
-    let rows = sqlx::query!(
-        r#"SELECT id, artifact_id, kind, url, metadata, created_at, updated_at
-           FROM evidence
-           ORDER BY created_at ASC"#
-    )
-    .fetch_all(&state.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("list_evidence DB error: {e}");
+    let items = state.store.list_evidence().await.unwrap_or_else(|e| {
+        tracing::error!("list_evidence store error: {e}");
         vec![]
     });
-
-    let items: Vec<EvidenceItem> = rows
-        .into_iter()
-        .map(|r| EvidenceItem {
-            id: r.id,
-            artifact_id: r.artifact_id,
-            kind: r.kind,
-            url: r.url,
-            metadata: r.metadata,
-            created_at: r.created_at,
-            updated_at: r.updated_at,
-        })
-        .collect();
-
     Json(EvidenceList {
         count: items.len(),
         items,
@@ -674,71 +653,31 @@ async fn create_evidence(
 ) -> (axum::http::StatusCode, Json<EvidenceItem>) {
     let now = Utc::now();
     let id = format!("ev-{}", Uuid::new_v4());
-    let meta_str = serde_json::to_value(&payload.metadata)
+    let meta = serde_json::to_value(&payload.metadata)
         .unwrap_or(Value::Object(serde_json::Map::new()));
 
-    sqlx::query!(
-        r#"INSERT INTO evidence (id, artifact_id, kind, url, metadata, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)"#,
-        id,
-        payload.artifact_id,
-        payload.kind,
-        payload.url,
-        meta_str,
-        now,
-        now,
-    )
-    .execute(&state.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("create_evidence DB error: {e}");
-        panic!("create_evidence: DB insert failed: {e}");
-    });
+    let item = state
+        .store
+        .create_evidence(id, payload.artifact_id, payload.kind, payload.url, meta, now)
+        .await
+        .unwrap_or_else(|e| {
+            panic!("create_evidence: store insert failed: {e}");
+        });
 
-    let item = EvidenceItem {
-        id,
-        artifact_id: payload.artifact_id,
-        kind: payload.kind,
-        url: payload.url,
-        metadata: payload.metadata,
-        created_at: now,
-        updated_at: now,
-    };
     (axum::http::StatusCode::CREATED, Json(item))
 }
 
 // ---------------------------------------------------------------------------
-// Sprint handlers — backed by `sprints` table
+// Sprint handlers — delegate to store trait
 // ---------------------------------------------------------------------------
 async fn list_sprints(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Json<Vec<Sprint>> {
-    let rows = sqlx::query!(
-        r#"SELECT id, name, goal, start_date, end_date, status, created_at, updated_at
-           FROM sprints
-           ORDER BY created_at ASC"#
-    )
-    .fetch_all(&state.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("list_sprints DB error: {e}");
+    let sprints = state.store.list_sprints().await.unwrap_or_else(|e| {
+        tracing::error!("list_sprints store error: {e}");
         vec![]
     });
-
-    Json(
-        rows.into_iter()
-            .map(|r| Sprint {
-                id: r.id,
-                name: r.name,
-                goal: r.goal,
-                start_date: r.start_date,
-                end_date: r.end_date,
-                status: r.status,
-                created_at: r.created_at,
-                updated_at: r.updated_at,
-            })
-            .collect(),
-    )
+    Json(sprints)
 }
 
 async fn create_sprint(
@@ -748,89 +687,47 @@ async fn create_sprint(
     let now = Utc::now();
     let id = format!("sprint-{}", Uuid::new_v4());
 
-    sqlx::query!(
-        r#"INSERT INTO sprints (id, name, goal, start_date, end_date, status, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $5, 'planned', $6, $7)"#,
-        id,
-        payload.name,
-        payload.goal,
-        payload.start_date,
-        payload.end_date,
-        now,
-        now,
-    )
-    .execute(&state.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("create_sprint DB error: {e}");
-        panic!("create_sprint: DB insert failed: {e}");
-    });
+    let sprint = state
+        .store
+        .create_sprint(
+            id,
+            payload.name,
+            payload.goal,
+            payload.start_date,
+            payload.end_date,
+            now,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!("create_sprint: store insert failed: {e}");
+        });
 
-    let sprint = Sprint {
-        id,
-        name: payload.name,
-        goal: payload.goal,
-        start_date: payload.start_date,
-        end_date: payload.end_date,
-        status: "planned".to_string(),
-        created_at: now,
-        updated_at: now,
-    };
     (axum::http::StatusCode::CREATED, Json(sprint))
 }
 
 // ---------------------------------------------------------------------------
-// Story handlers — backed by `stories` table
+// Story handlers
 // ---------------------------------------------------------------------------
 async fn list_stories(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Json<Vec<Story>> {
-    let rows = sqlx::query!(
-        r#"SELECT id, sprint_id, title, description, status, story_points, created_at, updated_at
-           FROM stories
-           ORDER BY created_at ASC"#
-    )
-    .fetch_all(&state.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("list_stories DB error: {e}");
+    let stories = state.store.list_stories().await.unwrap_or_else(|e| {
+        tracing::error!("list_stories store error: {e}");
         vec![]
     });
-
-    Json(
-        rows.into_iter()
-            .map(|r| Story {
-                id: r.id,
-                sprint_id: r.sprint_id,
-                title: r.title,
-                description: r.description,
-                status: r.status,
-                story_points: r.story_points,
-                created_at: r.created_at,
-                updated_at: r.updated_at,
-            })
-            .collect(),
-    )
+    Json(stories)
 }
 
 // ---------------------------------------------------------------------------
-// Teams handler — backed by `teams` table (seeded in migration 0004)
+// Teams handler
 // ---------------------------------------------------------------------------
 async fn list_teams(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Json<Vec<TeamResponse>> {
-    let rows = sqlx::query!(
-        r#"SELECT id, name, description, members
-           FROM teams
-           ORDER BY id ASC"#
-    )
-    .fetch_all(&state.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::error!("list_teams DB error: {e}");
+    let rows: Vec<TeamRow> = state.store.list_teams().await.unwrap_or_else(|e| {
+        tracing::error!("list_teams store error: {e}");
         vec![]
     });
-
     Json(
         rows.into_iter()
             .map(|r| TeamResponse {
@@ -844,16 +741,12 @@ async fn list_teams(
 }
 
 // ---------------------------------------------------------------------------
-// Org metrics — kept as live DB count for total_artifacts from evidence table
+// Org metrics
 // ---------------------------------------------------------------------------
 async fn org_metrics(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Json<MetricsResponse> {
-    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM evidence")
-        .fetch_one(&state.pool)
-        .await
-        .unwrap_or(0);
-
+    let count = state.store.count_evidence().await.unwrap_or(0);
     Json(MetricsResponse {
         total_artifacts: count as usize,
         coverage_ratio: 0.75,
@@ -862,7 +755,7 @@ async fn org_metrics(
 }
 
 // ---------------------------------------------------------------------------
-// Ingest handlers (no persistence — returns ingestion summary)
+// Ingest handlers (no persistence)
 // ---------------------------------------------------------------------------
 async fn ingest_github(Json(req): Json<GitHubIngestRequest>) -> Json<BulkIngestionResult> {
     Json(ingest_issues(&req.issues, "number"))
@@ -873,7 +766,7 @@ async fn ingest_jira(Json(req): Json<JiraIngestRequest>) -> Json<BulkIngestionRe
 }
 
 // ---------------------------------------------------------------------------
-// Pure-function utilities (no DB interaction — unit-testable without a pool)
+// Pure-function utilities (no DB interaction — unit-testable without a store)
 // ---------------------------------------------------------------------------
 fn neighbors_of(links: &[TraceLinkInput], id: &str, forward: bool) -> Vec<String> {
     links
@@ -900,7 +793,6 @@ fn build_adjacency(links: &[TraceLinkInput]) -> std::collections::HashMap<String
     adj
 }
 
-// BFS forward reachability with distance; seeds are excluded from output.
 fn bfs_distances(
     adj: &std::collections::HashMap<String, Vec<String>>,
     seeds: &[String],
@@ -983,7 +875,8 @@ fn default_max_depth() -> u32 {
 }
 
 // ---------------------------------------------------------------------------
-// Unit tests — no live DB required
+// Unit tests — no live DB required for pure-function tests.
+// SQLite in-memory round-trip tests prove on-device tier works standalone.
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod tests {
@@ -994,8 +887,6 @@ mod tests {
     // Impact traversal tests (from PR #706 — impact handler fix)
     // -----------------------------------------------------------------------
 
-    /// Build a minimal link list representing the chain:
-    ///   seed -> hop1 -> hop2 -> hop3
     fn chain_links() -> Vec<TraceLinkInput> {
         vec![
             TraceLinkInput {
@@ -1022,7 +913,6 @@ mod tests {
         ]
     }
 
-    /// Helper: run the BFS+depth-clamp logic the same way the handler does.
     fn run_impact(links: Vec<TraceLinkInput>, seeds: Vec<String>, max_depth: u32) -> ImpactResponse {
         let adj = build_adjacency(&links);
         let reachable = bfs_distances(&adj, &seeds);
@@ -1084,8 +974,6 @@ mod tests {
         resp.affected.iter().map(|n| n.artifact_id.as_str()).collect()
     }
 
-    /// Regression test for the stub: verifies that the impact handler now walks
-    /// the adjacency graph transitively, not just returning seeds.
     #[test]
     fn impact_traverses_multi_hop_at_depth_3() {
         let links = chain_links();
@@ -1093,19 +981,14 @@ mod tests {
         let resp = run_impact(links, seeds, 3);
 
         let ids = affected_ids(&resp);
-        // seed is always present at depth=0
         assert!(ids.contains(&"seed"), "seed must be in affected");
-        // 1-hop node
         assert!(ids.contains(&"hop1"), "hop1 (depth 1) must be in affected at max_depth=3");
-        // 2-hop node
         assert!(ids.contains(&"hop2"), "hop2 (depth 2) must be in affected at max_depth=3");
-        // 3-hop node — this was NOT returned by the stub (only seeds were returned)
         assert!(ids.contains(&"hop3"), "hop3 (depth 3) must be in affected at max_depth=3");
         assert!(!resp.truncated, "no truncation expected at max_depth=3 for a 3-hop chain");
         assert_eq!(resp.max_depth_seen, 3);
     }
 
-    /// Depth=1 bound must exclude the 2-hop (and deeper) nodes.
     #[test]
     fn impact_depth_1_excludes_2_hop_node() {
         let links = chain_links();
@@ -1121,7 +1004,6 @@ mod tests {
         assert_eq!(resp.max_depth_seen, 1);
     }
 
-    /// Depth=0 returns only seeds with truncated=true if graph has further edges.
     #[test]
     fn impact_depth_0_returns_only_seeds() {
         let links = chain_links();
@@ -1134,7 +1016,6 @@ mod tests {
         assert_eq!(resp.max_depth_seen, 0);
     }
 
-    /// bfs_distances itself: smoke test on adjacency
     #[test]
     fn bfs_distances_basic() {
         let links = chain_links();
@@ -1160,7 +1041,6 @@ mod tests {
         }
     }
 
-    // --- jaccard_score ---
     #[test]
     fn jaccard_identical() {
         assert!((jaccard_score("a b c", "a b c") - 1.0).abs() < 1e-9);
@@ -1173,7 +1053,6 @@ mod tests {
 
     #[test]
     fn jaccard_partial_overlap() {
-        // inter={b}, union={a,b,c} => 1/3
         let score = jaccard_score("a b", "b c");
         assert!((score - 1.0 / 3.0).abs() < 1e-9);
     }
@@ -1183,7 +1062,6 @@ mod tests {
         assert!((jaccard_score("", "") - 0.0).abs() < 1e-9);
     }
 
-    // --- classify_coverage ---
     #[test]
     fn coverage_conflict() {
         let link = make_link("a", "b", "conflicts_with", 0.5);
@@ -1208,7 +1086,6 @@ mod tests {
         assert_eq!(classify_coverage(&link), "missing");
     }
 
-    // --- neighbors_of ---
     #[test]
     fn neighbors_forward() {
         let links = vec![
@@ -1232,10 +1109,8 @@ mod tests {
         assert_eq!(ns, vec!["req-1", "req-2"]);
     }
 
-    // --- bfs_distances ---
     #[test]
     fn bfs_linear_chain() {
-        // a→b→c, seed=[a], expect b@1, c@2
         let mut adj = std::collections::HashMap::new();
         adj.insert("a".to_string(), vec!["b".to_string()]);
         adj.insert("b".to_string(), vec!["c".to_string()]);
@@ -1243,7 +1118,7 @@ mod tests {
         let map: std::collections::HashMap<_, _> = result.into_iter().collect();
         assert_eq!(map["b"], 1);
         assert_eq!(map["c"], 2);
-        assert!(!map.contains_key("a")); // seeds excluded
+        assert!(!map.contains_key("a"));
     }
 
     #[test]
@@ -1253,7 +1128,6 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    // --- ingest_issues ---
     #[test]
     fn ingest_all_valid() {
         let issues = vec![
@@ -1279,7 +1153,6 @@ mod tests {
         assert_eq!(r.errors.len(), 2);
     }
 
-    // --- build_coverage_matrix stale detection ---
     #[test]
     fn coverage_matrix_stale_link() {
         let old_ts = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
@@ -1300,7 +1173,6 @@ mod tests {
         assert_eq!(resp.cell_count, 1);
     }
 
-    // --- EvidenceItem round-trip serialization (mapping logic, no DB) ---
     #[test]
     fn evidence_item_serde_roundtrip() {
         let item = EvidenceItem {
@@ -1318,7 +1190,6 @@ mod tests {
         assert!(json.contains("passed"));
     }
 
-    // --- Sprint/Story/Team serialization ---
     #[test]
     fn sprint_serde() {
         let sprint = Sprint {
@@ -1356,7 +1227,7 @@ mod tests {
 
     #[test]
     fn team_response_serde() {
-        let team = TeamResponse {
+        let team = TeamRow {
             id: "team-1".to_string(),
             name: "Platform Team".to_string(),
             description: "Core platform engineering".to_string(),
@@ -1365,5 +1236,142 @@ mod tests {
         let json = serde_json::to_string(&team).unwrap();
         assert!(json.contains("Platform Team"));
         assert!(json.contains("\"members\":[]"));
+    }
+
+    // -----------------------------------------------------------------------
+    // SQLite in-memory round-trip tests — on-device tier proof
+    // No external DB required; uses sqlx SqlitePool with sqlite::memory:
+    // -----------------------------------------------------------------------
+
+    async fn make_sqlite_store() -> crate::sqlite_store::SqliteStore {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("open in-memory SQLite");
+        // Apply SQLite migrations manually using the embedded SQL
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS evidence (
+                id TEXT PRIMARY KEY,
+                artifact_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                url TEXT NOT NULL,
+                metadata TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create evidence table");
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS sprints (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                goal TEXT NOT NULL DEFAULT '',
+                start_date TEXT NOT NULL,
+                end_date TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'planned',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create sprints table");
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS stories (
+                id TEXT PRIMARY KEY,
+                sprint_id TEXT,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'open',
+                story_points INTEGER,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create stories table");
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS teams (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                members TEXT NOT NULL DEFAULT '[]',
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create teams table");
+
+        crate::sqlite_store::SqliteStore::new(pool)
+    }
+
+    /// SQLite evidence round-trip: create then list returns the same item.
+    #[tokio::test]
+    async fn sqlite_evidence_create_then_list() {
+        let store = make_sqlite_store().await;
+
+        // Empty initially
+        let initial = store.list_evidence().await.expect("list_evidence");
+        assert!(initial.is_empty(), "store should be empty initially");
+
+        let now = Utc::now();
+        let ev = store
+            .create_evidence(
+                "ev-test-1".to_string(),
+                "req-001".to_string(),
+                "test_result".to_string(),
+                "https://ci.example.com/run/42".to_string(),
+                serde_json::json!({"passed": true, "suite": "unit"}),
+                now,
+            )
+            .await
+            .expect("create_evidence");
+
+        assert_eq!(ev.id, "ev-test-1");
+        assert_eq!(ev.artifact_id, "req-001");
+        assert_eq!(ev.kind, "test_result");
+
+        let listed = store.list_evidence().await.expect("list_evidence after create");
+        assert_eq!(listed.len(), 1, "exactly one evidence item");
+        let found = &listed[0];
+        assert_eq!(found.id, "ev-test-1");
+        assert_eq!(found.metadata["passed"], true);
+
+        // count_evidence reflects the insert
+        let count = store.count_evidence().await.expect("count_evidence");
+        assert_eq!(count, 1);
+    }
+
+    /// SQLite sprint round-trip: create then list returns the sprint with status=planned.
+    #[tokio::test]
+    async fn sqlite_sprint_create_then_list() {
+        let store = make_sqlite_store().await;
+
+        let now = Utc::now();
+        let start = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 1, 14, 0, 0, 0).unwrap();
+
+        let sprint = store
+            .create_sprint(
+                "sprint-sqlite-1".to_string(),
+                "On-device Sprint 1".to_string(),
+                "Prove SQLite tier works without a server".to_string(),
+                start,
+                end,
+                now,
+            )
+            .await
+            .expect("create_sprint");
+
+        assert_eq!(sprint.id, "sprint-sqlite-1");
+        assert_eq!(sprint.status, "planned");
+
+        let listed = store.list_sprints().await.expect("list_sprints");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "On-device Sprint 1");
     }
 }

--- a/crates/tracera-server/src/pg_store.rs
+++ b/crates/tracera-server/src/pg_store.rs
@@ -1,0 +1,223 @@
+/// PgStore — Postgres backend implementing `Store`.
+///
+/// Uses runtime `sqlx::query()` (not macros) so `env -u DATABASE_URL cargo build`
+/// stays green. There is no pre-existing `.sqlx/` offline cache on this branch;
+/// adding one would require a live Postgres for `cargo sqlx prepare`.
+/// The runtime query path is equally correct at runtime and avoids the two-DB
+/// prepare problem noted in the task specification.
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::{PgPool, Row};
+
+use crate::store::{BoxFuture, EvidenceItem, Sprint, Store, StoreError, StoreResult, Story, TeamRow};
+
+#[derive(Clone)]
+pub struct PgStore {
+    pub pool: PgPool,
+}
+
+impl PgStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl Store for PgStore {
+    fn list_evidence(&self) -> BoxFuture<'_, StoreResult<Vec<EvidenceItem>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, artifact_id, kind, url, metadata::text, \
+                 created_at, updated_at \
+                 FROM evidence ORDER BY created_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| {
+                    let meta_str: String = r.try_get("metadata").unwrap_or_default();
+                    let metadata: Value =
+                        serde_json::from_str(&meta_str).unwrap_or(Value::Object(Default::default()));
+                    EvidenceItem {
+                        id: r.try_get("id").unwrap_or_default(),
+                        artifact_id: r.try_get("artifact_id").unwrap_or_default(),
+                        kind: r.try_get("kind").unwrap_or_default(),
+                        url: r.try_get("url").unwrap_or_default(),
+                        metadata,
+                        created_at: r.try_get("created_at").unwrap_or_else(|_| Utc::now()),
+                        updated_at: r.try_get("updated_at").unwrap_or_else(|_| Utc::now()),
+                    }
+                })
+                .collect())
+        })
+    }
+
+    fn create_evidence(
+        &self,
+        id: String,
+        artifact_id: String,
+        kind: String,
+        url: String,
+        metadata: Value,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<EvidenceItem>> {
+        Box::pin(async move {
+            let meta_str =
+                serde_json::to_string(&metadata).unwrap_or_else(|_| "{}".to_string());
+            sqlx::query(
+                "INSERT INTO evidence \
+                 (id, artifact_id, kind, url, metadata, created_at, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)",
+            )
+            .bind(&id)
+            .bind(&artifact_id)
+            .bind(&kind)
+            .bind(&url)
+            .bind(&meta_str)
+            .bind(now)
+            .bind(now)
+            .execute(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(EvidenceItem {
+                id,
+                artifact_id,
+                kind,
+                url,
+                metadata,
+                created_at: now,
+                updated_at: now,
+            })
+        })
+    }
+
+    fn list_sprints(&self) -> BoxFuture<'_, StoreResult<Vec<Sprint>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, name, goal, start_date, end_date, status, created_at, updated_at \
+                 FROM sprints ORDER BY created_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| Sprint {
+                    id: r.try_get("id").unwrap_or_default(),
+                    name: r.try_get("name").unwrap_or_default(),
+                    goal: r.try_get("goal").unwrap_or_default(),
+                    start_date: r.try_get("start_date").unwrap_or_else(|_| Utc::now()),
+                    end_date: r.try_get("end_date").unwrap_or_else(|_| Utc::now()),
+                    status: r.try_get("status").unwrap_or_default(),
+                    created_at: r.try_get("created_at").unwrap_or_else(|_| Utc::now()),
+                    updated_at: r.try_get("updated_at").unwrap_or_else(|_| Utc::now()),
+                })
+                .collect())
+        })
+    }
+
+    fn create_sprint(
+        &self,
+        id: String,
+        name: String,
+        goal: String,
+        start_date: DateTime<Utc>,
+        end_date: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<Sprint>> {
+        Box::pin(async move {
+            sqlx::query(
+                "INSERT INTO sprints \
+                 (id, name, goal, start_date, end_date, status, created_at, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5, 'planned', $6, $7)",
+            )
+            .bind(&id)
+            .bind(&name)
+            .bind(&goal)
+            .bind(start_date)
+            .bind(end_date)
+            .bind(now)
+            .bind(now)
+            .execute(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(Sprint {
+                id,
+                name,
+                goal,
+                start_date,
+                end_date,
+                status: "planned".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+        })
+    }
+
+    fn list_stories(&self) -> BoxFuture<'_, StoreResult<Vec<Story>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, sprint_id, title, description, status, story_points, \
+                 created_at, updated_at FROM stories ORDER BY created_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| Story {
+                    id: r.try_get("id").unwrap_or_default(),
+                    sprint_id: r.try_get("sprint_id").ok(),
+                    title: r.try_get("title").unwrap_or_default(),
+                    description: r.try_get("description").unwrap_or_default(),
+                    status: r.try_get("status").unwrap_or_default(),
+                    story_points: r.try_get("story_points").ok(),
+                    created_at: r.try_get("created_at").unwrap_or_else(|_| Utc::now()),
+                    updated_at: r.try_get("updated_at").unwrap_or_else(|_| Utc::now()),
+                })
+                .collect())
+        })
+    }
+
+    fn list_teams(&self) -> BoxFuture<'_, StoreResult<Vec<TeamRow>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, name, description, members FROM teams ORDER BY id ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| {
+                    // members is TEXT[] in Postgres; sqlx decodes it as Vec<String>
+                    let members: Vec<String> = r.try_get("members").unwrap_or_default();
+                    TeamRow {
+                        id: r.try_get("id").unwrap_or_default(),
+                        name: r.try_get("name").unwrap_or_default(),
+                        description: r.try_get("description").unwrap_or_default(),
+                        members,
+                    }
+                })
+                .collect())
+        })
+    }
+
+    fn count_evidence(&self) -> BoxFuture<'_, StoreResult<i64>> {
+        Box::pin(async move {
+            let row = sqlx::query("SELECT COUNT(*) AS cnt FROM evidence")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(StoreError::from)?;
+            let count: i64 = row.try_get("cnt").unwrap_or(0);
+            Ok(count)
+        })
+    }
+}

--- a/crates/tracera-server/src/sqlite_store.rs
+++ b/crates/tracera-server/src/sqlite_store.rs
@@ -1,0 +1,242 @@
+/// SqliteStore — SQLite on-device/per-project backend implementing `Store`.
+///
+/// Uses runtime `sqlx::query()` (not macros) so the PG `.sqlx/` offline cache
+/// remains the sole compile-time check surface; `env -u DATABASE_URL cargo build`
+/// stays green without a live DB.
+///
+/// Backend selection: any `DATABASE_URL` with scheme `sqlite://` or a plain
+/// file path ending in `.db` routes here. A special `sqlite::memory:` URL gives
+/// an in-process ephemeral store — used by tests.
+///
+/// Timestamps are stored as ISO-8601 TEXT (SQLite has no native timestamp type).
+/// The `members` column from the PG TEXT[] is stored as a JSON array string.
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::{Row, SqlitePool};
+
+use crate::store::{BoxFuture, EvidenceItem, Sprint, Store, StoreError, StoreResult, Story, TeamRow};
+
+#[derive(Clone)]
+pub struct SqliteStore {
+    pub pool: SqlitePool,
+}
+
+impl SqliteStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+// Helpers for timestamp round-trips (TEXT ↔ DateTime<Utc>)
+fn ts_to_str(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339()
+}
+
+fn str_to_ts(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc::now())
+}
+
+impl Store for SqliteStore {
+    fn list_evidence(&self) -> BoxFuture<'_, StoreResult<Vec<EvidenceItem>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, artifact_id, kind, url, metadata, created_at, updated_at
+                 FROM evidence ORDER BY created_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            let items = rows
+                .into_iter()
+                .map(|r| {
+                    let meta_str: String = r.try_get("metadata").unwrap_or_default();
+                    let metadata: Value =
+                        serde_json::from_str(&meta_str).unwrap_or(Value::Object(Default::default()));
+                    EvidenceItem {
+                        id: r.try_get("id").unwrap_or_default(),
+                        artifact_id: r.try_get("artifact_id").unwrap_or_default(),
+                        kind: r.try_get("kind").unwrap_or_default(),
+                        url: r.try_get("url").unwrap_or_default(),
+                        metadata,
+                        created_at: str_to_ts(&r.try_get::<String, _>("created_at").unwrap_or_default()),
+                        updated_at: str_to_ts(&r.try_get::<String, _>("updated_at").unwrap_or_default()),
+                    }
+                })
+                .collect();
+
+            Ok(items)
+        })
+    }
+
+    fn create_evidence(
+        &self,
+        id: String,
+        artifact_id: String,
+        kind: String,
+        url: String,
+        metadata: Value,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<EvidenceItem>> {
+        Box::pin(async move {
+            let meta_str = serde_json::to_string(&metadata)
+                .unwrap_or_else(|_| "{}".to_string());
+            let now_str = ts_to_str(now);
+
+            sqlx::query(
+                "INSERT INTO evidence (id, artifact_id, kind, url, metadata, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            )
+            .bind(&id)
+            .bind(&artifact_id)
+            .bind(&kind)
+            .bind(&url)
+            .bind(&meta_str)
+            .bind(&now_str)
+            .bind(&now_str)
+            .execute(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(EvidenceItem {
+                id,
+                artifact_id,
+                kind,
+                url,
+                metadata,
+                created_at: now,
+                updated_at: now,
+            })
+        })
+    }
+
+    fn list_sprints(&self) -> BoxFuture<'_, StoreResult<Vec<Sprint>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, name, goal, start_date, end_date, status, created_at, updated_at
+                 FROM sprints ORDER BY created_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| Sprint {
+                    id: r.try_get("id").unwrap_or_default(),
+                    name: r.try_get("name").unwrap_or_default(),
+                    goal: r.try_get("goal").unwrap_or_default(),
+                    start_date: str_to_ts(&r.try_get::<String, _>("start_date").unwrap_or_default()),
+                    end_date: str_to_ts(&r.try_get::<String, _>("end_date").unwrap_or_default()),
+                    status: r.try_get("status").unwrap_or_default(),
+                    created_at: str_to_ts(&r.try_get::<String, _>("created_at").unwrap_or_default()),
+                    updated_at: str_to_ts(&r.try_get::<String, _>("updated_at").unwrap_or_default()),
+                })
+                .collect())
+        })
+    }
+
+    fn create_sprint(
+        &self,
+        id: String,
+        name: String,
+        goal: String,
+        start_date: DateTime<Utc>,
+        end_date: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<Sprint>> {
+        Box::pin(async move {
+            let now_str = ts_to_str(now);
+            sqlx::query(
+                "INSERT INTO sprints (id, name, goal, start_date, end_date, status, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'planned', ?6, ?7)",
+            )
+            .bind(&id)
+            .bind(&name)
+            .bind(&goal)
+            .bind(ts_to_str(start_date))
+            .bind(ts_to_str(end_date))
+            .bind(&now_str)
+            .bind(&now_str)
+            .execute(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(Sprint {
+                id,
+                name,
+                goal,
+                start_date,
+                end_date,
+                status: "planned".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+        })
+    }
+
+    fn list_stories(&self) -> BoxFuture<'_, StoreResult<Vec<Story>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, sprint_id, title, description, status, story_points, created_at, updated_at
+                 FROM stories ORDER BY created_at ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| Story {
+                    id: r.try_get("id").unwrap_or_default(),
+                    sprint_id: r.try_get("sprint_id").ok(),
+                    title: r.try_get("title").unwrap_or_default(),
+                    description: r.try_get("description").unwrap_or_default(),
+                    status: r.try_get("status").unwrap_or_default(),
+                    story_points: r.try_get("story_points").ok(),
+                    created_at: str_to_ts(&r.try_get::<String, _>("created_at").unwrap_or_default()),
+                    updated_at: str_to_ts(&r.try_get::<String, _>("updated_at").unwrap_or_default()),
+                })
+                .collect())
+        })
+    }
+
+    fn list_teams(&self) -> BoxFuture<'_, StoreResult<Vec<TeamRow>>> {
+        Box::pin(async move {
+            let rows = sqlx::query(
+                "SELECT id, name, description, members FROM teams ORDER BY id ASC",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|r| {
+                    let members_str: String = r.try_get("members").unwrap_or_else(|_| "[]".to_string());
+                    let members: Vec<String> =
+                        serde_json::from_str(&members_str).unwrap_or_default();
+                    TeamRow {
+                        id: r.try_get("id").unwrap_or_default(),
+                        name: r.try_get("name").unwrap_or_default(),
+                        description: r.try_get("description").unwrap_or_default(),
+                        members,
+                    }
+                })
+                .collect())
+        })
+    }
+
+    fn count_evidence(&self) -> BoxFuture<'_, StoreResult<i64>> {
+        Box::pin(async move {
+            let row = sqlx::query("SELECT COUNT(*) as cnt FROM evidence")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(StoreError::from)?;
+            let count: i64 = row.try_get("cnt").unwrap_or(0);
+            Ok(count)
+        })
+    }
+}

--- a/crates/tracera-server/src/store.rs
+++ b/crates/tracera-server/src/store.rs
@@ -1,0 +1,121 @@
+/// Pluggable storage abstraction for Tracera server.
+///
+/// Both `PgStore` (Postgres, server/hosted tier) and `SqliteStore`
+/// (SQLite, on-device/per-project tier) implement this trait.
+/// Handlers hold `Arc<dyn Store + Send + Sync>` and call only this interface.
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+// ---------------------------------------------------------------------------
+// Shared error type
+// ---------------------------------------------------------------------------
+#[derive(Debug)]
+pub enum StoreError {
+    Database(String),
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoreError::Database(msg) => write!(f, "database error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+impl From<sqlx::Error> for StoreError {
+    fn from(e: sqlx::Error) -> Self {
+        StoreError::Database(e.to_string())
+    }
+}
+
+pub type StoreResult<T> = Result<T, StoreError>;
+
+// ---------------------------------------------------------------------------
+// Domain types (copied from main.rs — single source of truth here)
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EvidenceItem {
+    pub id: String,
+    pub artifact_id: String,
+    pub kind: String,
+    pub url: String,
+    pub metadata: Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Sprint {
+    pub id: String,
+    pub name: String,
+    pub goal: String,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Story {
+    pub id: String,
+    pub sprint_id: Option<String>,
+    pub title: String,
+    pub description: String,
+    pub status: String,
+    pub story_points: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TeamRow {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub members: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Store trait
+// ---------------------------------------------------------------------------
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+pub trait Store: Send + Sync {
+    // Evidence
+    fn list_evidence(&self) -> BoxFuture<'_, StoreResult<Vec<EvidenceItem>>>;
+    fn create_evidence(
+        &self,
+        id: String,
+        artifact_id: String,
+        kind: String,
+        url: String,
+        metadata: Value,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<EvidenceItem>>;
+
+    // Sprints
+    fn list_sprints(&self) -> BoxFuture<'_, StoreResult<Vec<Sprint>>>;
+    fn create_sprint(
+        &self,
+        id: String,
+        name: String,
+        goal: String,
+        start_date: DateTime<Utc>,
+        end_date: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<Sprint>>;
+
+    // Stories
+    fn list_stories(&self) -> BoxFuture<'_, StoreResult<Vec<Story>>>;
+
+    // Teams
+    fn list_teams(&self) -> BoxFuture<'_, StoreResult<Vec<TeamRow>>>;
+
+    // Metrics
+    fn count_evidence(&self) -> BoxFuture<'_, StoreResult<i64>>;
+}


### PR DESCRIPTION
## Summary

- Extracts an async `Store` trait (`src/store.rs`) capturing all persisted operations: `list_evidence`/`create_evidence`, `list_sprints`/`create_sprint`, `list_stories`, `list_teams`, `count_evidence`. Returns domain types from `store.rs` and a `StoreError` covering database failures.
- Refactors existing PG code into `PgStore` (`src/pg_store.rs`) implementing `Store` via runtime `sqlx::query()` (not macros, so no `.sqlx/` offline cache required). `AppState` holds `Arc<dyn Store>` instead of a bare `PgPool`. All handler signatures and HTTP response shapes are identical to #709 — no API break.
- Adds `SqliteStore` (`src/sqlite_store.rs`) implementing the same `Store` trait via `sqlx::Sqlite`. SQLite-dialect migrations live in `migrations-sqlite/` (TEXT timestamps, TEXT for JSONB, TEXT JSON-array for PG TEXT[]). Zero-ops: supply `sqlite:///path/to/file.db` or `sqlite::memory:` as `DATABASE_URL`.
- Backend selection at startup by `DATABASE_URL` scheme: `postgres://` / `postgresql://` → `PgStore`; `sqlite://` / `sqlite:` / `*.db` → `SqliteStore`. Unrecognised scheme exits with an actionable error. Missing `DATABASE_URL` exits with a message listing both supported URL forms.

## Verification (`env -u DATABASE_URL`)

```
$ env -u DATABASE_URL cargo build -p tracera-server
   Compiling tracera-server v0.1.3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.75s

$ env -u DATABASE_URL cargo test -p tracera-server
running 25 tests
test tests::coverage_missing ... ok
test tests::coverage_covered ... ok
test tests::coverage_conflict ... ok
test tests::coverage_partial ... ok
test tests::coverage_matrix_stale_link ... ok
test tests::bfs_linear_chain ... ok
test tests::bfs_no_outgoing_edges ... ok
test tests::bfs_distances_basic ... ok
test tests::impact_depth_1_excludes_2_hop_node ... ok
test tests::impact_depth_0_returns_only_seeds ... ok
test tests::evidence_item_serde_roundtrip ... ok
test tests::impact_traverses_multi_hop_at_depth_3 ... ok
test tests::ingest_all_valid ... ok
test tests::ingest_missing_title ... ok
test tests::jaccard_disjoint ... ok
test tests::jaccard_empty ... ok
test tests::jaccard_identical ... ok
test tests::neighbors_forward ... ok
test tests::jaccard_partial_overlap ... ok
test tests::neighbors_reverse ... ok
test tests::sprint_serde ... ok
test tests::story_optional_fields ... ok
test tests::team_response_serde ... ok
test tests::sqlite_sprint_create_then_list ... ok
test tests::sqlite_evidence_create_then_list ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ env -u DATABASE_URL cargo clippy -p tracera-server --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.84s
```

25/25 tests pass including:
- `impact_traverses_multi_hop_at_depth_3` (#706 regression)
- All 21 logic tests from #709
- `sqlite_evidence_create_then_list` — in-memory SQLite round-trip: create→list→count, no external DB
- `sqlite_sprint_create_then_list` — in-memory SQLite round-trip: create→list, status=planned confirmed

## Backend Selection

```
DATABASE_URL=postgres://user:pass@localhost:5432/tracera   → PgStore (server tier)
DATABASE_URL=sqlite:///home/user/.tracera/local.db         → SqliteStore (on-device tier)
DATABASE_URL=sqlite::memory:                               → SqliteStore (ephemeral, tests)
<unset>                                                    → FATAL: actionable error, exits 1
```