### PR TITLE
fix(ci): release-desktop.yml matches Electrobun build pipeline

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,5 +1,17 @@
 name: Release Tracera Desktop
 
+# Builds cross-platform installers for the Tracera Electrobun desktop app.
+# Triggered on v* tags (release) or manual dispatch (test build).
+#
+# Output per platform:
+#   - macOS:   Tracera-<ver>-macos-<arch>.zip  (zipped .app bundle)
+#   - Windows: Tracera-<ver>-win-<arch>.zip    (zipped .exe + Resources)
+#   - Linux:   Tracera-<ver>-linux-<arch>.tar.gz
+#
+# Code signing: not configured — produces unsigned binaries. Personal
+# installation works without signing; distribution requires notarization
+# (out of scope for v0.1).
+
 on:
   push:
     tags:
@@ -16,50 +28,90 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            arch: arm64
+            artifact_subdir: dev-macos-arm64
+            package_ext: app
+            archive_format: zip
+          - os: windows-latest
+            arch: x64
+            artifact_subdir: dev-windows-x64
+            package_ext: exe
+            archive_format: zip
+          - os: ubuntu-latest
+            arch: x64
+            artifact_subdir: dev-linux-x64
+            package_ext: AppImage
+            archive_format: tar.gz
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '22'
+          bun-version: '1.3.11'
 
       - name: Install dependencies
         working-directory: frontend/apps/desktop
-        run: npm ci
+        run: bun install --frozen-lockfile
 
-      - name: Build (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Build with Electrobun
         working-directory: frontend/apps/desktop
-        env:
-          # No code signing configured — produces unsigned binaries (still installable on personal machines).
-          CSC_IDENTITY_AUTO_DISCOVERY: false
-        run: npm run build:mac
+        run: bunx electrobun build
 
-      - name: Build (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Locate built artifact
+        id: locate
         working-directory: frontend/apps/desktop
-        run: npm run build:win
+        run: |
+          set -e
+          SUB="${{ matrix.artifact_subdir }}"
+          EXT="${{ matrix.package_ext }}"
+          if [ "$EXT" = "app" ]; then
+            ARTIFACT="build/${SUB}/Tracera-dev.app"
+          else
+            ARTIFACT=$(find "build/${SUB}" -maxdepth 2 -type f -name "*.${EXT}" | head -1)
+          fi
+          if [ -z "$ARTIFACT" ] || [ ! -e "$ARTIFACT" ]; then
+            echo "::error::Built artifact not found (looked for build/${SUB}/Tracera-dev.${EXT})"
+            ls -la "build/${SUB}/" || true
+            exit 1
+          fi
+          echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
+          echo "Built artifact: ${ARTIFACT}"
 
-      - name: Build (Linux)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Archive artifact
         working-directory: frontend/apps/desktop
-        run: npm run build:linux
+        run: |
+          set -e
+          ARTIFACT="${{ steps.locate.outputs.artifact }}"
+          FMT="${{ matrix.archive_format }}"
+          APP_NAME=$(node -p "require('./package.json').name")
+          APP_VERSION=$(node -p "require('./package.json').version")
+          OUT="${APP_NAME}-${APP_VERSION}-${{ matrix.os }}-${{ matrix.arch }}.${FMT}"
+          case "$FMT" in
+            zip)
+              if [ -d "$ARTIFACT" ]; then
+                (cd "$(dirname "$ARTIFACT")" && zip -r "$OLDPWD/$OUT" "$(basename "$ARTIFACT")")
+              else
+                zip "$OUT" "$ARTIFACT"
+              fi
+              ;;
+            tar.gz)
+              tar -czf "$OUT" -C "$(dirname "$ARTIFACT")" "$(basename "$ARTIFACT")"
+              ;;
+          esac
+          echo "Archived to: ${OUT}"
+          ls -la "${OUT}"
 
-      - name: Upload artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tracera-desktop-${{ matrix.os }}
-          path: |
-            frontend/apps/desktop/release/**/*.dmg
-            frontend/apps/desktop/release/**/*.zip
-            frontend/apps/desktop/release/**/*.exe
-            frontend/apps/desktop/release/**/*.AppImage
-            frontend/apps/desktop/release/**/*.deb
-          if-no-files-found: warn
+          name: tracera-desktop-${{ matrix.os }}-${{ matrix.arch }}
+          path: frontend/apps/desktop/Tracera-*-${{ matrix.os }}-${{ matrix.arch }}.{{ matrix.archive_format }}
+          if-no-files-found: error
 
   release:
     name: Attach to GitHub Release
@@ -73,7 +125,7 @@ jobs:
           path: artifacts
 
       - name: List artifacts
-        run: ls -la artifacts/
+        run: ls -la artifacts/*/
 
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

After PR #716 migrated the desktop app from Electron to Electrobun, the `release-desktop.yml` workflow was orphaned: it still called `npm run build:mac`, `npm run build:win`, `npm run build:linux` — but the new `package.json` only exposes `build`, `package`, `dev`. The release workflow would fail immediately on the first matrix step.

## Root cause

PR #716 replaced `electron@39.8.5` + `electron-builder@25.1.8` with `electrobun@1.18.1`. The migration updated:
- `frontend/apps/desktop/package.json` (scripts now `dev`, `build`, `package`, `test:e2e`, `postinstall`)
- `frontend/apps/desktop/electron/main.js` + `preload.js` (deleted)
- `frontend/apps/desktop/electrobun.config.ts` (new — replaces electron-builder config)

…but did NOT update `.github/workflows/release-desktop.yml`. The release workflow still referenced the old `electron-builder` platform-specific scripts and `release/**/*.dmg|zip|exe|AppImage|deb` artifact paths.

## Diff

`+79 / -27` in `.github/workflows/release-desktop.yml`.

## What changed

| Before | After |
|--------|-------|
| `setup-node@v4` (Node 22) | `oven-sh/setup-bun@v2` (Bun 1.3.11) |
| `npm ci` | `bun install --frozen-lockfile` |
| 3 hard-coded `npm run build:<os>` steps | Single `bunx electrobun build` (Electrobun auto-detects host platform) |
| `release/**/*.dmg\|zip\|exe\|AppImage\|deb` glob | Dynamic locate + archive (`.zip` for mac/win, `.tar.gz` for linux) |
| Matrix by os only | Matrix by os + arch + subdir + ext + format |

## Verification

Verified locally on macOS:
- `bun install` succeeds — electrobun 1.18.1 + @types/bun 1.3.14 installed
- `bunx tsc --noEmit` passes
- `bunx electrobun build` produces `build/dev-macos-arm64/Tracera-dev.app` (full bundle: launcher, bun runtime, AppIcon.icns, valid Info.plist)
- `open build/dev-macos-arm64/Tracera-dev.app` launches the app (launcher PID + bun runtime both spawn correctly)

PR #716 verified the same `bunx electrobun build` command works on all 3 platforms (mac arm64, win x64, linux x64), so the CI matrix should resolve cleanly.

## Test plan

- [ ] Manual `workflow_dispatch` run after merge (this branch's PR build won't trigger it — workflow only fires on `v*` tag or manual)
- [ ] Tag `v0.1.0-desktop` → all 3 OS jobs build, artifacts attach to release

## Fork-only note

Pure `.github/workflows/` change. No fork-only operational changes.