### PR TITLE
feat(tracera): persist verified benchmark replays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Gitleaks scans the complete PR commit range; a shallow checkout
+          # can omit the base SHA and make the scan fail before inspection.
+          fetch-depth: 0
       - name: gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: '1.1.38'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         if: ${{ env.HAS_VERCEL_TOKEN != '' && env.HAS_VERCEL_ORG != '' && env.HAS_VERCEL_PROJECT != '' }}
         with:
-          bun-version: latest
+          bun-version: '1.1.38'
 
       - name: Validate and stage API base for Vercel build
         if: ${{ env.HAS_VERCEL_TOKEN != '' && env.HAS_VERCEL_ORG != '' && env.HAS_VERCEL_PROJECT != '' }}

--- a/.github/workflows/frontend-contract-checks.yml
+++ b/.github/workflows/frontend-contract-checks.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
-          bun-version: latest
+          bun-version: '1.1.38'
 
       - name: Install frontend deps
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,10 +16,24 @@ jobs:
         run: cargo build --locked --release -p tracera-server
       - name: Smoke test endpoints
         run: |
-          ./target/release/tracera-server &
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          DATABASE_URL="sqlite://${tmp_dir}/tracera.db?mode=rwc" \
+          TRACERA_BIND_ADDR="127.0.0.1:18080" \
+          RUST_LOG=tracera_server=warn \
+            ./target/release/tracera-server >/tmp/tracera-nightly.log 2>&1 &
           SRV=$!
-          sleep 3
-          curl -fsS http://127.0.0.1:8080/health
-          curl -fsS http://127.0.0.1:8080/ready
-          curl -fsS -X POST http://127.0.0.1:8080/api/v1/coverage-matrix -H 'content-type: application/json' -d '{"links":[]}'
-          kill $SRV
+          cleanup() {
+            kill "${SRV}" 2>/dev/null || true
+            wait "${SRV}" 2>/dev/null || true
+            rm -rf "${tmp_dir}"
+          }
+          trap cleanup EXIT
+          for _ in $(seq 1 50); do
+            curl --silent --fail http://127.0.0.1:18080/health >/dev/null && break
+            sleep 0.1
+          done
+          curl --silent --fail http://127.0.0.1:18080/health
+          curl --silent --fail http://127.0.0.1:18080/ready
+          curl --silent --fail -X POST http://127.0.0.1:18080/api/v1/coverage-matrix \
+            -H 'content-type: application/json' -d '{"links":[]}'

--- a/.github/workflows/runtime-latency-smoke.yml
+++ b/.github/workflows/runtime-latency-smoke.yml
@@ -33,7 +33,7 @@ jobs:
           toolchain: stable
       - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
-          bun-version: latest
+          bun-version: '1.1.38'
       - name: Build frontend bundle
         working-directory: frontend
         run: bun install --frozen-lockfile --ignore-scripts && npm run build

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,8 +20,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    security:
-      permissions: read-all
+    permissions: read-all
 
     steps:
       - name: Checkout

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,12 +5,12 @@ pull_request_rules:
   # Auto-merge when all CI checks pass and PR is approved
   - name: Auto-merge when approved + CI green
     conditions:
-      - "#review-requested=0"
-      - "#approved-reviews-by>=1"
-      - check-success=ci
-      - check-success=lint
-      - check-success=typecheck
-      - check-success=test
+      - "#review-requested = 0"
+      - "#approved-reviews-by >= 1"
+      - check-success = ci
+      - check-success = lint
+      - check-success = typecheck
+      - check-success = test
       - -conflict
       - -closed
     actions:
@@ -20,14 +20,14 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge dependabot/Renovate PRs when CI passes
   - name: Auto-merge dependency updates
     conditions:
-      - author=dependabot[bot] | renovate[bot]
-      - check-success=ci
+      - or:
+          - author = dependabot[bot]
+          - author = renovate[bot]
+      - check-success = ci
       - -conflict
       - -closed
     actions:
@@ -37,15 +37,16 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge bot PRs (CI configs, formatting) when CI passes
   - name: Auto-merge bot housekeeping PRs
     conditions:
-      - author=trunk-io[bot] | mergify[bot] | github-actions[bot]
-      - check-success=ci
-      - check-success=lint
+      - or:
+          - author = trunk-io[bot]
+          - author = mergify[bot]
+          - author = github-actions[bot]
+      - check-success = ci
+      - check-success = lint
       - -conflict
       - -closed
     actions:
@@ -61,13 +62,13 @@ pull_request_rules:
       request_reviews:
         teams:
           - phenotype/core
-        github_accounts:
+        users:
           - KooshaPari
 
   # Label PRs based on changed files
   - name: Label Python changes
     conditions:
-      - files~=\.py$
+      - files ~= \.py$
     actions:
       label:
         add:
@@ -75,7 +76,7 @@ pull_request_rules:
 
   - name: Label Rust changes
     conditions:
-      - files~=\.rs$|Cargo\.
+      - files ~= \.rs$|Cargo\.
     actions:
       label:
         add:
@@ -83,7 +84,7 @@ pull_request_rules:
 
   - name: Label Go changes
     conditions:
-      - files~=\.go$|go\.
+      - files ~= \.go$|go\.
     actions:
       label:
         add:
@@ -91,7 +92,7 @@ pull_request_rules:
 
   - name: Label TypeScript changes
     conditions:
-      - files~=\.ts$|\.tsx$|package\.json
+      - files ~= \.ts$|\.tsx$|package\.json
     actions:
       label:
         add:
@@ -102,8 +103,8 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - age>=30d
-      - "#review-requested=0"
+      - updated-at < 30 days ago
+      - "#review-requested = 0"
     actions:
       comment:
         message: >
@@ -116,7 +117,7 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - "#files>20"
+      - "#files > 20"
     actions:
       comment:
         message: >
@@ -128,10 +129,10 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - check-success=ci
-      - check-success=lint
-      - check-success=test
-      - "#approved-reviews-by>=1"
+      - check-success = ci
+      - check-success = lint
+      - check-success = test
+      - "#approved-reviews-by >= 1"
     actions:
       label:
         add:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +480,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +559,31 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -568,6 +642,12 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1352,6 +1432,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1584,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -1602,6 +1701,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1751,6 +1859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +2006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +2046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2203,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2450,7 +2583,9 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "ed25519-dalek",
  "http",
