### PR TITLE
fix(ts): Phase E — remove 5 stale @ts-expect-error directives

### DIFF
--- a/frontend/apps/web/src/stores/auth-store.ts
+++ b/frontend/apps/web/src/stores/auth-store.ts
@@ -554,7 +554,6 @@ const buildAuthStore = (set: StoreSetter, get: StoreGetter): AuthState => ({
 });
 
 export const useAuthStore = create<AuthState>()(
-  // @ts-expect-error Zustand persist middleware incompatible with exactOptionalPropertyTypes
   persist<AuthState>((set, get) => buildAuthStore(set, get), {
     name: 'tracertm-auth-store',
     partialize: (state: AuthState) =>

--- a/frontend/apps/web/src/stores/chat-store.ts
+++ b/frontend/apps/web/src/stores/chat-store.ts
@@ -405,7 +405,6 @@ const buildChatStore = (set: StoreSetter, get: StoreGetter): ChatState => ({
 });
 
 export const useChatStore = create<ChatState>()(
-  // @ts-expect-error Zustand persist middleware incompatible with exactOptionalPropertyTypes
   persist<ChatState>((set, get) => buildChatStore(set, get), {
     name: 'tracertm-chat-store',
     partialize: (state: ChatState) =>

--- a/frontend/apps/web/src/stores/graph-cache-store.ts
+++ b/frontend/apps/web/src/stores/graph-cache-store.ts
@@ -218,7 +218,6 @@ const buildGraphCacheStore = (set: StoreSetter, get: StoreGetter): GraphCacheSto
 };
 
 const useGraphCacheStore = create<GraphCacheStoreState>()(
-  // @ts-expect-error Zustand immer middleware incompatible with exactOptionalPropertyTypes
   immer<GraphCacheStoreState>((set, get) => buildGraphCacheStore(set, get)),
 );
 

--- a/frontend/apps/web/src/stores/project-store.ts
+++ b/frontend/apps/web/src/stores/project-store.ts
@@ -170,7 +170,6 @@ const buildProjectStore = (set: StoreSetter, get: StoreGetter): ProjectState => 
 });
 
 export const useProjectStore = create<ProjectState>()(
-  // @ts-expect-error Zustand persist middleware incompatible with exactOptionalPropertyTypes
   persist<ProjectState>((set, get) => buildProjectStore(set, get), {
     name: 'tracertm-project-store',
     partialize: (state: ProjectState) =>

--- a/frontend/apps/web/src/stores/ui-store.ts
+++ b/frontend/apps/web/src/stores/ui-store.ts
@@ -156,7 +156,6 @@ const buildUIStore = (set: StoreSetter, get: StoreGetter): UIState => ({
 });
 
 export const useUIStore = create<UIState>()(
-  // @ts-expect-error Zustand persist middleware incompatible with exactOptionalPropertyTypes
   persist<UIState>((set, get) => buildUIStore(set, get), {
     name: 'tracertm-ui-store',
     partialize: (state: UIState) =>


### PR DESCRIPTION
Mechanical Phase E of issue #722. Each directive was a leftover from earlier fix iterations; underlying code no longer raises the expected error.

Files touched (5):
- frontend/apps/web/src/stores/auth-store.ts (L557)
- frontend/apps/web/src/stores/chat-store.ts (L408)
- frontend/apps/web/src/stores/graph-cache-store.ts (L221)
- frontend/apps/web/src/stores/project-store.ts (L173)
- frontend/apps/web/src/stores/ui-store.ts (L159)