### PR TITLE
fix(frontend): include token in checkAuth() return shape (Phase D)

### DIFF
--- a/frontend/apps/web/src/lib/route-guards.ts
+++ b/frontend/apps/web/src/lib/route-guards.ts
@@ -124,6 +124,6 @@ export async function requireAdmin(options?: Pick<RouteGuardOptions, 'redirectTo
  * ```
  */
 export function checkAuth(): RouteGuardState {
-  const { isAuthenticated, user, account } = useAuthStore.getState();
-  return { isAuthenticated, user, account };
+  const { isAuthenticated, user, account, token } = useAuthStore.getState();
+  return { isAuthenticated, user, account, token };
 }


### PR DESCRIPTION
## Phase D of strict-TS debt burn-down

Resolves the one in-scope TS2741 (Property does not exist / is missing in
type) on the source-code files the burn-down targets.

### Root cause
`RouteGuardState` declares `{ account, isAuthenticated, token, user }`,
derived from `useAuthStore.getState()`'s return type. `checkAuth()` at
`apps/web/src/lib/route-guards.ts:128` destructured only
`{ isAuthenticated, user, account }`, producing TS2741 'Property
"token" is missing' under `apps/web/tsconfig.json` strict mode.

### Fix
Destructure and return `token` alongside the other three fields,
matching the contract already enforced by the interface. `checkAuth()` is
a read-only inspection helper; the token is already on the store, so this
is purely a type-shape correction with no runtime impact.

### Scope check (other sites flagged in the spec)

- **`CoverageMatrixView.tsx`** — already schema-conformant against
  `TraceabilityMatrix` / `CoverageGapsResponse` in
  `packages/types/src/types.ts:802` /`:819`. Property accesses
  (`matrix.matrix`, `matrix.coveragePercentage`, `gaps.gaps`,
  `gaps.uncoveredCount`) all match the schema. No fix required.

- **Store `*-store.ts` files** — the TS2339 'Property X does not exist
  on type Y' errors are concentrated in
  `apps/web/src/__tests__/stores/authStore*.test.ts` (test files),
  where stale tests call `state.login(...)` while `AuthStateActions`
  now exposes `loginWithCode`. Out of scope per the 'do not change
  unrelated code' constraint; trivially resolvable in a follow-up by
  either adding a `login: typeof loginWithCode` alias on
  `AuthStateActions` or updating the tests.

- **Unused `@ts-expect-error` directives** (5× TS2578 across
  stores/{auth,chat,graph-cache,project,ui}-store.ts) are Phase E
  territory per the burn-down table.

### Files
- M `frontend/apps/web/src/lib/route-guards.ts` (+2/-2)

`tsc --noEmit -p apps/web/tsconfig.json` errors after this change:
- `route-guards.ts`: 0 (was 1)