### PR TITLE
chore(web): adopt tokens.css palette library (5-family canonical)

### DIFF
--- a/frontend/apps/web/src/assets/tokens.css
+++ b/frontend/apps/web/src/assets/tokens.css
@@ -1,0 +1,131 @@
+/**
+ * tokens.css — shared visual identity palette library (vision-pillar).
+ *
+ * Source of truth for the 4 brand-family palettes across the 7 owned repos.
+ * Each token is referenced by `<repo>/.claude/audit/.vision/L96-L107.md`
+ * scorecards and can be vendored into per-repo CSS / Rust / SwiftUI palettes.
+ *
+ * Backbone-2 (infrastructure family — sharecli + substrate)
+ * Lab-Coat   (R&D family           — SessionLedger)
+ * Terminal-Forge (terminal family  — forgecode)
+ * Tracera    (trace family         — Tracera; pre-existing, kept for cohesion)
+ * MelosViz   (festival family      — MelosViz; pre-existing)
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="https://raw.githubusercontent.com/KooshaPari/AgilePlus/<sha>/.claude/worktrees/vision-pillar/assets/tokens.css">
+ *
+ * Or vendor into your repo as `assets/tokens.css` and import the family you need.
+ *
+ * Regeneration cadence:
+ *   tokens.css is a hand-authored single-file reference; not generated.
+ *   Update by editing this file + bumping the L107 scorecard entry per repo.
+ */
+
+:root {
+  /* ────────────────────────────────────────────────────────────
+   * BACKBONE-2 — sharecli + substrate (infra family)
+   * Decision: substrate-mesh, 2026-07-06
+   * Domain: process control + dispatch mesh
+   * ──────────────────────────────────────────────────────────── */
+  --bb2-graphite:        #0a0d12;  /* outer background */
+  --bb2-panel:           #161b22;  /* inset panel base (SHARED across family) */
+  --bb2-pulse-green:     #3fb950;  /* sharecli dominant — process heartbeat */
+  --bb2-sync-violet:     #a371f7;  /* substrate dominant — dispatch mesh */
+  --bb2-warm-amber:      #d29922;  /* cooldown/warning — single hot pixel */
+
+  /* ────────────────────────────────────────────────────────────
+   * LAB-COAT — SessionLedger (R&D family)
+   * Decision: vision-pillar proposed, 2026-07-06 (meloSviz-3d ack 2026-07-06)
+   * Domain: session-bundle compiler + Dioxus viewer
+   * Hex revision: amber-orange #f59e0b → orange-500 #f97316 on 2026-07-06
+   *   to avoid MelosViz --mv-warn hex collision (different semantics).
+   * ──────────────────────────────────────────────────────────── */
+  --lc-lab-white:        #f6f8fa;  /* primary background (lab-coat) */
+  --lc-slate:            #1f2937;  /* panel/text base */
+  --lc-cobalt:           #2563eb;  /* primary accent — slide-stain blue */
+  --lc-orange:           #f97316;  /* live-session — lit Bunsen burner */
+  --lc-teal:             #14b8a6;  /* secondary — growth-medium teal */
+
+  /* ────────────────────────────────────────────────────────────
+   * TERMINAL-FORGE — forgecode (terminal family)
+   * Decision: vision-pillar proposed, 2026-07-06
+   * Domain: agentic coding CLI/TUI
+   * Note: marked Phenotype-org addition per fork CLAUDE.md
+   * ──────────────────────────────────────────────────────────── */
+  --tf-deep-charcoal:    #0e0e10;  /* background */
+  --tf-deep-charcoal-2:  #1c1c1f;  /* window frame / panel secondary */
+  --tf-amber-crt:        #f5a623;  /* primary — CRT phosphor (F> prompt) */
+  --tf-synthwave:        #d946a8;  /* secondary — AI glow / spark */
+  --tf-mint-prompt:      #6ee7b7;  /* tertiary — CLI success / echo */
+
+  /* ────────────────────────────────────────────────────────────
+   * TRACERA — Tracera (trace family, pre-existing in repo brand)
+   * Source: assets/brand/icon.svg (Tracera repo)
+   * Domain: traceability analysis
+   * ──────────────────────────────────────────────────────────── */
+  --tr-midnight:         #090a0c;  /* outer background */
+  --tr-teal:             #7ebab5;  /* primary accent */
+  --tr-teal-dark:        #5a9aa6;  /* gradient mid */
+  --tr-indigo:           #6366f1;  /* gradient end / accent */
+  --tr-accent-light:     #a5b4fc;  /* diamond stroke */
+  --tr-grid:             #c7d2fe;  /* secondary glass */
+  --tr-glow:             #ffffff;  /* center dot */
+
+  /* ────────────────────────────────────────────────────────────
+   * MELOSVIZ — melosviz (festival family, pre-existing in repo brand)
+   * Source: melosviz/desktop/assets/brand/tokens.css
+   * Domain: festival visualizer
+   * ──────────────────────────────────────────────────────────── */
+  --mv-violet:           #a855f7;  /* primary accent — neon spectrum */
+  --mv-pink:             #ec4899;  /* gradient end */
+  --mv-amber:            #f59e0b;  /* spectral hue shift */
+  --mv-mint:             #10b981;  /* beat pulse */
+}
+
+/**
+ * Helper selectors — convenient per-family groupings.
+ * Use in a wrapper element: <div class="family-backbone-2">...</div>
+ */
+.family-backbone-2 {
+  --bg-primary: var(--bb2-graphite);
+  --bg-panel: var(--bb2-panel);
+  --accent-primary: var(--bb2-pulse-green);
+  --accent-secondary: var(--bb2-sync-violet);
+  --accent-warning: var(--bb2-warm-amber);
+}
+
+.family-lab-coat {
+  --bg-primary: var(--lc-lab-white);
+  --bg-panel: var(--lc-slate);
+  --accent-primary: var(--lc-cobalt);
+  --accent-secondary: var(--lc-teal);
+  --accent-warning: var(--lc-orange);
+}
+
+.family-terminal-forge {
+  --bg-primary: var(--tf-deep-charcoal);
+  --bg-panel: var(--tf-deep-charcoal-2);
+  --accent-primary: var(--tf-amber-crt);
+  --accent-secondary: var(--tf-synthwave);
+  --accent-tertiary: var(--tf-mint-prompt);
+}
+
+.family-tracera {
+  --bg-primary: var(--tr-midnight);
+  --accent-primary: var(--tr-teal);
+  --accent-secondary: var(--tr-indigo);
+}
+
+.family-melosviz {
+  --accent-primary: var(--mv-violet);
+  --accent-secondary: var(--mv-pink);
+  --accent-tertiary: var(--mv-amber);
+}
+
+/**
+ * Cross-family decision matrix (vision-pillar audit 2026-07-06).
+ * Each cell: accent primary → secondary → warning.
+ */
+:root {
+  --family-matrix: "Backbone-2(pulse-green → sync-violet → warm-amber) | Lab-Coat(cobalt → teal → orange-500) | Terminal-Forge(amber-crt → synthwave → mint-prompt) | Tracera(teal → indigo → accent-light) | MelosViz(violet → pink → amber)";
+}

--- a/frontend/apps/web/src/main.jsx
+++ b/frontend/apps/web/src/main.jsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+// Shared vision-pillar palette library (5-family cross-palette registry).
+// Vendored from /Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus/.claude/worktrees/vision-pillar/assets/tokens.css
+// Must be imported BEFORE ./index.css so :root vars here are available
+// to component overrides. Existing --color-* aliases in index.css remain
+// untouched for backward compat.
+import './assets/tokens.css'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
Vendors the canonical 5-family tokens.css (Backbone-2 / Lab-Coat / Terminal-Forge / Tracera / MelosViz) per vision-pillar L107 spec. main.jsx imports BEFORE index.css for cascade precedence. Existing --color-* aliases in index.css untouched for backward compat.

No AI trailer. GPG opt-out. Scope-fenced to web frontend only.