### PR TITLE
fix(edge): resolve wasm32-unknown-unknown build failure with Homebrew cargo on PATH

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,10 @@ ENVIRONMENT = "production"
 TRACERA_API = "https://tracera.pheno.studio"
 
 [build]
-command = "cargo install -q worker-build && worker-build --release"
+# Prepend $HOME/.cargo/bin so the rustup cargo shim is used instead of any system-installed
+# cargo (e.g. Homebrew).  The shim reads rust-toolchain.toml and delegates to rustup's own
+# rustc/sysroot, which contains the wasm32-unknown-unknown target.
+command = "export PATH=\"$HOME/.cargo/bin:$PATH\" && cargo install -q worker-build && worker-build --release"
 
 [[kv_namespaces]]
 binding = "TRACERA_KV"


### PR DESCRIPTION
## Summary

- **Root cause confirmed**: `/opt/homebrew/bin/rustc` uses its own Homebrew sysroot (`/opt/homebrew/Cellar/rust/1.95.0/lib/rustlib/`) which has no `wasm32-unknown-unknown` target. Since `/opt/homebrew/bin/cargo` is first on PATH and invokes the Homebrew `rustc`, `cargo check --target wasm32-unknown-unknown` fails even though the target is installed via rustup. Setting `RUSTUP_TOOLCHAIN` or calling `rustup run stable cargo` does **not** help — Homebrew's `rustc` ignores `RUSTUP_TOOLCHAIN` entirely.

- **Fix part 1 — `rust-toolchain.toml`**: Pins the workspace to `channel = "stable"` with `targets = ["wasm32-unknown-unknown"]`. Any user or CI runner whose `cargo` comes from the rustup shim (`~/.cargo/bin/cargo`) will automatically get the correct rustc/sysroot.

- **Fix part 2 — `wrangler.toml` `[build]` command**: Prepends `$HOME/.cargo/bin` to `PATH` before invoking `cargo install -q worker-build && worker-build --release`. This ensures wrangler uses the rustup shim even when Homebrew cargo is first on the user's PATH, so `rust-toolchain.toml` is honoured during the Worker build.

## Verification

```
# wasm32 check — with /opt/homebrew/bin/cargo still on PATH (adversarial case):
$ export PATH="$HOME/.cargo/bin:$PATH" && cargo check --target wasm32-unknown-unknown -p tracera-edge
    Checking tracera-edge v0.1.0 (.../crates/tracera-edge)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s

# Host build unaffected:
$ /opt/homebrew/bin/cargo check -p tracera-server
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 51s
```

## Files changed

- `rust-toolchain.toml` — new, pins `stable` + `wasm32-unknown-unknown`
- `wrangler.toml` — `[build].command` prepends `$HOME/.cargo/bin` to PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnKxyJL4rzUFa7MqQQ3DbE