+ "rand_core 0.6.4",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +518,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -533,6 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -2590,6 +2597,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror 2.0.19",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ authors = ["kooshapari"]
 [workspace.dependencies]
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
+ed25519-dalek = { version = "2", features = ["rand_core"] }
 indexmap = { version = "2", features = ["serde"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"

--- a/crates/tracera-server/Cargo.toml
+++ b/crates/tracera-server/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.13", features = ["json", "rustls", "rustls-native-certs
 regex = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 sqlx = { version = "0.9", features = ["postgres", "sqlite", "runtime-tokio", "macros", "uuid", "chrono", "migrate"] }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }

--- a/crates/tracera-server/Cargo.toml
+++ b/crates/tracera-server/Cargo.toml
@@ -18,6 +18,7 @@ phenodag-queue = []
 axum = "0.8"
 base64 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
+ed25519-dalek = { workspace = true }
 http = "1"
 # wraps: reqwest 0.13
 reqwest = { version = "0.13", features = ["json", "rustls", "rustls-native-certs"], default-features = false }
@@ -34,5 +35,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
+rand_core = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/tracera-server/migrations-sqlite/0009_create_benchmark_runs.sql
+++ b/crates/tracera-server/migrations-sqlite/0009_create_benchmark_runs.sql
@@ -1,0 +1,19 @@
+-- Verified replay-v2 provenance. Revert with:
+-- DROP TABLE IF EXISTS benchmark_runs;
+CREATE TABLE IF NOT EXISTS benchmark_runs (
+    run_id           TEXT PRIMARY KEY,
+    session_id       TEXT NOT NULL,
+    attempt_id       TEXT NOT NULL,
+    schema_version   TEXT NOT NULL,
+    replay_hash      TEXT NOT NULL UNIQUE,
+    outcome_sha256   TEXT NOT NULL,
+    key_id           TEXT NOT NULL,
+    signature_digest TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    metadata         TEXT NOT NULL DEFAULT '{}',
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_benchmark_runs_created_at
+    ON benchmark_runs (created_at);

--- a/crates/tracera-server/migrations/0009_create_benchmark_runs.sql
+++ b/crates/tracera-server/migrations/0009_create_benchmark_runs.sql
@@ -1,0 +1,19 @@
+-- Verified replay-v2 provenance. Revert with:
+-- DROP TABLE IF EXISTS benchmark_runs;
+CREATE TABLE IF NOT EXISTS benchmark_runs (
+    run_id           TEXT PRIMARY KEY,
+    session_id       TEXT NOT NULL,
+    attempt_id       TEXT NOT NULL,
+    schema_version   TEXT NOT NULL,
+    replay_hash      TEXT NOT NULL UNIQUE,
+    outcome_sha256   TEXT NOT NULL,
+    key_id           TEXT NOT NULL,
+    signature_digest TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    metadata         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at       TIMESTAMPTZ NOT NULL,
+    updated_at       TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_benchmark_runs_created_at
+    ON benchmark_runs (created_at);

--- a/crates/tracera-server/src/ingest.rs
+++ b/crates/tracera-server/src/ingest.rs
@@ -73,13 +73,6 @@ pub struct NormalisedIssue {
 
 /// Map a Helios benchmark envelope into the existing story/evidence ingest path.
 /// The envelope remains content-addressed through its outcome/replay hashes.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "public ingest adapter exercised by contract and integration callers"
-    )
-)]
 pub fn benchmark_run_to_issue(envelope: &Value) -> Result<NormalisedIssue, IngestError> {
     let run_id = envelope
         .get("run_id")

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -2,6 +2,7 @@ mod db;
 mod health;
 mod ingest;
 mod pg_store;
+mod replay;
 #[cfg(feature = "phenodag-queue")]
 mod queue;
 mod sqlite_store;

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -2,9 +2,9 @@ mod db;
 mod health;
 mod ingest;
 mod pg_store;
-mod replay;
 #[cfg(feature = "phenodag-queue")]
 mod queue;
+mod replay;
 mod sqlite_store;
 mod store;
 mod validation;
@@ -46,7 +46,7 @@ use validation::{
     MAX_SHORT_TEXT_CHARS, MAX_URL_CHARS,
 };
 
-use store::{EvidenceItem, Problem, Sprint, Store, Story, TeamRow};
+use store::{BenchmarkRun, EvidenceItem, Problem, Sprint, Store, Story, TeamRow};
 
 // ---------------------------------------------------------------------------
 // App state — Arc<dyn Store> replaces the bare PgPool.
@@ -62,6 +62,7 @@ struct AppState {
     backend: &'static str,
     started_at: Instant,
     store: Arc<dyn Store>,
+    replay_keyring: replay::PublicKeyring,
 }
 
 // ---------------------------------------------------------------------------
@@ -484,11 +485,17 @@ async fn main() {
             std::process::exit(1);
         };
 
+    let replay_keyring = replay::PublicKeyring::from_env().unwrap_or_else(|error| {
+        eprintln!("FATAL: invalid TRACERA_REPLAY_PUBLIC_KEYS_JSON: {error}");
+        std::process::exit(1);
+    });
+
     let state = AppState {
         version: env!("CARGO_PKG_VERSION").to_string(),
         backend,
         started_at: Instant::now(),
         store,
+        replay_keyring,
     };
 
     let app = build_router(state);
@@ -536,12 +543,13 @@ fn build_router(state: AppState) -> Router {
         .route("/api/v1/confidence", post(confidence))
         .route("/api/v1/blast-radius", post(blast_radius))
         .route("/api/v1/governance/spec-check", post(spec_check))
-        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
-        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/api/v1/trace/forward/{artifact_id}", post(trace_forward))
+        .route("/api/v1/trace/reverse/{artifact_id}", post(trace_reverse))
         .route("/evidence", get(list_evidence).post(create_evidence))
         .route("/evidence/health", get(health::health))
         .route("/ingest/github", post(ingest_github))
         .route("/ingest/jira", post(ingest_jira))
+        .route("/ingest/benchmark", post(ingest_benchmark))
         .route("/sdlc-pm/health", get(health::health))
         .route("/sdlc-pm/sprints", get(list_sprints).post(create_sprint))
         .route("/sdlc-pm/stories", get(list_stories))
@@ -1170,6 +1178,138 @@ async fn ingest_jira(
     (axum::http::StatusCode::OK, Json(result))
 }
 
+/// POST /ingest/benchmark
+///
+/// Accepts only an Ed25519-signed replay-v2 envelope.  The verifier runs
+/// before the existing benchmark mapper and Store write, so no unverified
+/// replay, signature, or outcome metadata reaches persistence.
+async fn ingest_benchmark(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Json(envelope): Json<Value>,
+) -> Result<
+    (axum::http::StatusCode, Json<BenchmarkRun>),
+    (axum::http::StatusCode, Json<ErrorResponse>),
+> {
+    let verified = replay::verify_benchmark_envelope(&envelope, &state.replay_keyring)
+        .map_err(benchmark_verification_error)?;
+    ingest::benchmark_run_to_issue(&envelope).map_err(|error| {
+        tracing::warn!("benchmark replay mapper rejected verified envelope: {error}");
+        bad_request("invalid benchmark envelope")
+    })?;
+
+    let run_id = benchmark_required_string(&envelope, "run_id")?;
+    let session_id = benchmark_required_string(&envelope, "session_id")?;
+    let attempt_id = benchmark_required_string(&envelope, "attempt_id")?;
+    let outcome_sha256 = envelope
+        .pointer("/result/outcome_sha256")
+        .and_then(Value::as_str)
+        .filter(|hash| is_sha256_hex(hash))
+        .ok_or_else(|| bad_request("invalid result.outcome_sha256"))?
+        .to_string();
+    let status = envelope
+        .pointer("/result/status")
+        .and_then(Value::as_str)
+        .ok_or_else(|| bad_request("invalid result.status"))?
+        .to_string();
+
+    if let Some(existing) = state
+        .store
+        .get_benchmark_run(run_id.clone())
+        .await
+        .map_err(benchmark_store_error)?
+    {
+        if existing.replay_hash == verified.replay_hash {
+            return Ok((axum::http::StatusCode::OK, Json(existing)));
+        }
+        return Err((
+            axum::http::StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: "benchmark run_id conflicts with a different replay_hash",
+            }),
+        ));
+    }
+
+    let metadata = serde_json::json!({
+        "verification": {
+            "schema_version": "2.0.0",
+            "replay_hash": verified.replay_hash.clone(),
+            "outcome_sha256": outcome_sha256.clone(),
+            "key_id": verified.key_id.clone(),
+            "signature_digest": verified.signature_digest.clone(),
+        }
+    });
+    let record = state
+        .store
+        .create_benchmark_run(
+            run_id.clone(),
+            session_id,
+            attempt_id,
+            "2.0.0".to_string(),
+            verified.replay_hash,
+            outcome_sha256,
+            verified.key_id,
+            verified.signature_digest,
+            status,
+            metadata,
+            Utc::now(),
+        )
+        .await
+        .map_err(benchmark_store_error)?;
+    let status = if record.run_id == run_id {
+        axum::http::StatusCode::CREATED
+    } else {
+        axum::http::StatusCode::OK
+    };
+    Ok((status, Json(record)))
+}
+
+fn benchmark_required_string(
+    envelope: &Value,
+    field: &'static str,
+) -> Result<String, (axum::http::StatusCode, Json<ErrorResponse>)> {
+    envelope
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| bad_request("invalid benchmark envelope"))
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn benchmark_verification_error(
+    error: replay::VerificationError,
+) -> (axum::http::StatusCode, Json<ErrorResponse>) {
+    let status = match error {
+        replay::VerificationError::UnknownKey(_) => axum::http::StatusCode::UNAUTHORIZED,
+        replay::VerificationError::ReplayHashMismatch { .. } => {
+            axum::http::StatusCode::UNPROCESSABLE_ENTITY
+        }
+        _ => axum::http::StatusCode::BAD_REQUEST,
+    };
+    tracing::warn!("benchmark replay verification rejected envelope: {error}");
+    (
+        status,
+        Json(ErrorResponse {
+            error: "benchmark replay verification failed",
+        }),
+    )
+}
+
+fn benchmark_store_error(
+    error: store::StoreError,
+) -> (axum::http::StatusCode, Json<ErrorResponse>) {
+    tracing::error!("benchmark replay persistence failed: {error}");
+    (
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            error: "benchmark replay persistence failed",
+        }),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Pure-function utilities (no DB interaction — unit-testable without a store)
 // ---------------------------------------------------------------------------
@@ -1287,9 +1427,128 @@ fn default_max_depth() -> u32 {
 mod tests {
     use super::*;
     use axum::body::Body;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
     use chrono::TimeZone;
+    use ed25519_dalek::{Signer, SigningKey};
     use http::{Request, StatusCode};
+    use rand_core::OsRng;
     use tower::ServiceExt;
+
+    fn signed_benchmark_envelope() -> (Value, replay::PublicKeyring, SigningKey) {
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let identity = "a".repeat(64);
+        let events = serde_json::json!([{
+            "type": "run_started",
+            "seq": 0,
+            "details": {"suite": "signed-replay"}
+        }]);
+        let mut envelope = serde_json::json!({
+            "schema_version": "2.0.0",
+            "run_id": format!("run_{identity}"),
+            "session_id": format!("ses_{identity}"),
+            "attempt_id": format!("att_{identity}"),
+            "events": events,
+            "result": {
+                "status": "passed",
+                "outcome_sha256": "b".repeat(64),
+                "replay_hash": replay::replay_hash(&events).expect("events hash")
+            }
+        });
+        sign_benchmark_envelope(&mut envelope, &signing_key);
+        let keyring = replay::PublicKeyring::from_json_str(
+            &serde_json::json!({
+                "test-producer": STANDARD.encode(signing_key.verifying_key().to_bytes())
+            })
+            .to_string(),
+        )
+        .expect("test keyring");
+        (envelope, keyring, signing_key)
+    }
+
+    fn sign_benchmark_envelope(envelope: &mut Value, signing_key: &SigningKey) {
+        let signature =
+            signing_key.sign(&replay::signed_envelope_bytes(envelope).expect("unsigned envelope"));
+        envelope["signature"] = serde_json::json!({
+            "algorithm": "ed25519",
+            "key_id": "test-producer",
+            "signature_b64": STANDARD.encode(signature.to_bytes())
+        });
+    }
+
+    async fn replay_app(keyring: replay::PublicKeyring) -> Router {
+        build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(make_sqlite_store().await),
+            replay_keyring: keyring,
+        })
+    }
+
+    async fn post_benchmark(app: Router, envelope: &Value) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/ingest/benchmark")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(envelope).expect("benchmark JSON"),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+    }
+
+    #[tokio::test]
+    async fn benchmark_ingest_persists_verified_envelope_and_is_idempotent() {
+        let (envelope, keyring, _) = signed_benchmark_envelope();
+        let app = replay_app(keyring).await;
+
+        let created = post_benchmark(app.clone(), &envelope).await;
+        assert_eq!(created.status(), StatusCode::CREATED);
+        let created_body = axum::body::to_bytes(created.into_body(), 4096)
+            .await
+            .expect("created benchmark body");
+        let record: Value = serde_json::from_slice(&created_body).expect("created benchmark JSON");
+        assert_eq!(record["key_id"], "test-producer");
+        assert_eq!(record["schema_version"], "2.0.0");
+        assert_eq!(
+            record["metadata"]["verification"]["key_id"],
+            "test-producer"
+        );
+        let duplicate = post_benchmark(app, &envelope).await;
+        assert_eq!(duplicate.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn benchmark_ingest_rejects_tampered_signature() {
+        let (mut envelope, keyring, _) = signed_benchmark_envelope();
+        envelope["events"][0]["details"]["suite"] = Value::String("tampered".to_string());
+        let response = post_benchmark(replay_app(keyring).await, &envelope).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn benchmark_ingest_rejects_unknown_key() {
+        let (mut envelope, _, _) = signed_benchmark_envelope();
+        envelope["signature"]["key_id"] = Value::String("unknown-producer".to_string());
+        let response = post_benchmark(
+            replay_app(replay::PublicKeyring::default()).await,
+            &envelope,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn benchmark_ingest_rejects_re_signed_hash_mismatch() {
+        let (mut envelope, keyring, signing_key) = signed_benchmark_envelope();
+        envelope["result"]["replay_hash"] = Value::String("c".repeat(64));
+        sign_benchmark_envelope(&mut envelope, &signing_key);
+        let response = post_benchmark(replay_app(keyring).await, &envelope).await;
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
 
     #[tokio::test]
     async fn api_router_emits_readiness_and_security_contract() {
@@ -1299,6 +1558,7 @@ mod tests {
             backend: "sqlite",
             started_at: Instant::now(),
             store: Arc::new(store),
+            replay_keyring: replay::PublicKeyring::default(),
         });
 
         let response = app
@@ -1329,6 +1589,7 @@ mod tests {
             backend: "sqlite",
             started_at: Instant::now(),
             store: Arc::new(store),
+            replay_keyring: replay::PublicKeyring::default(),
         });
 
         let malformed = app
@@ -1392,6 +1653,7 @@ mod tests {
             backend: "sqlite",
             started_at: Instant::now(),
             store: Arc::new(store),
+            replay_keyring: replay::PublicKeyring::default(),
         });
 
         let response = app
@@ -1426,6 +1688,7 @@ mod tests {
             backend: "sqlite",
             started_at: Instant::now(),
             store: Arc::new(make_sqlite_store().await),
+            replay_keyring: replay::PublicKeyring::default(),
         };
         let ready = health::readyz(axum::extract::State(state)).await.0;
         assert_eq!(ready.status, "ready");
@@ -1896,6 +2159,10 @@ mod tests {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:")
             .await
             .expect("open in-memory SQLite");
+        sqlx::migrate!("./migrations-sqlite")
+            .run(&pool)
+            .await
+            .expect("apply SQLite migrations");
         // Apply SQLite migrations manually using the embedded SQL
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS evidence (

--- a/crates/tracera-server/src/pg_store.rs
+++ b/crates/tracera-server/src/pg_store.rs
@@ -10,8 +10,8 @@ use serde_json::Value;
 use sqlx::{PgPool, Row};
 
 use crate::store::{
-    BoxFuture, EvidenceItem, Problem, Sprint, Store, StoreError, StoreResult, Story, TeamRow,
-    TraceLink,
+    BenchmarkRun, BoxFuture, EvidenceItem, Problem, Sprint, Store, StoreError, StoreResult, Story,
+    TeamRow, TraceLink,
 };
 
 #[derive(Clone)]
@@ -22,6 +22,20 @@ pub struct PgStore {
 impl PgStore {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
+    }
+
+    fn get_benchmark_run_by_replay_hash(
+        &self,
+        replay_hash: String,
+    ) -> BoxFuture<'_, StoreResult<Option<BenchmarkRun>>> {
+        Box::pin(async move {
+            let row = sqlx::query("SELECT run_id, session_id, attempt_id, schema_version, replay_hash, outcome_sha256, key_id, signature_digest, status, metadata::text, created_at, updated_at FROM benchmark_runs WHERE replay_hash = $1")
+            .bind(replay_hash)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+            Ok(row.map(pg_row_to_benchmark_run))
+        })
     }
 }
 
@@ -304,6 +318,82 @@ impl Store for PgStore {
         })
     }
 
+    fn get_benchmark_run(
+        &self,
+        run_id: String,
+    ) -> BoxFuture<'_, StoreResult<Option<BenchmarkRun>>> {
+        Box::pin(async move {
+            let row = sqlx::query(
+                "SELECT run_id, session_id, attempt_id, schema_version, replay_hash, \
+                 outcome_sha256, key_id, signature_digest, status, metadata::text, created_at, updated_at \
+                 FROM benchmark_runs WHERE run_id = $1",
+            )
+            .bind(&run_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+            Ok(row.map(pg_row_to_benchmark_run))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_benchmark_run(
+        &self,
+        run_id: String,
+        session_id: String,
+        attempt_id: String,
+        schema_version: String,
+        replay_hash: String,
+        outcome_sha256: String,
+        key_id: String,
+        signature_digest: String,
+        status: String,
+        metadata: Value,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<BenchmarkRun>> {
+        Box::pin(async move {
+            if let Some(existing) = self.get_benchmark_run(run_id.clone()).await? {
+                if existing.replay_hash != replay_hash {
+                    return Err(StoreError::Database(
+                        "benchmark run_id already exists with a different replay_hash".to_string(),
+                    ));
+                }
+                return Ok(existing);
+            }
+
+            let metadata_str =
+                serde_json::to_string(&metadata).unwrap_or_else(|_| "{}".to_string());
+            sqlx::query(
+                "INSERT INTO benchmark_runs \
+                 (run_id, session_id, attempt_id, schema_version, replay_hash, outcome_sha256, \
+                  key_id, signature_digest, status, metadata, created_at, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12) \
+                 ON CONFLICT DO NOTHING",
+            )
+            .bind(&run_id)
+            .bind(&session_id)
+            .bind(&attempt_id)
+            .bind(&schema_version)
+            .bind(&replay_hash)
+            .bind(&outcome_sha256)
+            .bind(&key_id)
+            .bind(&signature_digest)
+            .bind(&status)
+            .bind(&metadata_str)
+            .bind(now)
+            .bind(now)
+            .execute(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            self.get_benchmark_run_by_replay_hash(replay_hash)
+                .await?
+                .ok_or_else(|| {
+                    StoreError::Database("benchmark run insert returned no row".to_string())
+                })
+        })
+    }
+
     // -----------------------------------------------------------------------
     // Problems (ITIL) — Postgres implementations
     // -----------------------------------------------------------------------
@@ -497,5 +587,24 @@ fn pg_row_to_problem(r: sqlx::postgres::PgRow) -> Problem {
         created_at: r.try_get("created_at").unwrap_or_else(|_| Utc::now()),
         updated_at: r.try_get("updated_at").unwrap_or_else(|_| Utc::now()),
         deleted_at: r.try_get("deleted_at").ok().flatten(),
+    }
+}
+
+fn pg_row_to_benchmark_run(r: sqlx::postgres::PgRow) -> BenchmarkRun {
+    let metadata_str: String = r.try_get("metadata").unwrap_or_else(|_| "{}".to_string());
+    let metadata = serde_json::from_str(&metadata_str).unwrap_or(Value::Object(Default::default()));
+    BenchmarkRun {
+        run_id: r.try_get("run_id").unwrap_or_default(),
+        session_id: r.try_get("session_id").unwrap_or_default(),
+        attempt_id: r.try_get("attempt_id").unwrap_or_default(),
+        schema_version: r.try_get("schema_version").unwrap_or_default(),
+        replay_hash: r.try_get("replay_hash").unwrap_or_default(),
+        outcome_sha256: r.try_get("outcome_sha256").unwrap_or_default(),
+        key_id: r.try_get("key_id").unwrap_or_default(),
+        signature_digest: r.try_get("signature_digest").unwrap_or_default(),
+        status: r.try_get("status").unwrap_or_default(),
+        metadata,
+        created_at: r.try_get("created_at").unwrap_or_else(|_| Utc::now()),
+        updated_at: r.try_get("updated_at").unwrap_or_else(|_| Utc::now()),
     }
 }

--- a/crates/tracera-server/src/replay.rs
+++ b/crates/tracera-server/src/replay.rs
@@ -1,0 +1,176 @@
+//! Replay-v2 verification primitives.
+//!
+//! This slice owns only the public-key keyring boundary.  Private signing
+//! material never crosses into Tracera; producers publish a JSON object of
+//! key IDs to canonical base64-encoded Ed25519 public keys.
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ed25519_dalek::VerifyingKey;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+const KEYRING_ENV: &str = "TRACERA_REPLAY_PUBLIC_KEYS_JSON";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyringError {
+    InvalidJson(String),
+    InvalidKeyId(String),
+    InvalidKeyEncoding(String),
+}
+
+impl std::fmt::Display for KeyringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidJson(message) => write!(f, "invalid replay public-key JSON: {message}"),
+            Self::InvalidKeyId(message) => write!(f, "invalid replay key_id: {message}"),
+            Self::InvalidKeyEncoding(message) => {
+                write!(f, "invalid replay public-key encoding: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KeyringError {}
+
+/// Rotation-safe Ed25519 public keys indexed by stable producer key IDs.
+#[derive(Clone, Default)]
+pub struct PublicKeyring {
+    keys: BTreeMap<String, VerifyingKey>,
+}
+
+impl PublicKeyring {
+    /// Load the keyring from `TRACERA_REPLAY_PUBLIC_KEYS_JSON`.
+    ///
+    /// Missing or blank configuration yields an empty keyring so existing
+    /// non-replay routes can start; replay verification remains fail-closed
+    /// because an empty keyring cannot resolve any producer key ID.
+    pub fn from_env() -> Result<Self, KeyringError> {
+        match std::env::var(KEYRING_ENV) {
+            Ok(raw) if !raw.trim().is_empty() => Self::from_json_str(&raw),
+            _ => Ok(Self::default()),
+        }
+    }
+
+    /// Parse a JSON object shaped as `{ "key-id": "base64-public-key" }`.
+    pub fn from_json_str(raw: &str) -> Result<Self, KeyringError> {
+        let value: Value = serde_json::from_str(raw)
+            .map_err(|error| KeyringError::InvalidJson(error.to_string()))?;
+        let entries = value.as_object().ok_or_else(|| {
+            KeyringError::InvalidJson("keyring must be a JSON object".to_string())
+        })?;
+        if entries.is_empty() {
+            return Err(KeyringError::InvalidJson(
+                "keyring must contain at least one key".to_string(),
+            ));
+        }
+
+        let mut keys = BTreeMap::new();
+        for (key_id, encoded) in entries {
+            validate_key_id(key_id)?;
+            let encoded = encoded.as_str().ok_or_else(|| {
+                KeyringError::InvalidKeyEncoding(format!("{key_id} must be a string"))
+            })?;
+            let raw = STANDARD.decode(encoded).map_err(|error| {
+                KeyringError::InvalidKeyEncoding(format!("{key_id} is not valid base64: {error}"))
+            })?;
+            if STANDARD.encode(&raw) != encoded {
+                return Err(KeyringError::InvalidKeyEncoding(format!(
+                    "{key_id} must use canonical base64"
+                )));
+            }
+            let bytes: [u8; 32] = raw.try_into().map_err(|_| {
+                KeyringError::InvalidKeyEncoding(format!("{key_id} must encode 32 bytes"))
+            })?;
+            let key = VerifyingKey::from_bytes(&bytes).map_err(|error| {
+                KeyringError::InvalidKeyEncoding(format!("{key_id} is not an Ed25519 key: {error}"))
+            })?;
+            keys.insert(key_id.clone(), key);
+        }
+        Ok(Self { keys })
+    }
+
+    pub fn contains(&self, key_id: &str) -> bool {
+        self.keys.contains_key(key_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+}
+
+fn validate_key_id(key_id: &str) -> Result<(), KeyringError> {
+    let mut chars = key_id.chars();
+    let first = chars.next().ok_or_else(|| {
+        KeyringError::InvalidKeyId("must be 1-128 safe identifier characters".to_string())
+    })?;
+    if !first.is_ascii_alphanumeric()
+        || key_id.len() > 128
+        || chars.any(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')))
+    {
+        return Err(KeyringError::InvalidKeyId(format!(
+            "{key_id:?} must match [A-Za-z0-9][A-Za-z0-9._-]{{0,127}}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use rand_core::OsRng;
+    use std::sync::{Mutex, OnceLock};
+
+    fn generated_keyring() -> (String, String) {
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let public_key = STANDARD.encode(signing_key.verifying_key().to_bytes());
+        ("producer-20260804-a".to_string(), public_key)
+    }
+
+    #[test]
+    fn parses_generated_public_key_json() {
+        let (key_id, public_key) = generated_keyring();
+        let keyring =
+            PublicKeyring::from_json_str(&serde_json::json!({key_id: public_key}).to_string())
+                .expect("generated public key should parse");
+        assert_eq!(keyring.len(), 1);
+        assert!(keyring.contains("producer-20260804-a"));
+    }
+
+    #[test]
+    fn rejects_bad_base64_and_wrong_length() {
+        let invalid = PublicKeyring::from_json_str(r#"{"producer-a":"not base64"}"#);
+        assert!(matches!(invalid, Err(KeyringError::InvalidKeyEncoding(_))));
+
+        let short = STANDARD.encode([1_u8; 31]);
+        let invalid =
+            PublicKeyring::from_json_str(&serde_json::json!({"producer-a": short}).to_string());
+        assert!(matches!(invalid, Err(KeyringError::InvalidKeyEncoding(_))));
+    }
+
+    #[test]
+    fn rejects_unsafe_key_ids_and_empty_keyrings() {
+        let key = STANDARD.encode([1_u8; 32]);
+        let invalid =
+            PublicKeyring::from_json_str(&serde_json::json!({"producer/a": key}).to_string());
+        assert!(matches!(invalid, Err(KeyringError::InvalidKeyId(_))));
+        assert!(matches!(
+            PublicKeyring::from_json_str("{}"),
+            Err(KeyringError::InvalidJson(_))
+        ));
+    }
+
+    #[test]
+    fn loads_keyring_from_environment() {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let (key_id, public_key) = generated_keyring();
+        std::env::set_var(
+            KEYRING_ENV,
+            serde_json::json!({key_id: public_key}).to_string(),
+        );
+        let loaded = PublicKeyring::from_env().expect("environment keyring should parse");
+        std::env::remove_var(KEYRING_ENV);
+        assert_eq!(loaded.len(), 1);
+    }
+}

--- a/crates/tracera-server/src/replay.rs
+++ b/crates/tracera-server/src/replay.rs
@@ -1,12 +1,12 @@
 //! Replay-v2 verification primitives.
 //!
-//! This slice owns only the public-key keyring boundary.  Private signing
-//! material never crosses into Tracera; producers publish a JSON object of
-//! key IDs to canonical base64-encoded Ed25519 public keys.
+//! Private signing material never crosses into Tracera; producers publish a
+//! JSON object of key IDs to canonical base64-encoded Ed25519 public keys.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use ed25519_dalek::VerifyingKey;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 const KEYRING_ENV: &str = "TRACERA_REPLAY_PUBLIC_KEYS_JSON";
@@ -96,6 +96,185 @@ impl PublicKeyring {
     pub fn len(&self) -> usize {
         self.keys.len()
     }
+
+    fn get(&self, key_id: &str) -> Option<&VerifyingKey> {
+        self.keys.get(key_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationError {
+    Schema(String),
+    UnknownKey(String),
+    InvalidEncoding(String),
+    InvalidSignature,
+    ReplayHashMismatch { expected: String, actual: String },
+}
+
+impl std::fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Schema(message) => write!(f, "invalid benchmark replay schema: {message}"),
+            Self::UnknownKey(key_id) => write!(f, "unknown replay signing key_id: {key_id}"),
+            Self::InvalidEncoding(message) => {
+                write!(f, "invalid replay signature encoding: {message}")
+            }
+            Self::InvalidSignature => write!(f, "invalid replay signature"),
+            Self::ReplayHashMismatch { expected, actual } => write!(
+                f,
+                "replay_hash mismatch: envelope={expected}, recomputed={actual}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VerificationError {}
+
+/// The verified fields needed by the persistence adapter in the next slice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedBenchmark {
+    pub key_id: String,
+    pub replay_hash: String,
+    pub signature_digest: String,
+}
+
+/// Serialize JSON using the producer's sorted-key, compact UTF-8 contract.
+pub fn canonical_json_bytes(value: &Value) -> Vec<u8> {
+    let mut output = Vec::new();
+    write_canonical(value, &mut output);
+    output
+}
+
+fn write_canonical(value: &Value, output: &mut Vec<u8>) {
+    match value {
+        Value::Null => output.extend_from_slice(b"null"),
+        Value::Bool(value) => output.extend_from_slice(if *value { b"true" } else { b"false" }),
+        Value::Number(value) => output.extend_from_slice(value.to_string().as_bytes()),
+        Value::String(value) => serde_json::to_writer(output, value).expect("strings serialize"),
+        Value::Array(values) => {
+            output.push(b'[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                write_canonical(value, output);
+            }
+            output.push(b']');
+        }
+        Value::Object(values) => {
+            let mut keys: Vec<&String> = values.keys().collect();
+            keys.sort_unstable();
+            output.push(b'{');
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                serde_json::to_writer(&mut *output, key).expect("keys serialize");
+                output.push(b':');
+                write_canonical(&values[key], output);
+            }
+            output.push(b'}');
+        }
+    }
+}
+
+pub fn sha256_hex(value: &[u8]) -> String {
+    let digest = Sha256::digest(value);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+pub fn replay_hash(events: &Value) -> Result<String, VerificationError> {
+    if !events.is_array() {
+        return Err(VerificationError::Schema(
+            "events must be an array".to_string(),
+        ));
+    }
+    Ok(sha256_hex(&canonical_json_bytes(events)))
+}
+
+pub fn signed_envelope_bytes(envelope: &Value) -> Result<Vec<u8>, VerificationError> {
+    let object = envelope
+        .as_object()
+        .ok_or_else(|| VerificationError::Schema("envelope must be an object".to_string()))?;
+    let mut unsigned = object.clone();
+    unsigned.remove("signature");
+    Ok(canonical_json_bytes(&Value::Object(unsigned)))
+}
+
+/// Verify schema version, replay hash, and detached Ed25519 signature.
+pub fn verify_benchmark_envelope(
+    envelope: &Value,
+    keyring: &PublicKeyring,
+) -> Result<VerifiedBenchmark, VerificationError> {
+    let object = envelope
+        .as_object()
+        .ok_or_else(|| VerificationError::Schema("envelope must be an object".to_string()))?;
+    if object.get("schema_version").and_then(Value::as_str) != Some("2.0.0") {
+        return Err(VerificationError::Schema(
+            "schema_version must be 2.0.0".to_string(),
+        ));
+    }
+    let events = object
+        .get("events")
+        .ok_or_else(|| VerificationError::Schema("events is required".to_string()))?;
+    let actual_hash = replay_hash(events)?;
+    let result = object
+        .get("result")
+        .and_then(Value::as_object)
+        .ok_or_else(|| VerificationError::Schema("result must be an object".to_string()))?;
+    let expected_hash = result
+        .get("replay_hash")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VerificationError::Schema("result.replay_hash is required".to_string()))?;
+    if expected_hash != actual_hash {
+        return Err(VerificationError::ReplayHashMismatch {
+            expected: expected_hash.to_string(),
+            actual: actual_hash,
+        });
+    }
+    let signature = object
+        .get("signature")
+        .and_then(Value::as_object)
+        .ok_or_else(|| VerificationError::Schema("signature must be an object".to_string()))?;
+    if signature.get("algorithm").and_then(Value::as_str) != Some("ed25519") {
+        return Err(VerificationError::Schema(
+            "signature.algorithm must be ed25519".to_string(),
+        ));
+    }
+    let key_id = signature
+        .get("key_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VerificationError::Schema("signature.key_id is required".to_string()))?;
+    let verifying_key = keyring
+        .get(key_id)
+        .ok_or_else(|| VerificationError::UnknownKey(key_id.to_string()))?;
+    let encoded = signature
+        .get("signature_b64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            VerificationError::Schema("signature.signature_b64 is required".to_string())
+        })?;
+    let signature_bytes = STANDARD.decode(encoded).map_err(|error| {
+        VerificationError::InvalidEncoding(format!("base64 decode failed: {error}"))
+    })?;
+    if STANDARD.encode(&signature_bytes) != encoded || signature_bytes.len() != 64 {
+        return Err(VerificationError::InvalidEncoding(
+            "signature must be canonical base64 encoding of 64 bytes".to_string(),
+        ));
+    }
+    let signature_array: [u8; 64] = signature_bytes.try_into().expect("length checked");
+    verifying_key
+        .verify(
+            &signed_envelope_bytes(envelope)?,
+            &Signature::from_bytes(&signature_array),
+        )
+        .map_err(|_| VerificationError::InvalidSignature)?;
+
+    Ok(VerifiedBenchmark {
+        key_id: key_id.to_string(),
+        replay_hash: expected_hash.to_string(),
+        signature_digest: sha256_hex(&signature_array),
+    })
 }
 
 fn validate_key_id(key_id: &str) -> Result<(), KeyringError> {
@@ -117,22 +296,50 @@ fn validate_key_id(key_id: &str) -> Result<(), KeyringError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ed25519_dalek::SigningKey;
+    use ed25519_dalek::{Signer, SigningKey};
     use rand_core::OsRng;
     use std::sync::{Mutex, OnceLock};
 
-    fn generated_keyring() -> (String, String) {
-        let signing_key = SigningKey::generate(&mut OsRng);
+    fn generated_signing_key() -> SigningKey {
+        SigningKey::generate(&mut OsRng)
+    }
+
+    fn generated_keyring(signing_key: &SigningKey) -> PublicKeyring {
         let public_key = STANDARD.encode(signing_key.verifying_key().to_bytes());
-        ("producer-20260804-a".to_string(), public_key)
+        PublicKeyring::from_json_str(
+            &serde_json::json!({"producer-20260804-a": public_key}).to_string(),
+        )
+        .expect("generated public key should parse")
+    }
+
+    fn signed_fixture(signing_key: &SigningKey) -> Value {
+        let events = serde_json::json!([
+            {"type": "run_started", "seq": 0, "details": {"suite": "synthetic"}},
+            {"type": "run_finished", "seq": 1, "details": {"status": "passed"}}
+        ]);
+        let mut envelope = serde_json::json!({
+            "schema_version": "2.0.0",
+            "events": events,
+            "result": {"replay_hash": replay_hash(&events).expect("events hash")}
+        });
+        resign(&mut envelope, signing_key);
+        envelope
+    }
+
+    fn resign(envelope: &mut Value, signing_key: &SigningKey) {
+        let bytes = signed_envelope_bytes(envelope).expect("unsigned envelope bytes");
+        let signature = signing_key.sign(&bytes);
+        envelope["signature"] = serde_json::json!({
+            "algorithm": "ed25519",
+            "key_id": "producer-20260804-a",
+            "signature_b64": STANDARD.encode(signature.to_bytes())
+        });
     }
 
     #[test]
     fn parses_generated_public_key_json() {
-        let (key_id, public_key) = generated_keyring();
-        let keyring =
-            PublicKeyring::from_json_str(&serde_json::json!({key_id: public_key}).to_string())
-                .expect("generated public key should parse");
+        let signing_key = generated_signing_key();
+        let keyring = generated_keyring(&signing_key);
         assert_eq!(keyring.len(), 1);
         assert!(keyring.contains("producer-20260804-a"));
     }
@@ -164,7 +371,9 @@ mod tests {
     fn loads_keyring_from_environment() {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-        let (key_id, public_key) = generated_keyring();
+        let signing_key = generated_signing_key();
+        let key_id = "producer-20260804-a";
+        let public_key = STANDARD.encode(signing_key.verifying_key().to_bytes());
         std::env::set_var(
             KEYRING_ENV,
             serde_json::json!({key_id: public_key}).to_string(),
@@ -172,5 +381,64 @@ mod tests {
         let loaded = PublicKeyring::from_env().expect("environment keyring should parse");
         std::env::remove_var(KEYRING_ENV);
         assert_eq!(loaded.len(), 1);
+    }
+
+    #[test]
+    fn verifies_generated_detached_signature_and_replay_hash() {
+        let signing_key = generated_signing_key();
+        let envelope = signed_fixture(&signing_key);
+        let verified = verify_benchmark_envelope(&envelope, &generated_keyring(&signing_key))
+            .expect("generated envelope should verify");
+        assert_eq!(verified.key_id, "producer-20260804-a");
+        assert_eq!(
+            verified.replay_hash,
+            replay_hash(&envelope["events"]).unwrap()
+        );
+        assert_eq!(verified.signature_digest.len(), 64);
+    }
+
+    #[test]
+    fn rejects_unknown_key_and_bad_signature_encoding() {
+        let signing_key = generated_signing_key();
+        let envelope = signed_fixture(&signing_key);
+        let other = generated_signing_key();
+        assert!(matches!(
+            verify_benchmark_envelope(&envelope, &generated_keyring(&other)),
+            Err(VerificationError::UnknownKey(_))
+        ));
+
+        let mut bad_encoding = envelope.clone();
+        bad_encoding["signature"]["signature_b64"] = Value::String("%%%".to_string());
+        assert!(matches!(
+            verify_benchmark_envelope(&bad_encoding, &generated_keyring(&signing_key)),
+            Err(VerificationError::InvalidEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_tampering_and_re_signed_hash_mismatch() {
+        let signing_key = generated_signing_key();
+        let mut tampered = signed_fixture(&signing_key);
+        tampered["events"][0]["details"]["suite"] = Value::String("tampered".to_string());
+        assert!(matches!(
+            verify_benchmark_envelope(&tampered, &generated_keyring(&signing_key)),
+            Err(VerificationError::InvalidSignature)
+        ));
+
+        let mut hash_mismatch = signed_fixture(&signing_key);
+        hash_mismatch["result"]["replay_hash"] = Value::String("b".repeat(64));
+        resign(&mut hash_mismatch, &signing_key);
+        assert!(matches!(
+            verify_benchmark_envelope(&hash_mismatch, &generated_keyring(&signing_key)),
+            Err(VerificationError::ReplayHashMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn canonical_bytes_sort_keys_without_ascii_escaping() {
+        assert_eq!(
+            canonical_json_bytes(&serde_json::json!({"z": "mu", "a": "αλφα"})),
+            "{\"a\":\"αλφα\",\"z\":\"mu\"}".as_bytes()
+        );
     }
 }

--- a/crates/tracera-server/src/replay.rs
+++ b/crates/tracera-server/src/replay.rs
@@ -13,17 +13,17 @@ const KEYRING_ENV: &str = "TRACERA_REPLAY_PUBLIC_KEYS_JSON";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyringError {
-    InvalidJson(String),
-    InvalidKeyId(String),
-    InvalidKeyEncoding(String),
+    Json(String),
+    KeyId(String),
+    KeyEncoding(String),
 }
 
 impl std::fmt::Display for KeyringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidJson(message) => write!(f, "invalid replay public-key JSON: {message}"),
-            Self::InvalidKeyId(message) => write!(f, "invalid replay key_id: {message}"),
-            Self::InvalidKeyEncoding(message) => {
+            Self::Json(message) => write!(f, "invalid replay public-key JSON: {message}"),
+            Self::KeyId(message) => write!(f, "invalid replay key_id: {message}"),
+            Self::KeyEncoding(message) => {
                 write!(f, "invalid replay public-key encoding: {message}")
             }
         }
@@ -53,13 +53,13 @@ impl PublicKeyring {
 
     /// Parse a JSON object shaped as `{ "key-id": "base64-public-key" }`.
     pub fn from_json_str(raw: &str) -> Result<Self, KeyringError> {
-        let value: Value = serde_json::from_str(raw)
-            .map_err(|error| KeyringError::InvalidJson(error.to_string()))?;
-        let entries = value.as_object().ok_or_else(|| {
-            KeyringError::InvalidJson("keyring must be a JSON object".to_string())
-        })?;
+        let value: Value =
+            serde_json::from_str(raw).map_err(|error| KeyringError::Json(error.to_string()))?;
+        let entries = value
+            .as_object()
+            .ok_or_else(|| KeyringError::Json("keyring must be a JSON object".to_string()))?;
         if entries.is_empty() {
-            return Err(KeyringError::InvalidJson(
+            return Err(KeyringError::Json(
                 "keyring must contain at least one key".to_string(),
             ));
         }
@@ -67,32 +67,34 @@ impl PublicKeyring {
         let mut keys = BTreeMap::new();
         for (key_id, encoded) in entries {
             validate_key_id(key_id)?;
-            let encoded = encoded.as_str().ok_or_else(|| {
-                KeyringError::InvalidKeyEncoding(format!("{key_id} must be a string"))
-            })?;
+            let encoded = encoded
+                .as_str()
+                .ok_or_else(|| KeyringError::KeyEncoding(format!("{key_id} must be a string")))?;
             let raw = STANDARD.decode(encoded).map_err(|error| {
-                KeyringError::InvalidKeyEncoding(format!("{key_id} is not valid base64: {error}"))
+                KeyringError::KeyEncoding(format!("{key_id} is not valid base64: {error}"))
             })?;
             if STANDARD.encode(&raw) != encoded {
-                return Err(KeyringError::InvalidKeyEncoding(format!(
+                return Err(KeyringError::KeyEncoding(format!(
                     "{key_id} must use canonical base64"
                 )));
             }
-            let bytes: [u8; 32] = raw.try_into().map_err(|_| {
-                KeyringError::InvalidKeyEncoding(format!("{key_id} must encode 32 bytes"))
-            })?;
+            let bytes: [u8; 32] = raw
+                .try_into()
+                .map_err(|_| KeyringError::KeyEncoding(format!("{key_id} must encode 32 bytes")))?;
             let key = VerifyingKey::from_bytes(&bytes).map_err(|error| {
-                KeyringError::InvalidKeyEncoding(format!("{key_id} is not an Ed25519 key: {error}"))
+                KeyringError::KeyEncoding(format!("{key_id} is not an Ed25519 key: {error}"))
             })?;
             keys.insert(key_id.clone(), key);
         }
         Ok(Self { keys })
     }
 
+    #[cfg(test)]
     pub fn contains(&self, key_id: &str) -> bool {
         self.keys.contains_key(key_id)
     }
 
+    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.keys.len()
     }
@@ -217,7 +219,6 @@ pub fn verify_benchmark_envelope(
     let events = object
         .get("events")
         .ok_or_else(|| VerificationError::Schema("events is required".to_string()))?;
-    let actual_hash = replay_hash(events)?;
     let result = object
         .get("result")
         .and_then(Value::as_object)
@@ -226,12 +227,6 @@ pub fn verify_benchmark_envelope(
         .get("replay_hash")
         .and_then(Value::as_str)
         .ok_or_else(|| VerificationError::Schema("result.replay_hash is required".to_string()))?;
-    if expected_hash != actual_hash {
-        return Err(VerificationError::ReplayHashMismatch {
-            expected: expected_hash.to_string(),
-            actual: actual_hash,
-        });
-    }
     let signature = object
         .get("signature")
         .and_then(Value::as_object)
@@ -270,6 +265,16 @@ pub fn verify_benchmark_envelope(
         )
         .map_err(|_| VerificationError::InvalidSignature)?;
 
+    // Authenticate the full unsigned envelope before trusting the replay hash.
+    // This keeps a stale hash on a tampered payload from masking signature failure.
+    let actual_hash = replay_hash(events)?;
+    if expected_hash != actual_hash {
+        return Err(VerificationError::ReplayHashMismatch {
+            expected: expected_hash.to_string(),
+            actual: actual_hash,
+        });
+    }
+
     Ok(VerifiedBenchmark {
         key_id: key_id.to_string(),
         replay_hash: expected_hash.to_string(),
@@ -280,13 +285,13 @@ pub fn verify_benchmark_envelope(
 fn validate_key_id(key_id: &str) -> Result<(), KeyringError> {
     let mut chars = key_id.chars();
     let first = chars.next().ok_or_else(|| {
-        KeyringError::InvalidKeyId("must be 1-128 safe identifier characters".to_string())
+        KeyringError::KeyId("must be 1-128 safe identifier characters".to_string())
     })?;
     if !first.is_ascii_alphanumeric()
         || key_id.len() > 128
         || chars.any(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')))
     {
-        return Err(KeyringError::InvalidKeyId(format!(
+        return Err(KeyringError::KeyId(format!(
             "{key_id:?} must match [A-Za-z0-9][A-Za-z0-9._-]{{0,127}}"
         )));
     }
@@ -304,12 +309,14 @@ mod tests {
         SigningKey::generate(&mut OsRng)
     }
 
-    fn generated_keyring(signing_key: &SigningKey) -> PublicKeyring {
+    fn generated_keyring_with_id(signing_key: &SigningKey, key_id: &str) -> PublicKeyring {
         let public_key = STANDARD.encode(signing_key.verifying_key().to_bytes());
-        PublicKeyring::from_json_str(
-            &serde_json::json!({"producer-20260804-a": public_key}).to_string(),
-        )
-        .expect("generated public key should parse")
+        PublicKeyring::from_json_str(&serde_json::json!({key_id: public_key}).to_string())
+            .expect("generated public key should parse")
+    }
+
+    fn generated_keyring(signing_key: &SigningKey) -> PublicKeyring {
+        generated_keyring_with_id(signing_key, "producer-20260804-a")
     }
 
     fn signed_fixture(signing_key: &SigningKey) -> Value {
@@ -347,12 +354,12 @@ mod tests {
     #[test]
     fn rejects_bad_base64_and_wrong_length() {
         let invalid = PublicKeyring::from_json_str(r#"{"producer-a":"not base64"}"#);
-        assert!(matches!(invalid, Err(KeyringError::InvalidKeyEncoding(_))));
+        assert!(matches!(invalid, Err(KeyringError::KeyEncoding(_))));
 
         let short = STANDARD.encode([1_u8; 31]);
         let invalid =
             PublicKeyring::from_json_str(&serde_json::json!({"producer-a": short}).to_string());
-        assert!(matches!(invalid, Err(KeyringError::InvalidKeyEncoding(_))));
+        assert!(matches!(invalid, Err(KeyringError::KeyEncoding(_))));
     }
 
     #[test]
@@ -360,10 +367,10 @@ mod tests {
         let key = STANDARD.encode([1_u8; 32]);
         let invalid =
             PublicKeyring::from_json_str(&serde_json::json!({"producer/a": key}).to_string());
-        assert!(matches!(invalid, Err(KeyringError::InvalidKeyId(_))));
+        assert!(matches!(invalid, Err(KeyringError::KeyId(_))));
         assert!(matches!(
             PublicKeyring::from_json_str("{}"),
-            Err(KeyringError::InvalidJson(_))
+            Err(KeyringError::Json(_))
         ));
     }
 
@@ -403,7 +410,10 @@ mod tests {
         let envelope = signed_fixture(&signing_key);
         let other = generated_signing_key();
         assert!(matches!(
-            verify_benchmark_envelope(&envelope, &generated_keyring(&other)),
+            verify_benchmark_envelope(
+                &envelope,
+                &generated_keyring_with_id(&other, "other-producer-20260804-a")
+            ),
             Err(VerificationError::UnknownKey(_))
         ));
 

--- a/crates/tracera-server/src/sqlite_store.rs
+++ b/crates/tracera-server/src/sqlite_store.rs
@@ -15,8 +15,8 @@ use serde_json::Value;
 use sqlx::{Row, SqlitePool};
 
 use crate::store::{
-    BoxFuture, EvidenceItem, Problem, Sprint, Store, StoreError, StoreResult, Story, TeamRow,
-    TraceLink,
+    BenchmarkRun, BoxFuture, EvidenceItem, Problem, Sprint, Store, StoreError, StoreResult, Story,
+    TeamRow, TraceLink,
 };
 
 #[derive(Clone)]
@@ -27,6 +27,20 @@ pub struct SqliteStore {
 impl SqliteStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self { pool }
+    }
+
+    fn get_benchmark_run_by_replay_hash(
+        &self,
+        replay_hash: String,
+    ) -> BoxFuture<'_, StoreResult<Option<BenchmarkRun>>> {
+        Box::pin(async move {
+            let row = sqlx::query("SELECT run_id, session_id, attempt_id, schema_version, replay_hash, outcome_sha256, key_id, signature_digest, status, metadata, created_at, updated_at FROM benchmark_runs WHERE replay_hash = ?1")
+            .bind(replay_hash)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+            Ok(row.map(row_to_benchmark_run))
+        })
     }
 }
 
@@ -351,6 +365,83 @@ impl Store for SqliteStore {
         })
     }
 
+    fn get_benchmark_run(
+        &self,
+        run_id: String,
+    ) -> BoxFuture<'_, StoreResult<Option<BenchmarkRun>>> {
+        Box::pin(async move {
+            let row = sqlx::query(
+                "SELECT run_id, session_id, attempt_id, schema_version, replay_hash, \
+                 outcome_sha256, key_id, signature_digest, status, metadata, created_at, updated_at \
+                 FROM benchmark_runs WHERE run_id = ?1",
+            )
+            .bind(&run_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+            Ok(row.map(row_to_benchmark_run))
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_benchmark_run(
+        &self,
+        run_id: String,
+        session_id: String,
+        attempt_id: String,
+        schema_version: String,
+        replay_hash: String,
+        outcome_sha256: String,
+        key_id: String,
+        signature_digest: String,
+        status: String,
+        metadata: Value,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<BenchmarkRun>> {
+        Box::pin(async move {
+            if let Some(existing) = self.get_benchmark_run(run_id.clone()).await? {
+                if existing.replay_hash != replay_hash {
+                    return Err(StoreError::Database(
+                        "benchmark run_id already exists with a different replay_hash".to_string(),
+                    ));
+                }
+                return Ok(existing);
+            }
+
+            let metadata_str =
+                serde_json::to_string(&metadata).unwrap_or_else(|_| "{}".to_string());
+            let now_str = ts_to_str(now);
+            sqlx::query(
+                "INSERT INTO benchmark_runs \
+                 (run_id, session_id, attempt_id, schema_version, replay_hash, outcome_sha256, \
+                  key_id, signature_digest, status, metadata, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12) \
+                 ON CONFLICT DO NOTHING",
+            )
+            .bind(&run_id)
+            .bind(&session_id)
+            .bind(&attempt_id)
+            .bind(&schema_version)
+            .bind(&replay_hash)
+            .bind(&outcome_sha256)
+            .bind(&key_id)
+            .bind(&signature_digest)
+            .bind(&status)
+            .bind(&metadata_str)
+            .bind(&now_str)
+            .bind(&now_str)
+            .execute(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
+
+            self.get_benchmark_run_by_replay_hash(replay_hash)
+                .await?
+                .ok_or_else(|| {
+                    StoreError::Database("benchmark run insert returned no row".to_string())
+                })
+        })
+    }
+
     // -----------------------------------------------------------------------
     // Problems (ITIL) — SQLite implementations
     // -----------------------------------------------------------------------
@@ -554,9 +645,135 @@ fn row_to_problem(r: sqlx::sqlite::SqliteRow) -> Problem {
     }
 }
 
+fn row_to_benchmark_run(r: sqlx::sqlite::SqliteRow) -> BenchmarkRun {
+    let metadata_str: String = r.try_get("metadata").unwrap_or_else(|_| "{}".to_string());
+    let metadata = serde_json::from_str(&metadata_str).unwrap_or(Value::Object(Default::default()));
+    BenchmarkRun {
+        run_id: r.try_get("run_id").unwrap_or_default(),
+        session_id: r.try_get("session_id").unwrap_or_default(),
+        attempt_id: r.try_get("attempt_id").unwrap_or_default(),
+        schema_version: r.try_get("schema_version").unwrap_or_default(),
+        replay_hash: r.try_get("replay_hash").unwrap_or_default(),
+        outcome_sha256: r.try_get("outcome_sha256").unwrap_or_default(),
+        key_id: r.try_get("key_id").unwrap_or_default(),
+        signature_digest: r.try_get("signature_digest").unwrap_or_default(),
+        status: r.try_get("status").unwrap_or_default(),
+        metadata,
+        created_at: str_to_ts(&r.try_get::<String, _>("created_at").unwrap_or_default()),
+        updated_at: str_to_ts(&r.try_get::<String, _>("updated_at").unwrap_or_default()),
+    }
+}
+
 // Keep the helpers visible to clippy even when no other code in this module
 // currently uses them — they're shared with the PgStore port in a follow-up.
 #[allow(dead_code)]
 fn _keep_helpers() {
     let _ = opt_ts_to_str(None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+
+    async fn benchmark_store() -> SqliteStore {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations-sqlite")
+            .run(&pool)
+            .await
+            .expect("apply SQLite benchmark-run migration");
+        SqliteStore::new(pool)
+    }
+
+    #[tokio::test]
+    async fn benchmark_run_create_is_idempotent_and_replay_hash_is_unique() {
+        let store = benchmark_store().await;
+        let now = Utc::now();
+        let metadata = serde_json::json!({
+            "schema_version": "2.0.0",
+            "replay_hash": "a".repeat(64),
+            "outcome_sha256": "b".repeat(64),
+            "key_id": "producer-a",
+            "signature_digest": "c".repeat(64)
+        });
+        let first = store
+            .create_benchmark_run(
+                "run_a".to_string(),
+                "ses_a".to_string(),
+                "att_a".to_string(),
+                "2.0.0".to_string(),
+                "a".repeat(64),
+                "b".repeat(64),
+                "producer-a".to_string(),
+                "c".repeat(64),
+                "passed".to_string(),
+                metadata.clone(),
+                now,
+            )
+            .await
+            .unwrap();
+        let second = store
+            .create_benchmark_run(
+                "run_a".to_string(),
+                "ses-a-new".to_string(),
+                "att-a-new".to_string(),
+                "2.0.0".to_string(),
+                "a".repeat(64),
+                "d".repeat(64),
+                "producer-b".to_string(),
+                "e".repeat(64),
+                "failed".to_string(),
+                serde_json::json!({"changed": true}),
+                now + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.run_id, second.run_id);
+        assert_eq!(first.replay_hash, second.replay_hash);
+        assert_eq!(first.metadata, metadata);
+        assert_eq!(second.status, "passed");
+
+        let loaded = store
+            .get_benchmark_run("run_a".to_string())
+            .await
+            .unwrap()
+            .expect("idempotent row");
+        assert_eq!(loaded.signature_digest, "c".repeat(64));
+
+        let conflicting_hash = store
+            .create_benchmark_run(
+                "run_a".to_string(),
+                "ses_a".to_string(),
+                "att_a".to_string(),
+                "2.0.0".to_string(),
+                "f".repeat(64),
+                "b".repeat(64),
+                "producer-a".to_string(),
+                "c".repeat(64),
+                "passed".to_string(),
+                metadata,
+                now,
+            )
+            .await;
+        assert!(conflicting_hash.is_err());
+
+        let same_replay = store
+            .create_benchmark_run(
+                "run_b".to_string(),
+                "ses_b".to_string(),
+                "att_b".to_string(),
+                "2.0.0".to_string(),
+                "a".repeat(64),
+                "b".repeat(64),
+                "producer-a".to_string(),
+                "c".repeat(64),
+                "passed".to_string(),
+                serde_json::json!({}),
+                now,
+            )
+            .await;
+        let same_replay = same_replay.expect("same replay hash should be idempotent");
+        assert_eq!(same_replay.run_id, "run_a");
+        assert_eq!(same_replay.replay_hash, "a".repeat(64));
+    }
 }

--- a/crates/tracera-server/src/store.rs
+++ b/crates/tracera-server/src/store.rs
@@ -97,6 +97,23 @@ pub struct TraceLink {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Verified benchmark-run provenance retained for replay and idempotency.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BenchmarkRun {
+    pub run_id: String,
+    pub session_id: String,
+    pub attempt_id: String,
+    pub schema_version: String,
+    pub replay_hash: String,
+    pub outcome_sha256: String,
+    pub key_id: String,
+    pub signature_digest: String,
+    pub status: String,
+    pub metadata: Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// ITIL Problem-management domain record.
 ///
 /// Recovered from the Python `src/tracertm/models/problem.py` model
@@ -213,6 +230,28 @@ pub trait Store: Send + Sync {
 
     // Metrics
     fn count_evidence(&self) -> BoxFuture<'_, StoreResult<i64>>;
+
+    // Verified benchmark replay provenance.
+    fn get_benchmark_run(&self, run_id: String)
+        -> BoxFuture<'_, StoreResult<Option<BenchmarkRun>>>;
+
+    /// Insert a benchmark run, or return the existing row when the stable
+    /// run/replay identity is submitted again. A conflicting hash is an error.
+    #[allow(clippy::too_many_arguments)]
+    fn create_benchmark_run(
+        &self,
+        run_id: String,
+        session_id: String,
+        attempt_id: String,
+        schema_version: String,
+        replay_hash: String,
+        outcome_sha256: String,
+        key_id: String,
+        signature_digest: String,
+        status: String,
+        metadata: Value,
+        now: DateTime<Utc>,
+    ) -> BoxFuture<'_, StoreResult<BenchmarkRun>>;
 
     // -----------------------------------------------------------------------
     // Problems (ITIL problem-management) — recovered from Python model

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,7 @@ allow = [
   "CC0-1.0",
   "CDLA-Permissive-2.0",
   "ISC",
-  "LGPL-2.1-or-later",
+  "LGPL-2.1",
   "MIT",
   "MIT-0",
   "Unicode-3.0",

--- a/docs/04-guides/DEPLOYMENT_GUIDE.md
+++ b/docs/04-guides/DEPLOYMENT_GUIDE.md
@@ -96,7 +96,8 @@ REDIS_URL=redis://host:6379
 LOG_LEVEL=INFO
 API_HOST=0.0.0.0
 API_PORT=8000
-TRACERA_JWT_SECRET=<production-secret>
+# Inject this value from the deployment secret manager; never commit a literal.
+TRACERA_JWT_SECRET="${TRACERA_JWT_SECRET:?set via the deployment secret manager}"
 TRACERA_JWT_AUDIENCE=tracera-api
 TRACERA_JWT_ISSUER=tracera
 ```

--- a/frontend/apps/web/src/__tests__/security/auth.test.tsx
+++ b/frontend/apps/web/src/__tests__/security/auth.test.tsx
@@ -97,9 +97,8 @@ describe('Authentication Security Tests', () => {
       expect(validateJWT('invalid')).toBeFalsy();
       expect(validateJWT('a.b')).toBeFalsy();
 
-      // Mock valid JWT structure
-      const validJWT =
-        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+      // Mock a structurally valid JWT without embedding a signed token fixture.
+      const validJWT = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
       expect(validateJWT(validJWT)).toBeTruthy();
     });
 


### PR DESCRIPTION
## **User description**
## Summary
- persist verified Ed25519 benchmark replay envelopes through the existing Tracera store
- reject tampered, unknown-key, and signed hash-mismatch envelopes before persistence
- keep replay-hash idempotency durable across SQLite and Postgres
- authenticate the signature before reporting replay-hash disagreement
- repair Axum 0.8 trace-route capture syntax so the router constructs

## Validation
- `CARGO_NET_OFFLINE=true CARGO_TARGET_DIR=target/p4 cargo test --offline -p tracera-server benchmark_ingest_ -- --nocapture`
- `CARGO_NET_OFFLINE=true CARGO_TARGET_DIR=target/p4 cargo clippy --offline -p tracera-server --all-targets -- -D warnings`
- `CARGO_NET_OFFLINE=true CARGO_TARGET_DIR=target/p4 cargo fmt --check -p tracera-server`

The focused endpoint suite covers create/persist, duplicate idempotency, tampered signatures, unknown keys, and a re-signed replay-hash mismatch.


___

## **CodeAnt-AI Description**
Accept and persist authenticated benchmark replay submissions

### What Changed
- Added a benchmark ingestion endpoint that accepts only schema 2.0.0 envelopes with valid Ed25519 signatures and replay hashes
- Unknown signing keys, tampered payloads, malformed signatures, and hash mismatches are rejected before persistence with clear HTTP outcomes
- Verified benchmark runs are stored in SQLite and Postgres with signing provenance, outcome details, and replay metadata
- Repeated submissions return the existing run, while conflicting run IDs or replay hashes are rejected
- Stabilized CI smoke tests and frontend builds by pinning the Bun version and using isolated runtime data

### Impact
`✅ Tamper-resistant benchmark replay ingestion`
`✅ Idempotent benchmark submissions`
`✅ Consistent SQLite and Postgres replay records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
