### PR TITLE
docs(readme): inject centered brand icon + tagline (L104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Tracera
+
+<p align="center">
+  <a href="assets/brand/icon.svg"><img src="assets/brand/icon.svg" alt="Tracera" width="160" height="160"></a>
+</p>
+<p align="center"><em>Hexagonal trace-link matrix for Agentic + LLM observability — Rust core, Python SDK, Electron desktop.</em></p>
+<p align="center"><sub>Tracera (navy + teal + indigo) palette · <a href="assets/brand/favicon.svg">favicon</a> · brand SVG ships in `tracera-splash` worktree</sub></p>
+
+---
+
+Tracera is the Phenotype-org **trace + observability + audit ledger** for
+agentic and LLM workflows. It captures structured trace-links across runs,
+distills short-term + long-term memory, and serves an Electron desktop
+viewer over OKF-bundled session history.
+
+## Where to start
+
+- Docs: see [`docs/01-getting-started/README.md`](docs/01-getting-started/README.md)
+- API reference: [`docs/06-api-reference/README.md`](docs/06-api-reference/README.md)
+- Governance: [`docs/governance/README.md`](docs/governance/README.md)
+- Self-hosted deploy: [`deploy/selfhost/README.md`](deploy/selfhost/README.md)
+
+## Repository layout
+
+- `src/` — Rust core (hexagonal: domain + adapters)
+- `crates/` — Cargo workspace members
+- `frontend/` — web app
+- `backend/` — Python SDK / service layer
+- `assets/brand/` — Tracera brand iconography (source of truth: `icon.svg`)
+- `audit/` — scorecard + L-pillar audit output
+
+## Build
+
+```bash
+# Rust workspace
+cargo build --workspace
+
+# Frontend
+cd frontend && bun install && bun run dev
+
+# Backend / API
+cd backend && uv sync && uv run pytest
+```
+
+See the getting-started guide for the full setup, including the
+desktop-app packaging recipe.


### PR DESCRIPTION
## What
Phase 3 of the vision-pillar rollout (L104) — **create** a top-level `README.md` with a centered brand icon + tagline, so the Tracera repo presents its visual identity on first render.

Tracera has no top-level `README.md` on `origin/main` — every consumer who clones the repo lands in an unkeyed directory listing. This PR adds the entry point.

## Files
- `README.md` — **created** (~46 LOC): centered `assets/brand/icon.svg` link, tagline, pointers to existing docs/06-api-reference, docs/01-getting-started, docs/governance, deploy/selfhost
- `assets/brand/icon.svg` — already on origin/main (vision-pillar + tracera-splash shipped)
- `assets/brand/favicon.svg` — already on origin/main

## Scope-fence
- Creates a file that didn't exist; does not modify any other file.
- Does not touch `assets/brand/`, `src/`, `crates/`, `frontend/`, or `backend/`.
- Does not touch `tokens.css` (it's not yet adopted in Tracera repo; `#735` wired the web frontend).

## Followup
- If `tracera-splash` PR (#738 / unmerged) lands first and adds `assets/brand/README.md`, this README's brand-pointer sub-line can be updated to point at it (one-line follow-up).
- Substrate / forgecode PRs (L104 counterpart) are blocked on their respective iconset merges; see the cross-team handoff queue.