### PR TITLE
fix(frontend): TS7006/TS7016 in quadTreeIndex.ts via local d3-quadtree types (Phase C)

### DIFF
--- a/frontend/apps/web/src/lib/quadTreeIndex.ts
+++ b/frontend/apps/web/src/lib/quadTreeIndex.ts
@@ -12,7 +12,7 @@
  * @see docs/architecture/quadtree-culling.md
  */
 
-import { quadtree, type Quadtree } from 'd3-quadtree';
+import { quadtree, type Quadtree, type QuadtreeLeaf } from 'd3-quadtree';
 
 /**
  * Node position in graph coordinate space
@@ -102,15 +102,16 @@ export class QuadTreeNodeIndex {
     // Use d3-quadtree's visit for efficient rectangle query
     this.tree.visit((node, x1Node, y1Node, x2Node, y2Node) => {
       // If this is a leaf node, check its data
+      const leaf = node as QuadtreeLeaf<QuadTreeNode>;
       if (!node.length) {
         // Leaf node - check all points in this node
-        let current = node as any;
+        let current: QuadtreeLeaf<QuadTreeNode> | undefined = leaf;
         do {
-          const d = current.data as QuadTreeNode;
+          const d = current?.data;
           if (d && d.x >= x0 && d.x <= x1 && d.y >= y0 && d.y <= y1) {
             results.push(d);
           }
-          current = current.next;
+          current = current?.next;
         } while (current);
       }
 
@@ -166,11 +167,12 @@ export class QuadTreeNodeIndex {
     const radiusSquared = radius * radius;
 
     this.tree.visit((node, x1, y1, x2, y2) => {
+      const leaf = node as QuadtreeLeaf<QuadTreeNode>;
       if (!node.length) {
         // Leaf node - check all points
-        let current = node as any;
+        let current: QuadtreeLeaf<QuadTreeNode> | undefined = leaf;
         do {
-          const d = current.data as QuadTreeNode;
+          const d = current?.data;
           if (d) {
             const dx = d.x - x;
             const dy = d.y - y;
@@ -179,7 +181,7 @@ export class QuadTreeNodeIndex {
               results.push(d);
             }
           }
-          current = current.next;
+          current = current?.next;
         } while (current);
       }
 

--- a/frontend/apps/web/src/types/d3-quadtree.d.ts
+++ b/frontend/apps/web/src/types/d3-quadtree.d.ts
@@ -1,0 +1,87 @@
+/**
+ * Ambient module declarations for `d3-quadtree`.
+ *
+ * The runtime npm package ships pure JavaScript with no bundled type
+ * definitions, and `@types/d3-quadtree` is not installed. The shapes below
+ * mirror the upstream DefinitelyTyped definitions so that consumers
+ * (e.g. `quadTreeIndex.ts`) can use `Quadtree<T>`, `QuadtreeLeaf<T>`, and
+ * `QuadtreeInternalNode<T>` for fully typed callbacks.
+ *
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/d3-quadtree/index.d.ts
+ */
+
+declare module 'd3-quadtree' {
+  /**
+   * Leaf node of the quadtree.
+   */
+  export interface QuadtreeLeaf<T> {
+    data: T;
+    next?: QuadtreeLeaf<T> | undefined;
+    length?: undefined;
+  }
+
+  /**
+   * Internal nodes of the quadtree are four-element arrays.
+   * A child quadrant may be undefined if it is empty.
+   */
+  export interface QuadtreeInternalNode<T> extends Array<QuadtreeInternalNode<T> | QuadtreeLeaf<T> | undefined> {
+    length: 4;
+  }
+
+  export type QuadtreeNode<T> = QuadtreeInternalNode<T> | QuadtreeLeaf<T>;
+
+  export interface Quadtree<T> {
+    x(): (d: T) => number;
+    x(x: (d: T) => number): this;
+
+    y(): (d: T) => number;
+    y(y: (d: T) => number): this;
+
+    extent(): [[number, number], [number, number]] | undefined;
+    extent(extend: [[number, number], [number, number]]): this;
+
+    cover(x: number, y: number): this;
+
+    add(datum: T): this;
+    addAll(data: T[]): this;
+    remove(datum: T): this;
+    removeAll(data: T[]): this;
+
+    copy(): Quadtree<T>;
+
+    root(): QuadtreeInternalNode<T> | QuadtreeLeaf<T>;
+
+    data(): T[];
+
+    size(): number;
+
+    find(x: number, y: number, radius?: number): T | undefined;
+
+    visit(
+      callback: (
+        node: QuadtreeInternalNode<T> | QuadtreeLeaf<T>,
+        x0: number,
+        y0: number,
+        x1: number,
+        y1: number,
+      ) => void | boolean,
+    ): this;
+
+    visitAfter(
+      callback: (
+        node: QuadtreeInternalNode<T> | QuadtreeLeaf<T>,
+        x0: number,
+        y0: number,
+        x1: number,
+        y1: number,
+      ) => void,
+    ): this;
+  }
+
+  export function quadtree<T = [number, number]>(data?: T[]): Quadtree<T>;
+  export function quadtree<T = [number, number]>(
+    data: T[],
+    x: (d: T) => number,
+    y: (d: T) => number,
+  ): Quadtree<T>;
+}


### PR DESCRIPTION
## Phase C of strict-TS debt burn-down

Bridges `apps/web/src/lib/quadTreeIndex.ts` against `d3-quadtree` so it
compiles clean under `apps/web/tsconfig.json` strict mode.

### Root cause
The runtime `d3-quadtree` package ships pure JavaScript without bundled
type declarations, and `@types/d3-quadtree` is not installed. As a result,
TS7016 cascaded into 17 TS7006 implicit-any errors on every d3-quadtree
callback parameter (d, x1, y1, x2, y2, node, etc.).

### Fix
- Add `frontend/apps/web/src/types/d3-quadtree.d.ts` with the canonical
  DefinitelyTyped module declarations (`Quadtree<T>`, `QuadtreeLeaf<T>`,
  `QuadtreeInternalNode<T>`, `visit`/`visitAfter`/`add`/`find`/...).
- Type the visit callbacks in `quadTreeIndex.ts` against the new module,
  swapping the `let current = node as any` chains for
  `QuadtreeLeaf<QuadTreeNode>` so `.data` and `.next` are typed.

### Scope confirmation
`tsc --noEmit -p apps/web/tsconfig.json` on `quadTreeIndex.ts`:
- Before: 18 errors (1x TS7016, 17x TS7006)
- After: 0 errors

### Files
- A `frontend/apps/web/src/types/d3-quadtree.d.ts` (87 lines)
- M `frontend/apps/web/src/lib/quadTreeIndex.ts` (16 lines)

No other production code in scope is touched; types-only changes plus
the visit-loop type tightening. Uncommitted dirty-tree changes
(package.json, Badge.tsx, etc.) on the parent branch are NOT staged.