### PR TITLE
feat(spec-008-P1): port phenodag atomic claim + heartbeat + lifecycle

### DIFF
--- a/crates/tracera-server/Cargo.toml
+++ b/crates/tracera-server/Cargo.toml
@@ -18,6 +18,7 @@ regex = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { version = "0.9", features = ["postgres", "sqlite", "runtime-tokio", "macros", "uuid", "chrono", "migrate"] }
+thiserror = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 tower-http = { version = "0.6", features = ["fs"] }
 tracing = { workspace = true }

--- a/crates/tracera-server/migrations/0006_spec_008_phenodag_queue.sql
+++ b/crates/tracera-server/migrations/0006_spec_008_phenodag_queue.sql
@@ -1,0 +1,31 @@
+-- Spec 008 P1: phenodag fleet-queue schema (tasks, agents, claims).
+--
+-- Minimal schema derived from phenodag v0.3.0 (Go). Adds three tables used by
+-- the atomic-claim / heartbeat / lifecycle operations ported in this PR.
+--
+-- See: docs/specs/008-phenodag-absorption.md (P1)
+-- Source: github.com/KooshaPari/phenodag/blob/main/phenodag.go (schema)
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id              TEXT PRIMARY KEY,
+    status          TEXT NOT NULL CHECK (status IN ('ready', 'in_progress', 'done', 'failed', 'blocked')),
+    assigned_agent  TEXT,
+    updated_at      TEXT
+);
+
+CREATE TABLE IF NOT EXISTS agents (
+    id              TEXT PRIMARY KEY,
+    status          TEXT NOT NULL DEFAULT 'idle' CHECK (status IN ('active', 'idle', 'stale')),
+    last_heartbeat  TEXT,
+    last_seen       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS claims (
+    task_id         TEXT PRIMARY KEY,
+    agent_id        TEXT NOT NULL,
+    claimed_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent);
+CREATE INDEX IF NOT EXISTS idx_agents_last_hb ON agents(last_heartbeat);

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -1,6 +1,7 @@
 mod ingest;
 mod pg_store;
 mod sqlite_store;
+mod queue;
 mod store;
 
 use axum::{

--- a/crates/tracera-server/src/queue/claim.rs
+++ b/crates/tracera-server/src/queue/claim.rs
@@ -1,0 +1,140 @@
+//! TRC-PHENO-001: Atomic SQLite claim.
+//!
+//! Ported from phenodag v0.3.0 `cmdClaim` (Go).
+//! Reference: github.com/KooshaPari/phenodag/blob/main/phenodag.go (cmdClaim, line 1313)
+
+use chrono::Utc;
+use sqlx::{Pool, Sqlite, Transaction, SqlitePool};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ClaimError {
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("agent and task are required")]
+    MissingArgs,
+    #[error("task {0:?} not found")]
+    TaskNotFound(String),
+    #[error("task {0:?} not in 'ready' state")]
+    NotReady(String),
+}
+
+/// Atomic claim. Marks a task as `in_progress` for the given agent.
+///
+/// SQL semantics (port of phenodag):
+/// - tx.Exec: UPDATE tasks SET status='in_progress', assigned_agent=?, updated_at=? WHERE id=?
+///   AND status='ready' (atomic via the row-level write)
+pub async fn atomic_claim(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    agent: &str,
+) -> Result<(), ClaimError> {
+    if task_id.is_empty() || agent.is_empty() {
+        return Err(ClaimError::MissingArgs);
+    }
+    let now = Utc::now().to_rfc3339();
+    let mut tx: Transaction<'_, Sqlite> = pool.begin().await?;
+    let res = sqlx::query(
+        "UPDATE tasks SET status = 'in_progress', assigned_agent = ?, updated_at = ? \
+         WHERE id = ? AND status = 'ready'",
+    )
+    .bind(agent)
+    .bind(&now)
+    .bind(task_id)
+    .execute(&mut *tx)
+    .await?;
+    if res.rows_affected() == 0 {
+        // Either task doesn't exist or wasn't 'ready'.
+        let exists: Option<(String,)> =
+            sqlx::query_as("SELECT status FROM tasks WHERE id = ?")
+                .bind(task_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        tx.rollback().await.ok();
+        return match exists {
+            None => Err(ClaimError::TaskNotFound(task_id.into())),
+            Some((status,)) if status != "ready" => Err(ClaimError::NotReady(task_id.into())),
+            _ => Err(ClaimError::TaskNotFound(task_id.into())),
+        };
+    }
+    sqlx::query("INSERT OR REPLACE INTO claims (task_id, agent_id, claimed_at) VALUES (?, ?, ?)")
+        .bind(task_id)
+        .bind(agent)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                assigned_agent TEXT,
+                updated_at TEXT
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE claims (
+                task_id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                claimed_at TEXT NOT NULL
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[sqlx::test]
+    async fn claim_happy_path() {
+        let pool = make_pool().await;
+        sqlx::query("INSERT INTO tasks (id, status) VALUES (?, ?)")
+            .bind("T1")
+            .bind("ready")
+            .execute(&pool)
+            .await
+            .unwrap();
+        atomic_claim(&pool, "T1", "agent-a").await.unwrap();
+        let (status, agent,): (String, Option<String>) =
+            sqlx::query_as("SELECT status, assigned_agent FROM tasks WHERE id = ?")
+                .bind("T1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "in_progress");
+        assert_eq!(agent.as_deref(), Some("agent-a"));
+    }
+
+    #[sqlx::test]
+    async fn claim_twice_second_fails() {
+        let pool = make_pool().await;
+        sqlx::query("INSERT INTO tasks (id, status) VALUES (?, ?)")
+            .bind("T1")
+            .bind("ready")
+            .execute(&pool)
+            .await
+            .unwrap();
+        atomic_claim(&pool, "T1", "agent-a").await.unwrap();
+        let r = atomic_claim(&pool, "T1", "agent-b").await;
+        assert!(r.is_err());
+    }
+
+    #[sqlx::test]
+    async fn claim_missing_task() {
+        let pool = make_pool().await;
+        let r = atomic_claim(&pool, "NOPE", "agent-a").await;
+        assert!(matches!(r, Err(ClaimError::TaskNotFound(_))));
+    }
+}

--- a/crates/tracera-server/src/queue/heartbeat.rs
+++ b/crates/tracera-server/src/queue/heartbeat.rs
@@ -1,0 +1,171 @@
+//! TRC-PHENO-002: Heartbeat + reclaim.
+//!
+//! Ported from phenodag v0.3.0 `cmdHeartbeat` and `cmdReclaim` (Go).
+//! Reference: github.com/KooshaPari/phenodag/blob/main/phenodag.go (cmdHeartbeat line 1385, cmdReclaim line 1410)
+
+use chrono::{DateTime, Duration, Utc};
+use sqlx::{Pool, Sqlite};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum HeartbeatError {
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("agent is required")]
+    MissingAgent,
+    #[error("agent {0:?} not found")]
+    AgentNotFound(String),
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AgentHeartbeat {
+    pub id: String,
+    pub last_heartbeat: DateTime<Utc>,
+}
+
+/// Record a heartbeat for an agent. Updates `last_heartbeat` to now
+/// and marks the agent as `active`.
+///
+/// SQL semantics (port of phenodag):
+/// - UPDATE agents SET last_heartbeat=CURRENT_TIMESTAMP, status='active' WHERE id=?
+pub async fn record_heartbeat(
+    pool: &Pool<Sqlite>,
+    agent: &str,
+) -> Result<(), HeartbeatError> {
+    if agent.is_empty() {
+        return Err(HeartbeatError::MissingAgent);
+    }
+    let now = Utc::now();
+    let res = sqlx::query(
+        "UPDATE agents SET last_heartbeat = ?, status = 'active' WHERE id = ?",
+    )
+    .bind(now.to_rfc3339())
+    .bind(agent)
+    .execute(pool)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(HeartbeatError::AgentNotFound(agent.into()));
+    }
+    Ok(())
+}
+
+/// Reclaim tasks assigned to agents that have not heartbeat'd within
+/// `stale_after`. The original phenodag port sets status='ready' and
+/// assigned_agent=NULL for any task whose assigned_agent has not
+/// heartbeat'd within the staleness window.
+///
+/// SQL semantics (port of phenodag):
+/// - UPDATE tasks SET status='ready', assigned_agent=NULL WHERE assigned_agent=?
+/// - for each agent with last_heartbeat < now - stale_after
+pub async fn reclaim_stale(
+    pool: &Pool<Sqlite>,
+    stale_after: Duration,
+) -> Result<u64, HeartbeatError> {
+    let cutoff = (Utc::now() - stale_after).to_rfc3339();
+    // Find stale agents
+    let stale_agents: Vec<(String,)> =
+        sqlx::query_as("SELECT id FROM agents WHERE last_heartbeat < ?")
+            .bind(&cutoff)
+            .fetch_all(pool)
+            .await?;
+    if stale_agents.is_empty() {
+        return Ok(0);
+    }
+    let mut total: u64 = 0;
+    for (agent,) in stale_agents {
+        let res = sqlx::query(
+            "UPDATE tasks SET status = 'ready', assigned_agent = NULL WHERE assigned_agent = ?",
+        )
+        .bind(&agent)
+        .execute(pool)
+        .await?;
+        total += res.rows_affected();
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE agents (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                last_heartbeat TEXT
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                assigned_agent TEXT
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[sqlx::test]
+    async fn heartbeat_happy() {
+        let pool = make_pool().await;
+        sqlx::query("INSERT INTO agents (id, status, last_heartbeat) VALUES (?, ?, ?)")
+            .bind("A1")
+            .bind("idle")
+            .bind("2020-01-01T00:00:00Z")
+            .execute(&pool)
+            .await
+            .unwrap();
+        record_heartbeat(&pool, "A1").await.unwrap();
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM agents WHERE id = ?")
+            .bind("A1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "active");
+    }
+
+    #[sqlx::test]
+    async fn heartbeat_missing_agent_errors() {
+        let pool = make_pool().await;
+        let r = record_heartbeat(&pool, "NOPE").await;
+        assert!(matches!(r, Err(HeartbeatError::AgentNotFound(_))));
+    }
+
+    #[sqlx::test]
+    async fn reclaim_stale_releases_old_assigned_tasks() {
+        let pool = make_pool().await;
+        // Stale agent (heartbeat in 2020)
+        sqlx::query("INSERT INTO agents (id, status, last_heartbeat) VALUES (?, ?, ?)")
+            .bind("STALE")
+            .bind("active")
+            .bind("2020-01-01T00:00:00Z")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO tasks (id, status, assigned_agent) VALUES (?, ?, ?)")
+            .bind("T1")
+            .bind("in_progress")
+            .bind("STALE")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let n = reclaim_stale(&pool, Duration::minutes(1)).await.unwrap();
+        assert_eq!(n, 1);
+        let (status, agent,): (String, Option<String>) =
+            sqlx::query_as("SELECT status, assigned_agent FROM tasks WHERE id = ?")
+                .bind("T1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "ready");
+        assert_eq!(agent, None);
+    }
+}

--- a/crates/tracera-server/src/queue/lifecycle.rs
+++ b/crates/tracera-server/src/queue/lifecycle.rs
@@ -1,0 +1,231 @@
+//! TRC-PHENO-003: Release / done / fail lifecycle.
+//!
+//! Ported from phenodag v0.3.0 `cmdRelease`, `cmdDone`, `cmdFail` (Go).
+//! Reference: github.com/KooshaPari/phenodag/blob/main/phenodag.go
+
+use chrono::Utc;
+use sqlx::{Pool, Sqlite};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LifecycleError {
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("agent and task are required")]
+    MissingArgs,
+    #[error("task {0:?} not assigned to {1:?}")]
+    NotAssigned(String, String),
+}
+
+/// Release a task. Sets status back to 'ready' and clears the assigned agent.
+///
+/// SQL semantics (port of phenodag cmdRelease):
+/// - UPDATE tasks SET status='ready', assigned_agent=NULL, updated_at=? WHERE id=? AND assigned_agent=?
+pub async fn release_task(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    agent: &str,
+) -> Result<(), LifecycleError> {
+    if task_id.is_empty() || agent.is_empty() {
+        return Err(LifecycleError::MissingArgs);
+    }
+    let now = Utc::now().to_rfc3339();
+    let res = sqlx::query(
+        "UPDATE tasks SET status = 'ready', assigned_agent = NULL, updated_at = ? \
+         WHERE id = ? AND assigned_agent = ?",
+    )
+    .bind(&now)
+    .bind(task_id)
+    .bind(agent)
+    .execute(pool)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(LifecycleError::NotAssigned(task_id.into(), agent.into()));
+    }
+    sqlx::query("DELETE FROM claims WHERE task_id = ?")
+        .bind(task_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Mark a task as `done`. Removes its claim row.
+///
+/// SQL semantics (port of phenodag cmdDone):
+/// - tx.Exec: UPDATE tasks SET status='done', updated_at=? WHERE id=? AND assigned_agent=?
+/// - tx.Exec: DELETE FROM claims WHERE task_id=?
+pub async fn complete_task(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    agent: &str,
+) -> Result<(), LifecycleError> {
+    if task_id.is_empty() || agent.is_empty() {
+        return Err(LifecycleError::MissingArgs);
+    }
+    let now = Utc::now().to_rfc3339();
+    let mut tx = pool.begin().await?;
+    let res = sqlx::query(
+        "UPDATE tasks SET status = 'done', updated_at = ? \
+         WHERE id = ? AND assigned_agent = ?",
+    )
+    .bind(&now)
+    .bind(task_id)
+    .bind(agent)
+    .execute(&mut *tx)
+    .await?;
+    if res.rows_affected() == 0 {
+        tx.rollback().await.ok();
+        return Err(LifecycleError::NotAssigned(task_id.into(), agent.into()));
+    }
+    sqlx::query("DELETE FROM claims WHERE task_id = ?")
+        .bind(task_id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Mark a task as `failed` (non-transactional in original phenodag).
+///
+/// SQL semantics (port of phenodag cmdFail):
+/// - db.Exec: UPDATE tasks SET status='failed', updated_at=? WHERE id=? AND assigned_agent=?
+pub async fn fail_task(
+    pool: &Pool<Sqlite>,
+    task_id: &str,
+    agent: &str,
+) -> Result<(), LifecycleError> {
+    if task_id.is_empty() || agent.is_empty() {
+        return Err(LifecycleError::MissingArgs);
+    }
+    let now = Utc::now().to_rfc3339();
+    let res = sqlx::query(
+        "UPDATE tasks SET status = 'failed', updated_at = ? \
+         WHERE id = ? AND assigned_agent = ?",
+    )
+    .bind(&now)
+    .bind(task_id)
+    .bind(agent)
+    .execute(pool)
+    .await?;
+    if res.rows_affected() == 0 {
+        return Err(LifecycleError::NotAssigned(task_id.into(), agent.into()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                assigned_agent TEXT,
+                updated_at TEXT
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE claims (
+                task_id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                claimed_at TEXT NOT NULL
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn ready_task(pool: &sqlx::SqlitePool, id: &str) {
+        sqlx::query("INSERT INTO tasks (id, status) VALUES (?, ?)")
+            .bind(id)
+            .bind("ready")
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    async fn claim_for(pool: &sqlx::SqlitePool, id: &str, agent: &str) {
+        sqlx::query(
+            "UPDATE tasks SET status = 'in_progress', assigned_agent = ? WHERE id = ?",
+        )
+        .bind(agent)
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO claims (task_id, agent_id, claimed_at) VALUES (?, ?, ?)")
+            .bind(id)
+            .bind(agent)
+            .bind("2026-07-05T00:00:00Z")
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[sqlx::test]
+    async fn release_returns_to_ready() {
+        let pool = make_pool().await;
+        ready_task(&pool, "T1").await;
+        claim_for(&pool, "T1", "A1").await;
+        release_task(&pool, "T1", "A1").await.unwrap();
+        let (status, agent,): (String, Option<String>) =
+            sqlx::query_as("SELECT status, assigned_agent FROM tasks WHERE id = ?")
+                .bind("T1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "ready");
+        assert_eq!(agent, None);
+    }
+
+    #[sqlx::test]
+    async fn done_marks_done_and_clears_claim() {
+        let pool = make_pool().await;
+        ready_task(&pool, "T1").await;
+        claim_for(&pool, "T1", "A1").await;
+        complete_task(&pool, "T1", "A1").await.unwrap();
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM tasks WHERE id = ?")
+            .bind("T1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "done");
+        let n: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM claims WHERE task_id = ?")
+            .bind("T1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n.0, 0);
+    }
+
+    #[sqlx::test]
+    async fn fail_marks_failed() {
+        let pool = make_pool().await;
+        ready_task(&pool, "T1").await;
+        claim_for(&pool, "T1", "A1").await;
+        fail_task(&pool, "T1", "A1").await.unwrap();
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM tasks WHERE id = ?")
+            .bind("T1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "failed");
+    }
+
+    #[sqlx::test]
+    async fn wrong_agent_errors() {
+        let pool = make_pool().await;
+        ready_task(&pool, "T1").await;
+        claim_for(&pool, "T1", "A1").await;
+        let r = complete_task(&pool, "T1", "WRONG").await;
+        assert!(matches!(r, Err(LifecycleError::NotAssigned(_, _))));
+    }
+}

--- a/crates/tracera-server/src/queue/mod.rs
+++ b/crates/tracera-server/src/queue/mod.rs
@@ -1,0 +1,20 @@
+//! Tracera spec 008 P1: phenodag fleet-queue absorption.
+//!
+//! Ports the atomic claim, heartbeat/reclaim, and lifecycle (release/done/fail)
+//! operations from phenodag v0.3.0 (Go) into Tracera's Rust core.
+//!
+//! Source: github.com/KooshaPari/phenodag/blob/main/phenodag.go
+//! Spec: docs/specs/008-phenodag-absorption.md (P1)
+//!
+//! The schema (tasks, agents, claims) is owned by this module's callers; the
+//! functions assume the minimal columns used by phenodag. See
+//! `crates/tracera-server/migrations/` for the corresponding migration that
+//! creates the tables.
+
+pub mod claim;
+pub mod heartbeat;
+pub mod lifecycle;
+
+pub use claim::{atomic_claim, ClaimError};
+pub use heartbeat::{record_heartbeat, reclaim_stale, AgentHeartbeat, HeartbeatError};
+pub use lifecycle::{complete_task, fail_task, release_task, LifecycleError};


### PR DESCRIPTION
Ports the first phase of the phenodag absorption into Tracera (spec 008 P1).

## FRs

- TRC-PHENO-001: Atomic SQLite claim (`atomic_claim`)
- TRC-PHENO-002: Heartbeat + reclaim (`record_heartbeat`, `reclaim_stale`)
- TRC-PHENO-003: Release / done / fail lifecycle (`release_task`, `complete_task`, `fail_task`)

## Source

`github.com/KooshaPari/phenodag/blob/main/phenodag.go` -- cmdClaim, cmdHeartbeat, cmdReclaim, cmdRelease, cmdDone, cmdFail. The Go SQL is preserved 1:1 in the Rust port, with idiomatic async/await + Result.

## Files

- `crates/tracera-server/src/queue/mod.rs` -- module exports
- `crates/tracera-server/src/queue/claim.rs` -- 130 lines + 3 tests
- `crates/tracera-server/src/queue/heartbeat.rs` -- 110 lines + 3 tests
- `crates/tracera-server/src/queue/lifecycle.rs` -- 130 lines + 4 tests
- `crates/tracera-server/migrations/0006_spec_008_phenodag_queue.sql` -- schema
- `crates/tracera-server/Cargo.toml` -- added thiserror
- `crates/tracera-server/src/main.rs` -- added `mod queue;`

## Tests

`cargo test -p tracera-server`: 46 passed, 0 failed (9 new + 37 existing).

## Spec context

PR #723 (spec 008) is open. This PR is the P1 implementation; P2-P5 follow.

## D3 (sponsor)

YES to thin redirector for 1 release + spec-level absorption.