### PR TITLE
fix(ci): make nightly smoke self-contained and secret-safe

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,10 +16,24 @@ jobs:
         run: cargo build --locked --release -p tracera-server
       - name: Smoke test endpoints
         run: |
-          ./target/release/tracera-server &
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          DATABASE_URL="sqlite://${tmp_dir}/tracera.db?mode=rwc" \
+          TRACERA_BIND_ADDR="127.0.0.1:18080" \
+          RUST_LOG=tracera_server=warn \
+            ./target/release/tracera-server >/tmp/tracera-nightly.log 2>&1 &
           SRV=$!
-          sleep 3
-          curl -fsS http://127.0.0.1:8080/health
-          curl -fsS http://127.0.0.1:8080/ready
-          curl -fsS -X POST http://127.0.0.1:8080/api/v1/coverage-matrix -H 'content-type: application/json' -d '{"links":[]}'
-          kill $SRV
+          cleanup() {
+            kill "${SRV}" 2>/dev/null || true
+            wait "${SRV}" 2>/dev/null || true
+            rm -rf "${tmp_dir}"
+          }
+          trap cleanup EXIT
+          for _ in $(seq 1 50); do
+            curl --silent --fail http://127.0.0.1:18080/health >/dev/null && break
+            sleep 0.1
+          done
+          curl --silent --fail http://127.0.0.1:18080/health
+          curl --silent --fail http://127.0.0.1:18080/ready
+          curl --silent --fail -X POST http://127.0.0.1:18080/api/v1/coverage-matrix \
+            -H 'content-type: application/json' -d '{"links":[]}'

--- a/docs/04-guides/DEPLOYMENT_GUIDE.md
+++ b/docs/04-guides/DEPLOYMENT_GUIDE.md
@@ -96,7 +96,8 @@ REDIS_URL=redis://host:6379
 LOG_LEVEL=INFO
 API_HOST=0.0.0.0
 API_PORT=8000
-TRACERA_JWT_SECRET=<production-secret>
+# Inject this value from the deployment secret manager; never commit a literal.
+TRACERA_JWT_SECRET="${TRACERA_JWT_SECRET:?set via the deployment secret manager}"
 TRACERA_JWT_AUDIENCE=tracera-api
 TRACERA_JWT_ISSUER=tracera
 ```


### PR DESCRIPTION
## **User description**
## Summary
- provision a disposable SQLite DATABASE_URL and loopback port for nightly build-smoke
- wait for health before readiness and endpoint probes; clean up server/temp DB
- replace the literal JWT placeholder that gitleaks flags with secret-manager injection syntax

## Evidence
- cargo deny check advisories licenses bans sources: pass locally (yanked spin remains warning)
- gitleaks detect --no-banner --redact --log-opts=-1: no leaks found
- nightly workflow YAML parses successfully

## Remaining owner gates
- frontend/bun.lock is out of sync with manifests on main; existing PR #774 owns that lockfile update
- OSV reports current dependency advisories requiring dependency-owner decisions; this PR does not suppress them
- branch protection/review required; do not merge without hosted checks.


___

## **CodeAnt-AI Description**
Make nightly smoke tests self-contained and keep deployment secrets out of configuration

### What Changed
- Nightly smoke tests now use a temporary SQLite database and a dedicated loopback port instead of relying on external services or the default port
- Tests wait for the server to become healthy before checking readiness and the coverage endpoint
- The smoke-test server and temporary database are cleaned up automatically, including after failures
- Deployment guidance now requires the JWT secret to come from a secret manager rather than a committed literal

### Impact
`✅ More reliable nightly smoke tests`
`✅ Fewer test-environment conflicts`
`✅ Safer deployment secret handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
