### PR TITLE
feat(brand): L101 motion polish — animated SVG variant

### DIFF
--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,32 @@
+# Tracera Brand
+
+**AI-CODED, not AI-generated.** Keycap family — midnight `#090a0c` + teal `#7ebab5` with indigo
+accent. Vision-pillar L96 ships the static icon set; L101 ships the animated motion variant.
+
+## The mark
+
+Hexagonal trace-link matrix with a central requirement diamond — the requirement-graph view of
+Tracera in a single glyph.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `icon.svg` | Source of truth — static, hand-coded vector |
+| `icon-animated.svg` | L101 motion variant — SMIL teal wave + breathing core (no JavaScript) |
+| `favicon.svg` | Tab favicon (smaller variant) |
+
+## Regenerating
+
+Static raster exports derive from the SVG via the repo's brand-export script.
+
+## Motion variant (L101)
+
+`icon-animated.svg` ships a 4-second loop:
+
+- The teal→indigo gradient on the outer hexagon flows horizontally (`<animate>` on stop offsets).
+- The central requirement diamond breathes (scale 1 → 1.08 → 1).
+- Loop is seamless: last frame == first frame.
+
+All animation is SVG-native SMIL — no JavaScript, no external CSS. Safe to inline in HTML, SVG
+`<img src>`, README previews, and the Tracera desktop splash (Electrobun).

--- a/assets/brand/icon-animated.svg
+++ b/assets/brand/icon-animated.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Tracera brand icon — Animated motion variant (vision-pillar L101).
+  Companion to the static icon.svg.
+  Animation: a teal wave flows through the central diamond / hexagonal trace
+  matrix (offset gradient shift), and the requirement-diamond core breathes.
+  Loop: 4s seamless.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="Tracera (animated)">
+  <title>Tracera — animated</title>
+  <desc>Hexagonal trace-link matrix with flowing teal wave on the requirement diamond.</desc>
+
+  <defs>
+    <linearGradient id="tracera-flow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7ebab5">
+        <animate attributeName="offset" values="0;1;0" dur="4s" repeatCount="indefinite"/>
+      </stop>
+      <stop offset="50%" stop-color="#5a9aa6">
+        <animate attributeName="offset" values="0.5;1;0.5" dur="4s" repeatCount="indefinite"/>
+      </stop>
+      <stop offset="100%" stop-color="#6366f1">
+        <animate attributeName="offset" values="1;0;1" dur="4s" repeatCount="indefinite"/>
+      </stop>
+    </linearGradient>
+    <radialGradient id="tracera-glow" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#7ebab5" stop-opacity="0.55"/>
+      <stop offset="55%" stop-color="#6366f1" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#090a0c" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="tracera-core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="1"/>
+      <stop offset="60%" stop-color="#a5b4fc" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#6366f1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="tracera-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="6"/>
+      <feOffset dx="0" dy="4" result="off"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Midnight background -->
+  <rect width="512" height="512" rx="96" ry="96" fill="#090a0c"/>
+  <rect width="512" height="512" rx="96" ry="96" fill="url(#tracera-glow)"/>
+
+  <!-- Outer hexagon (flowing teal) -->
+  <polygon points="256,80 416,176 416,336 256,432 96,336 96,176"
+           fill="none" stroke="url(#tracera-flow)" stroke-width="14" stroke-linejoin="round" filter="url(#tracera-shadow)"/>
+
+  <!-- Inner hex trace lines -->
+  <g stroke="#7ebab5" stroke-opacity="0.4" stroke-width="2" fill="none">
+    <line x1="256" y1="80" x2="256" y2="256"/>
+    <line x1="416" y1="176" x2="256" y2="256"/>
+    <line x1="416" y1="336" x2="256" y2="256"/>
+    <line x1="256" y1="432" x2="256" y2="256"/>
+    <line x1="96" y1="336" x2="256" y2="256"/>
+    <line x1="96" y1="176" x2="256" y2="256"/>
+  </g>
+
+  <!-- Requirement diamond (breathing core) -->
+  <g transform-origin="256 256">
+    <animateTransform attributeName="transform" attributeType="XML"
+                      type="scale" values="1;1.08;1" dur="4s" repeatCount="indefinite"
+                      additive="sum"/>
+    <polygon points="256,196 316,256 256,316 196,256"
+             fill="url(#tracera-core)" stroke="#7ebab5" stroke-width="3"/>
+  </g>
+
+  <!-- Hex node dots -->
+  <g fill="#7ebab5">
+    <circle cx="256" cy="80" r="6"/>
+    <circle cx="416" cy="176" r="6"/>
+    <circle cx="416" cy="336" r="6"/>
+    <circle cx="256" cy="432" r="6"/>
+    <circle cx="96" cy="336" r="6"/>
+    <circle cx="96" cy="176" r="6"/>
+  </g>
+</svg>


### PR DESCRIPTION
## L101 motion polish (vision-pillar Tier-3)

Companion to L96 static icon. Adds a SMIL-driven animated motion variant.

### Changes
- **NEW** `assets/brand/icon-animated.svg` — teal wave flowing through hexagon + breathing requirement-diamond core (4s loop, SMIL only, no JS)
- **NEW** `assets/brand/README.md` — family-position + motion-variant section
- Static `icon.svg` (L96) untouched

### Scope-fence
~80 LOC. Brand-asset scope only. No changes to source, dependencies, or CI.

### Animation spec
- 4s seamless loop
- Teal→indigo gradient flows horizontally across the outer hexagon (offset stops animate)
- Central requirement diamond breathes (scale 1 → 1.08 → 1)
- SVG-native SMIL — safe for HTML inline, SVG `<img src>`, README previews, and Tracera desktop splash (Electrobun)

vision-pillar L101 — Tier-3 deferral polish