### PR TITLE
fix(compose): route local frontend through same-origin API

### DIFF
--- a/frontend/Dockerfile.local
+++ b/frontend/Dockerfile.local
@@ -4,7 +4,7 @@ COPY package.json package-lock.json ./
 COPY apps ./apps
 COPY scripts ./scripts
 RUN npm ci --ignore-scripts
-ENV VITE_API_BASE=
+ENV VITE_API_URL=
 RUN npm run build
 
 FROM nginx:1.27-alpine

--- a/frontend/apps/web/index.html
+++ b/frontend/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TraceRTM</title>
+    <title>Tracera</title>
     <!-- Geist font family (Vercel) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/apps/web/src/api/client-core.ts
+++ b/frontend/apps/web/src/api/client-core.ts
@@ -13,6 +13,8 @@ import { responseHandlers } from './client-response-handlers';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- openapi-fetch needs explicit HttpMethod keys to avoid PathsWithMethod resolving to never under exactOptionalPropertyTypes
 type AnyPaths = { [path: string]: { [method in HttpMethod]: any } };
 
+const getBackendURL = (_path?: string): string => API_ORIGIN;
+
 const API_BASE_URL = API_ORIGIN;
 
 const rawApiClient = createClient<AnyPaths>({

--- a/frontend/apps/web/src/api/client-core.ts
+++ b/frontend/apps/web/src/api/client-core.ts
@@ -2,6 +2,7 @@ import type { HttpMethod } from 'openapi-typescript-helpers';
 
 import createClient from 'openapi-fetch';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 
 import { getCSRFHeaders } from '../lib/csrf';
@@ -12,22 +13,7 @@ import { responseHandlers } from './client-response-handlers';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- openapi-fetch needs explicit HttpMethod keys to avoid PathsWithMethod resolving to never under exactOptionalPropertyTypes
 type AnyPaths = { [path: string]: { [method in HttpMethod]: any } };
 
-const getBackendURL = (_path?: string): string => {
-  const { env } = import.meta;
-  let url = '';
-
-  if (env && env.VITE_API_URL) {
-    url = env.VITE_API_URL;
-  }
-
-  if (url !== '') {
-    return url.replace(/\/$/, '');
-  }
-
-  return 'http://127.0.0.1:18000';
-};
-
-const API_BASE_URL = getBackendURL();
+const API_BASE_URL = API_ORIGIN;
 
 const rawApiClient = createClient<AnyPaths>({
   baseUrl: API_BASE_URL,

--- a/frontend/apps/web/src/api/executions.ts
+++ b/frontend/apps/web/src/api/executions.ts
@@ -1,5 +1,7 @@
 // Execution API endpoints for QA Integration
 
+import { API_ORIGIN } from '@/config/api-origin';
+
 import { client, handleApiResponse, safeApiCall } from './client';
 
 const { apiClient } = client;
@@ -187,7 +189,7 @@ const create = async (projectId: string, data: ExecutionCreate): Promise<Executi
   );
 
 const downloadArtifact = (projectId: string, executionId: string, artifactId: string): string =>
-  `${import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000'}/api/v1/projects/${projectId}/executions/${executionId}/artifacts/${artifactId}/download`;
+  `${API_ORIGIN}/api/v1/projects/${projectId}/executions/${executionId}/artifacts/${artifactId}/download`;
 
 const get = async (projectId: string, executionId: string): Promise<Execution> =>
   handleApiResponse(

--- a/frontend/apps/web/src/api/github.ts
+++ b/frontend/apps/web/src/api/github.ts
@@ -4,8 +4,9 @@
  */
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 /**
  * Default fetch config for authenticated requests

--- a/frontend/apps/web/src/api/mcp-config.ts
+++ b/frontend/apps/web/src/api/mcp-config.ts
@@ -21,7 +21,7 @@ const MCP_CONFIG_ENDPOINT = `${API_BASE_URL}/api/v1/mcp/config`;
  * No Authorization headers needed - backend validates via cookies
  */
 
-let cachedConfig;
+let cachedConfig: McpConfig | null = null;
 
 const createEnvConfig = (baseUrl: string): McpConfig => ({
   auth_mode: 'env',

--- a/frontend/apps/web/src/components/forms/FormArrayField.tsx
+++ b/frontend/apps/web/src/components/forms/FormArrayField.tsx
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { ArrayPath, Control, FieldArray, FieldValues } from 'react-hook-form';
+import type { ArrayPath, Control, FieldArrayPathValue, FieldValues } from 'react-hook-form';
 
 import { Plus, Trash2 } from 'lucide-react';
 import { useFieldArray } from 'react-hook-form';
@@ -14,13 +14,16 @@ export interface FormArrayFieldProps<T extends FieldValues> {
   label: string;
   helpText?: string;
   renderField: (index: number) => React.ReactNode;
-  defaultValue?: FieldArray<T, ArrayPath<T>>;
+  defaultValue?: FormArrayItem<T>;
   addButtonLabel?: string;
   removeButtonLabel?: string;
   minItems?: number;
   maxItems?: number;
   className?: string;
 }
+
+type FormArrayItem<T extends FieldValues> =
+  FieldArrayPathValue<T, ArrayPath<T>> extends ReadonlyArray<infer Item> ? Item : never;
 
 export function FormArrayField<T extends FieldValues>({
   control,
@@ -56,9 +59,9 @@ export function FormArrayField<T extends FieldValues>({
           size='sm'
           onClick={() => {
             if (defaultValue !== undefined) {
-              append(defaultValue);
+              append(defaultValue as never);
             } else {
-              append({} as FieldArray<T, ArrayPath<T>>);
+              append({} as never);
             }
           }}
           disabled={!canAdd}

--- a/frontend/apps/web/src/config/api-origin.ts
+++ b/frontend/apps/web/src/config/api-origin.ts
@@ -1,8 +1,8 @@
 /** Single browser origin for the approved Tracera gateway. */
-export const API_ORIGIN = (
-  import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000'
-).replace(/\/$/, '');
+const configuredApiOrigin = import.meta.env.VITE_API_URL?.trim();
+const browserOrigin = typeof window === 'undefined' ? '' : window.location.origin;
 
-export const WS_ORIGIN = (
-  import.meta.env.VITE_WS_URL ?? API_ORIGIN.replace(/^http/, 'ws')
-).replace(/\/$/, '');
+export const API_ORIGIN = (configuredApiOrigin || browserOrigin).replace(/\/$/, '');
+
+const configuredWsOrigin = import.meta.env.VITE_WS_URL?.trim();
+export const WS_ORIGIN = (configuredWsOrigin || API_ORIGIN.replace(/^http/, 'ws')).replace(/\/$/, '');

--- a/frontend/apps/web/src/config/constants.ts
+++ b/frontend/apps/web/src/config/constants.ts
@@ -1,3 +1,5 @@
+import { API_ORIGIN, WS_ORIGIN } from './api-origin';
+
 // Application constants
 
 const APP_NAME = 'TraceRTM';
@@ -13,9 +15,8 @@ const AUTH_ROUTES = {
 } as const;
 
 // API configuration (gateway-only; no direct backend URLs)
-const { VITE_API_URL, VITE_WS_URL } = import.meta.env || {};
-const API_BASE_URL = VITE_API_URL || 'http://127.0.0.1:18000';
-const WS_BASE_URL = VITE_WS_URL || 'ws://127.0.0.1:18000';
+const API_BASE_URL = API_ORIGIN;
+const WS_BASE_URL = WS_ORIGIN;
 // 30 seconds
 const API_TIMEOUT = 30_000;
 

--- a/frontend/apps/web/src/hooks/coverage/api.ts
+++ b/frontend/apps/web/src/hooks/coverage/api.ts
@@ -8,10 +8,11 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+const API_URL = API_ORIGIN;
 
 function transformCoverage(data: Record<string, unknown>): TestCoverage {
   return {

--- a/frontend/apps/web/src/hooks/integrationsApi.ts
+++ b/frontend/apps/web/src/hooks/integrationsApi.ts
@@ -1,7 +1,8 @@
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 export { API_URL, getAuthHeaders };

--- a/frontend/apps/web/src/hooks/item-specs/constants.ts
+++ b/frontend/apps/web/src/hooks/item-specs/constants.ts
@@ -1,14 +1,14 @@
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const DEFAULT_API_URL = 'http://127.0.0.1:18000';
 const DEFAULT_REQUIREMENT_LIMIT = Number('100');
 const DEFAULT_TEST_LIMIT = Number('100');
 const DEFAULT_FLAKY_THRESHOLD = Number('0.2');
 const DEFAULT_FLAKY_LIMIT = Number('50');
 const DEFAULT_QUARANTINED_LIMIT = Number('50');
-const API_URL = import.meta.env.VITE_API_URL ?? DEFAULT_API_URL;
+const API_URL = API_ORIGIN;
 
 const getBulkHeaders = (): Record<string, string> => ({
   ...getAuthHeaders(),

--- a/frontend/apps/web/src/hooks/problems/problemsApi.ts
+++ b/frontend/apps/web/src/hooks/problems/problemsApi.ts
@@ -9,6 +9,7 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import {
   asArray,
   asBoolean,
@@ -22,7 +23,7 @@ import {
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface ProblemFilters {
   projectId: string;

--- a/frontend/apps/web/src/hooks/processes/process-api.ts
+++ b/frontend/apps/web/src/hooks/processes/process-api.ts
@@ -1,6 +1,7 @@
 import type { Process, ProcessExecution } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import type {
   CreateExecutionData,
@@ -14,7 +15,7 @@ import { processParsers } from './process-parsers';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface ProcessesResponse {
   processes: Process[];

--- a/frontend/apps/web/src/hooks/qa-metrics/api.ts
+++ b/frontend/apps/web/src/hooks/qa-metrics/api.ts
@@ -1,4 +1,5 @@
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import type {
   CoverageMetrics,
@@ -21,7 +22,7 @@ import {
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 async function readJsonRecord(res: Response): Promise<Record<string, unknown>> {
   const json: unknown = await res.json();

--- a/frontend/apps/web/src/hooks/test-runs/test-run-api.ts
+++ b/frontend/apps/web/src/hooks/test-runs/test-run-api.ts
@@ -1,6 +1,7 @@
 import type { TestResult, TestRun, TestRunActivity, TestRunStats } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import type { CreateTestRunData, SubmitTestResultData, TestRunFilters } from './test-run-types';
 
@@ -9,7 +10,7 @@ import { testRunParsers } from './test-run-parsers';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface TestRunsResponse {
   testRuns: TestRun[];

--- a/frontend/apps/web/src/hooks/test-suites/api.ts
+++ b/frontend/apps/web/src/hooks/test-suites/api.ts
@@ -7,6 +7,7 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import { asJsonObject, getOptionalArray, getOptionalNumber, getString } from './decoders';
 import {
@@ -18,7 +19,7 @@ import {
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface TestSuiteFilters {
   projectId: string;

--- a/frontend/apps/web/src/hooks/testCasesApi.ts
+++ b/frontend/apps/web/src/hooks/testCasesApi.ts
@@ -12,10 +12,11 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 const submitReviewResponseSchema = z.object({
   id: z.string(),

--- a/frontend/apps/web/src/hooks/use-specifications/api/base.ts
+++ b/frontend/apps/web/src/hooks/use-specifications/api/base.ts
@@ -1,4 +1,6 @@
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+import { API_ORIGIN } from '@/config/api-origin';
+
+const API_URL = API_ORIGIN;
 
 const setOptionalParam = (
   params: URLSearchParams,

--- a/frontend/apps/web/src/hooks/useChat.ts
+++ b/frontend/apps/web/src/hooks/useChat.ts
@@ -8,13 +8,14 @@ import type { SSEEvent, ToolCall } from '@/lib/ai/types';
 
 import { createAgentSession } from '@/api/agent';
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { buildSystemPrompt } from '@/lib/ai/systemPrompt';
 import { logger } from '@/lib/logger';
 import { useChatStore } from '@/stores/chat-store';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface SendMessageOptions {
   onChunk?: (chunk: string) => void;

--- a/frontend/apps/web/src/hooks/useItemSpecAnalytics.ts
+++ b/frontend/apps/web/src/hooks/useItemSpecAnalytics.ts
@@ -19,11 +19,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 // =============================================================================
 // Types

--- a/frontend/apps/web/src/hooks/useItems.ts
+++ b/frontend/apps/web/src/hooks/useItems.ts
@@ -4,11 +4,12 @@ import { toast } from 'sonner';
 import type { CreateItemData, CreateItemWithSpecData } from '@/hooks/use-items/items-utils';
 import type { Item, TypedItem, ViewType, ItemStatus } from '@tracertm/types';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import itemsUtils from '@/hooks/use-items/items-utils';
 import { QUERY_CONFIGS, queryKeys } from '@/lib/queryConfig';
 import { useAuthStore } from '@/stores/authStore';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface ItemFilters {
   projectId?: string | undefined;

--- a/frontend/apps/web/src/hooks/useNotifications.ts
+++ b/frontend/apps/web/src/hooks/useNotifications.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import type { SSEClient } from '@/lib/sse-client';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import { createNotificationSSEClient } from '@/lib/sse-client';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -28,7 +29,7 @@ export function useNotifications() {
   const { token } = useAuthStore();
   const queryClient = useQueryClient();
   const sseClientRef = useRef<SSEClient | null>(null);
-  const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+  const API_URL = API_ORIGIN;
 
   // Fetch initial notifications
   const query = useQuery({

--- a/frontend/apps/web/src/hooks/useQaMetrics.ts
+++ b/frontend/apps/web/src/hooks/useQaMetrics.ts
@@ -3,10 +3,11 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface QAMetricsSummary {
   projectId: string;

--- a/frontend/apps/web/src/hooks/useTemporal.ts
+++ b/frontend/apps/web/src/hooks/useTemporal.ts
@@ -6,12 +6,13 @@ import * as ReactQuery from '@tanstack/react-query';
 import type { Branch, Version } from '@/components/temporal/TemporalNavigator';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { QUERY_CONFIGS, queryKeys } from '@/lib/queryConfig';
 
 const { getAuthHeaders } = client;
 const { useMutation, useQuery, useQueryClient } = ReactQuery;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 type JsonObject = Record<string, unknown>;
 type TemporalConflict = Record<string, unknown>;
 

--- a/frontend/apps/web/src/hooks/useViewportGraph.ts
+++ b/frontend/apps/web/src/hooks/useViewportGraph.ts
@@ -25,11 +25,12 @@ import type { Edge, Node } from '@xyflow/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 /**
  * Viewport bounds with zoom level

--- a/frontend/apps/web/src/hooks/useWebhooks.ts
+++ b/frontend/apps/web/src/hooks/useWebhooks.ts
@@ -11,10 +11,11 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 const toNumber = (value: unknown, fallback: number): number =>
   value === undefined ? fallback : Number(value);

--- a/frontend/apps/web/src/hooks/useWorkflows.ts
+++ b/frontend/apps/web/src/hooks/useWorkflows.ts
@@ -3,10 +3,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { WorkflowRun, WorkflowSchedule } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 const REFRESH_RUNS_INTERVAL_MS = 15_000;
 const REFRESH_SCHEDULES_INTERVAL_MS = 30_000;
 

--- a/frontend/apps/web/src/lib/openapi-utils.ts
+++ b/frontend/apps/web/src/lib/openapi-utils.ts
@@ -1,3 +1,4 @@
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 /**
  * OpenAPI Utilities
@@ -174,7 +175,7 @@ export function getSupportedAuthTypes(
  */
 export function getServerUrls(spec: OpenAPISpec): string[] {
   if (!spec.servers || spec.servers.length === 0) {
-    return ['http://127.0.0.1:18000'];
+    return [API_ORIGIN];
   }
   return spec.servers.map((server) => server.url);
 }

--- a/frontend/apps/web/src/lib/preflight.ts
+++ b/frontend/apps/web/src/lib/preflight.ts
@@ -590,11 +590,6 @@ const fetchMcpStatus = async (baseUrl: string): Promise<Record<string, InfraStat
   }
 };
 
-const getDevHost = (): string =>
-  window.location.hostname && window.location.hostname !== 'localhost'
-    ? window.location.hostname
-    : '127.0.0.1';
-
 const buildChecks = (): PreflightCheck[] => {
   const checks: PreflightCheck[] = [];
   const configuredApiUrl = (import.meta.env?.VITE_API_URL ?? '').trim().replace(/\/$/, '');
@@ -612,18 +607,9 @@ const buildChecks = (): PreflightCheck[] => {
     return checks;
   }
 
-  // Use the approved local gateway. Direct legacy service ports are never
-  // browser origins; they bypass the readiness/auth contract.
-  const devHost = getDevHost();
-  const useGateway = window.location.port === '18000';
-  const gatewayBase = useGateway ? window.location.origin : `http://${devHost}:18000`;
-
-  if (useGateway) {
-    checks.push({ name: 'backend', url: gatewayBase });
-    return checks;
-  }
-
-  checks.push({ name: 'backend', url: gatewayBase });
+  // Keep development on the browser origin too: Vite proxies this path while
+  // the local Compose nginx serves it directly.
+  checks.push({ name: 'backend', url: window.location.origin });
   return checks;
 };
 

--- a/frontend/apps/web/src/lib/sse-client.ts
+++ b/frontend/apps/web/src/lib/sse-client.ts
@@ -2,6 +2,8 @@
  * Server-Sent Events (SSE) client with automatic reconnection and exponential backoff
  */
 
+import { API_ORIGIN } from '@/config/api-origin';
+
 export interface SSEClientOptions {
   url: string;
   headers?: Record<string, string>;
@@ -207,7 +209,7 @@ export function createNotificationSSEClient(
     return null;
   }
 
-  const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+  const API_URL = API_ORIGIN;
 
   return new SSEClient({
     url: `${API_URL}/api/v1/notifications/stream`,

--- a/frontend/apps/web/src/pages/settings/Settings.tsx
+++ b/frontend/apps/web/src/pages/settings/Settings.tsx
@@ -1,3 +1,5 @@
+import { API_ORIGIN } from '@/config/api-origin';
+
 export function Settings() {
   return (
     <div className='space-y-6'>
@@ -22,7 +24,7 @@ export function Settings() {
             <label className='text-sm font-medium'>Backend URL</label>
             <input
               type='text'
-              defaultValue='http://127.0.0.1:18000'
+              defaultValue={API_ORIGIN}
               className='mt-1 h-10 w-full rounded-lg border px-3'
             />
           </div>

--- a/frontend/apps/web/src/stores/auth-store.ts
+++ b/frontend/apps/web/src/stores/auth-store.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import { getCSRFHeaders } from '@/lib/csrf';
 import { logger } from '@/lib/logger';
 
-const API_BASE_URL_DEFAULT = 'http://127.0.0.1:18000';
+const API_BASE_URL_DEFAULT = API_ORIGIN;
 const AUTH_TOKEN_KEY = 'auth_token';
 const HTTP_UNAUTHORIZED = Number('401');
 const REFRESH_INTERVAL_MINUTES = Number('20');

--- a/frontend/apps/web/src/views/DashboardView.tsx
+++ b/frontend/apps/web/src/views/DashboardView.tsx
@@ -243,7 +243,8 @@ export function DashboardView({ systemStatus }: DashboardViewProps) {
         <div>
           <h1 className='text-2xl font-bold tracking-tight'>Traceability Dashboard</h1>
           <p className='text-muted-foreground text-sm'>
-            Monitor project health and system-wide traceability status.
+            Monitor project health and system-wide traceability status. Traceability and Evidence
+            details are available in each project.
           </p>
           <div className='mt-3 flex flex-wrap items-center gap-2'>
             <Badge variant='outline' className='text-xs'>

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -86,7 +86,7 @@
         "@tanstack/react-query": "^5.90.11",
         "@tanstack/react-router": "^1.158.1",
         "@tanstack/react-table": "^8.21.3",
-        "@tanstack/react-virtual": "^3.13.12",
+        "@tanstack/react-virtual": "^3.14.9",
         "@tanstack/router-devtools": "^1.158.1",
         "@tracertm/api-client": "workspace:*",
         "@tracertm/state": "workspace:*",
@@ -124,9 +124,9 @@
         "openapi-typescript-helpers": "^0.0.15",
         "prop-types": "^15.8.1",
         "rbush": "^4.0.1",
-        "react": "^19.2.0",
+        "react": "^19.2.8",
         "react-cytoscapejs": "^2.0.0",
-        "react-dom": "^19.2.0",
+        "react-dom": "^19.2.8",
         "react-hook-form": "^7.71.1",
         "react-hotkeys-hook": "^4.6.1",
         "react-is": "^19.2.8",
@@ -137,28 +137,28 @@
         "swagger-ui-react": "^5.30.3",
         "tailwind-merge": "^3.4.0",
         "use-sync-external-store": "^1.6.0",
-        "web-vitals": "^4.2.4",
+        "web-vitals": "^6.0.1",
         "zod": "^3.24.1",
         "zustand": "^5.0.9",
       },
       "devDependencies": {
         "@axe-core/react": "^4.11.0",
-        "@pact-foundation/pact": "^16.0.4",
+        "@pact-foundation/pact": "^17.0.1",
         "@pact-foundation/pact-node": "^10.18.0",
         "@percy/playwright": "^1.0.10",
         "@playwright/test": "^1.57.0",
         "@rollup/plugin-commonjs": "^29.0.0",
         "@storybook/addon-a11y": "8.6.14",
-        "@storybook/addon-coverage": "3.0.0",
+        "@storybook/addon-coverage": "3.0.2",
         "@storybook/addon-docs": "8.6.14",
         "@storybook/addon-themes": "8.6.14",
-        "@storybook/react": "8.6.14",
-        "@storybook/react-vite": "8.6.14",
+        "@storybook/react": "10.5.5",
+        "@storybook/react-vite": "10.5.5",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query-devtools": "^5.91.1",
         "@tanstack/react-start": "^1.158.1",
-        "@tanstack/router-generator": "^1.158.1",
-        "@tanstack/router-plugin": "^1.158.1",
+        "@tanstack/router-generator": "^1.167.21",
+        "@tanstack/router-plugin": "^1.168.23",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -172,7 +172,7 @@
         "@types/react": "^19.0.1",
         "@types/react-dom": "^19.0.1",
         "@types/swagger-ui-react": "^5.18.0",
-        "@vitejs/plugin-react": "^5.1.1",
+        "@vitejs/plugin-react": "^6.0.4",
         "@vitest/browser": "4.1.10",
         "@vitest/browser-playwright": "4.1.10",
         "@vitest/coverage-v8": "^4.1.10",
@@ -181,11 +181,11 @@
         "axe-core": "^4.11.0",
         "axe-playwright": "^2.2.2",
         "babel-plugin-react-compiler": "^1.0.0",
-        "chromatic": "^13.3.5",
+        "chromatic": "^18.1.0",
         "comlink": "^4.4.2",
         "graphql": "^16.8.1",
         "happy-dom": "^20.4.0",
-        "jest-axe": "^10.0.0",
+        "jest-axe": "^11.0.0",
         "jsdom": "^28.0.0",
         "lighthouse": "^13.0.1",
         "lighthouse-ci": "^1.13.1",
@@ -194,7 +194,7 @@
         "playwright-lighthouse": "^4.0.0",
         "redocly": "^1.0.0",
         "sharp": "^0.35.3",
-        "storybook": "8.6.17",
+        "storybook": "10.5.5",
         "svgo": "^4.0.0",
         "swagger-ui-dist": "^5.30.3",
         "tailwindcss": "^4.1.17",
@@ -811,23 +811,23 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@1.43.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA=="],
 
-    "@pact-foundation/pact": ["@pact-foundation/pact@16.5.0", "", { "dependencies": { "@pact-foundation/pact-core": "^19.2.0", "axios": "^1.12.2", "body-parser": "^2.2.0", "chalk": "4.1.2", "express": "^5.1.0", "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "http-proxy": "^1.18.1", "https-proxy-agent": "^9.0.0", "js-base64": "^3.7.8", "lodash": "^4.17.21", "ramda": "^0.32.0", "randexp": "^0.5.3", "router": "^2.2.0", "stack-utils": "^2.0.6" } }, "sha512-9YgmU6fDJGQVYoAm2ez52dyKfQwFzW47GlrT8IAKuzjL6qZVZ9+ael6myeMbQqz7J5lzEGLoUi2PMkBFFgQxRw=="],
+    "@pact-foundation/pact": ["@pact-foundation/pact@17.1.0", "", { "dependencies": { "@pact-foundation/pact-core": "^20.1.0", "@scarf/scarf": "^1.4.0", "axios": "^1.12.2", "body-parser": "^2.2.0", "chalk": "6.0.0", "express": "^5.1.0", "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "http-proxy": "^1.18.1", "https-proxy-agent": "^9.0.0", "js-base64": "^3.7.8", "lodash": "^4.17.21", "ramda": "^0.32.0", "randexp": "^0.5.3", "router": "^2.2.0", "stack-utils": "^2.0.6" } }, "sha512-nJ9CuAAVrIeGsjXVR53hDLjiSiRj4YONZT5ER5mV+4a8lXbfSFLXDyKk9j+B5dDvP+alYG/xBFnPBtRX6qSj0g=="],
 
-    "@pact-foundation/pact-core": ["@pact-foundation/pact-core@19.2.0", "", { "dependencies": { "check-types": "11.2.3", "detect-libc": "^2.0.3", "node-gyp-build": "^4.6.0", "pino": "^10.0.0", "pino-pretty": "^13.1.1", "underscore": "1.13.8" }, "optionalDependencies": { "@pact-foundation/pact-core-darwin-arm64": "19.2.0", "@pact-foundation/pact-core-darwin-x64": "19.2.0", "@pact-foundation/pact-core-linux-arm64-glibc": "19.2.0", "@pact-foundation/pact-core-linux-arm64-musl": "19.2.0", "@pact-foundation/pact-core-linux-x64-glibc": "19.2.0", "@pact-foundation/pact-core-linux-x64-musl": "19.2.0", "@pact-foundation/pact-core-windows-x64": "19.2.0" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "ia32", "arm64", ] }, "sha512-7EB2e850hmBzGnwOYTRj4TCFCJQa9zaOy53bK+ybzEDx801olf0gVlYqMYHt1EsHUZzmtS5uDybpr9UMcZQxgg=="],
+    "@pact-foundation/pact-core": ["@pact-foundation/pact-core@20.1.0", "", { "dependencies": { "check-types": "11.2.3", "detect-libc": "^2.0.3", "node-gyp-build": "^4.6.0", "pino": "^10.0.0", "pino-pretty": "^13.1.1", "underscore": "1.13.8" }, "optionalDependencies": { "@pact-foundation/pact-core-darwin-arm64": "20.1.0", "@pact-foundation/pact-core-darwin-x64": "20.1.0", "@pact-foundation/pact-core-linux-arm64-glibc": "20.1.0", "@pact-foundation/pact-core-linux-arm64-musl": "20.1.0", "@pact-foundation/pact-core-linux-x64-glibc": "20.1.0", "@pact-foundation/pact-core-linux-x64-musl": "20.1.0", "@pact-foundation/pact-core-windows-x64": "20.1.0" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "ia32", "arm64", ] }, "sha512-VPMV5X/gq5BTcQH7lbmmj5v4O1p+rG5iHemghrjNz+RFMHjISf657uIL5pZvhkOilHfGH2QuAvMgwRP16g2isw=="],
 
-    "@pact-foundation/pact-core-darwin-arm64": ["@pact-foundation/pact-core-darwin-arm64@19.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cQvvWfJKS7iMzkunzh/kdgmyVLhAxyr/BQ8fOnMco2M/1+GHR+sOXvhrR1tes+NAYd1xjE3fbg1K2Flno8aDBw=="],
+    "@pact-foundation/pact-core-darwin-arm64": ["@pact-foundation/pact-core-darwin-arm64@20.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GsQ1vgrcmfGFVzmudvvXthPrd53tarSxrSOBl9TvUJsnhCF/qENYe5hTYWXiAtCpugB3g7V8/J+iOg5qrtPhOw=="],
 
-    "@pact-foundation/pact-core-darwin-x64": ["@pact-foundation/pact-core-darwin-x64@19.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-UltPXDZ+h1r3JqgIpEBP16bQzB90otd1QbcoeM3XakF9khCrYhW4y9llSuaosyqPFYwCk+mLaZTl/4iitJJaow=="],
+    "@pact-foundation/pact-core-darwin-x64": ["@pact-foundation/pact-core-darwin-x64@20.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZQdwQJtSwNPCeMxIfl8XJPeizohPh7jquS6JBNw20EmSKg5eCVWIw3hdKuxZuIYGt/zze05ky8Z45nzn3qvHiQ=="],
 
-    "@pact-foundation/pact-core-linux-arm64-glibc": ["@pact-foundation/pact-core-linux-arm64-glibc@19.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-amiv4COurH1FRa7DSH3ks4UPQCb5J3x4GKrArf8UsTOkNhVGFUWVl83LOELj9Gtk67GwJ96iF7/fQps8I/iFIA=="],
+    "@pact-foundation/pact-core-linux-arm64-glibc": ["@pact-foundation/pact-core-linux-arm64-glibc@20.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jy+zd2tEL5jAbOf2PcW/xvf1onJBea7IzuFZMIKs+Jh0dl0c+9M7eg8L13plzGU4T3xhOzMn5X8IXyajYt2iIQ=="],
 
-    "@pact-foundation/pact-core-linux-arm64-musl": ["@pact-foundation/pact-core-linux-arm64-musl@19.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tGWF7dP72Ho1A1PApyUqUMRI/e+gfbPxfaXxwWMXNh8JLK2jQQnP4bWymGwHQ4vxL7wn8ayx8I5y6x1vk/2+rA=="],
+    "@pact-foundation/pact-core-linux-arm64-musl": ["@pact-foundation/pact-core-linux-arm64-musl@20.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8yY9ckAj0Fx/wojtsdonf7GEdTEfdvD+yzllZlmwCbfSGqA7dsbThVtSAjt+myylce82YSqxzmgqPJJn5GSm3w=="],
 
-    "@pact-foundation/pact-core-linux-x64-glibc": ["@pact-foundation/pact-core-linux-x64-glibc@19.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/ZNuWKuFJSBRZH09t7FXqKLy5koCaMIZ4RdbockLYlNo8uWF2ALfRCllj+SbXPLK+T+lVnBrs5s94X2cu4Rc7A=="],
+    "@pact-foundation/pact-core-linux-x64-glibc": ["@pact-foundation/pact-core-linux-x64-glibc@20.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-S4avgkfvM9fe2dtnAVUw8FRRs4Bjj4YMcrDcoGondf58mQtIAnsNuKVrmBjfz29qGTxb4amopTTlQNW6w8VIew=="],
 
-    "@pact-foundation/pact-core-linux-x64-musl": ["@pact-foundation/pact-core-linux-x64-musl@19.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-n0m39CzVkq8J2alir1redm0rAdUVQzkKJqYBQdRmhEIa+QeGjUrJq+gmakUysoJxfSY4UthnJ9jS8SoyiZ+k6A=="],
+    "@pact-foundation/pact-core-linux-x64-musl": ["@pact-foundation/pact-core-linux-x64-musl@20.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-o7qzQ4C4mBYpBCDmtGssGurCTFI/9vuqP1T8VavyeTbyeZThI9j2iWTpeNOmKlrI5+jnaWHYNeuwpqh6FFRurQ=="],
 
-    "@pact-foundation/pact-core-windows-x64": ["@pact-foundation/pact-core-windows-x64@19.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WZSDBL1Sn8y5+YJTK+HDiS/Fn9th1M4QJW2dflQ8UFwoaIh6yb0TrJjtuWbDGIwNeD4Sv8CJ5jJOf1nyNjFLfg=="],
+    "@pact-foundation/pact-core-windows-x64": ["@pact-foundation/pact-core-windows-x64@20.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-EutN/FQy/Fa6y5k0+Kfqy9o6uLzcz9J4y6aq6x+AsBpsPIakBYYugCZzXt6WZ+W9jzgY0cNtwOGjkWZI/gUucA=="],
 
     "@pact-foundation/pact-node": ["@pact-foundation/pact-node@10.18.0", "", { "dependencies": { "@types/needle": "^2.5.3", "@types/q": "1.5.5", "@types/request": "2.48.8", "chalk": "2.4.2", "check-types": "7.4.0", "cross-spawn": "^7.0.3", "libnpmconfig": "^1.2.1", "mkdirp": "1.0.4", "needle": "^2.9.1", "pino": "^8.11.0", "pino-pretty": "^9.4.0", "q": "1.5.1", "rimraf": "2.7.1", "sumchecker": "^2.0.2", "tar": "^6.1.13", "underscore": "1.13.6", "unixify": "1.0.0", "unzipper": "^0.10.11", "url-join": "^4.0.1" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "ia32", "arm64", ], "bin": { "pact": "bin/pact.js", "pact-broker": "bin/pact-broker.js", "pact-message": "bin/pact-message.js", "pact-mock-service": "bin/pact-mock-service.js", "pact-stub-service": "bin/pact-stub-service.js", "pact-provider-verifier": "bin/pact-provider-verifier.js" } }, "sha512-q6b/q0/IbuDSub2rL2pB/Zu5340vWGN+nUIk9I9HhJwbN/xOBv2yK2mve5ygTUUiKFNn4/1M9/YJ8ze/P5Etrw=="],
 
@@ -1053,7 +1053,7 @@
 
     "@storybook/addon-a11y": ["@storybook/addon-a11y@8.6.14", "", { "dependencies": { "@storybook/addon-highlight": "8.6.14", "@storybook/global": "^5.0.0", "@storybook/test": "8.6.14", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^8.6.14" } }, "sha512-fozv6enO9IgpWq2U8qqS8MZ21Nt+MVHiRQe3CjnCpBOejTyo/ATm690PeYYRVHVG6M/15TVePb0h3ngKQbrrzQ=="],
 
-    "@storybook/addon-coverage": ["@storybook/addon-coverage@3.0.0", "", { "dependencies": { "@istanbuljs/load-nyc-config": "^1.1.0", "@jsdevtools/coverage-istanbul-loader": "^3.0.5", "@types/istanbul-lib-coverage": "^2.0.4", "convert-source-map": "^2.0.0", "espree": "^9.6.1", "istanbul-lib-instrument": "^6.0.1", "test-exclude": "^6.0.0", "vite-plugin-istanbul": "^6.0.2" } }, "sha512-ADXpeAXtSvyGs1BSZhtO5Bi2BUedcP6eGPcBm7w3cYSj6KTpww4epEp1lnUD4faojSBBIOI2bRa/a4NA+/zt2Q=="],
+    "@storybook/addon-coverage": ["@storybook/addon-coverage@3.0.2", "", { "dependencies": { "@istanbuljs/load-nyc-config": "^1.1.0", "@jsdevtools/coverage-istanbul-loader": "^3.0.5", "@types/istanbul-lib-coverage": "^2.0.4", "convert-source-map": "^2.0.0", "espree": "^9.6.1", "istanbul-lib-instrument": "^6.0.1", "test-exclude": "^6.0.0", "vite-plugin-istanbul": "^6.0.2" } }, "sha512-QSWogA2gBSk1cHGnW/GNgO/OljcbI24PYr6fJKR8rNL0iusL84Sckbb4l2EjbMTotUx9NqSQUK2YKZr88EOpeQ=="],
 
     "@storybook/addon-docs": ["@storybook/addon-docs@8.6.14", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/blocks": "8.6.14", "@storybook/csf-plugin": "8.6.14", "@storybook/react-dom-shim": "8.6.14", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^8.6.14" } }, "sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ=="],
 
@@ -1731,7 +1731,7 @@
 
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
-    "chromatic": ["chromatic@13.3.5", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw=="],
+    "chromatic": ["chromatic@18.1.0", "", { "dependencies": { "semver": "^7.3.5" }, "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0", "@chromatic-com/vitest": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright", "@chromatic-com/vitest"], "bin": { "chroma": "dist/bin.cjs", "chromatic": "dist/bin.cjs", "chromatic-cli": "dist/bin.cjs" } }, "sha512-I9av8lUc5CQRlYzwKpmOG9cwYvZ4AFmTvtHeNrzOMC1353F9xYw45CHpSNIsNKuOiqqmzci9esXQd5akl0fi6w=="],
 
     "chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
@@ -1956,8 +1956,6 @@
     "devtools-protocol": ["devtools-protocol@0.0.1663043", "", {}, "sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
-
-    "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -2451,13 +2449,11 @@
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
-    "jest-axe": ["jest-axe@10.0.0", "", { "dependencies": { "axe-core": "4.10.2", "chalk": "4.1.2", "jest-matcher-utils": "29.2.2", "lodash.merge": "4.6.2" } }, "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg=="],
+    "jest-axe": ["jest-axe@11.0.0", "", { "dependencies": { "axe-core": "4.12.1", "chalk": "4.1.2", "jest-matcher-utils": "30.4.1", "lodash.merge": "4.6.2" } }, "sha512-JuLD/QzqDn5QxpFUMkbmf55GiI+sdutpryRD//rIRuyEefYAuMfQbQZ53TsNtZXKV3rjgfD4KKTKPY+2Ga1mGw=="],
 
-    "jest-diff": ["jest-diff@29.7.0", "", { "dependencies": { "chalk": "^4.0.0", "diff-sequences": "^29.6.3", "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw=="],
+    "jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
 
-    "jest-get-type": ["jest-get-type@29.6.3", "", {}, "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw=="],
-
-    "jest-matcher-utils": ["jest-matcher-utils@29.2.2", "", { "dependencies": { "chalk": "^4.0.0", "jest-diff": "^29.2.1", "jest-get-type": "^29.2.0", "pretty-format": "^29.2.1" } }, "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw=="],
+    "jest-matcher-utils": ["jest-matcher-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.4.1", "pretty-format": "30.4.1" } }, "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A=="],
 
     "jest-message-util": ["jest-message-util@30.4.1", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.4.1", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "jest-util": "30.4.1", "picomatch": "^4.0.3", "pretty-format": "30.4.1", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ=="],
 
@@ -3523,7 +3519,7 @@
 
     "web-tree-sitter": ["web-tree-sitter@0.24.5", "", {}, "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w=="],
 
-    "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
+    "web-vitals": ["web-vitals@6.1.0", "", {}, "sha512-ZNoJ/MbU6aaR2WjKrFVUvy5WQx+G96YvXQFSsmKTz3A/0VlAFywjUcxl00hc/S6wef2stfgQ4yWYIJCWCNudkA=="],
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
 
@@ -3626,6 +3622,8 @@
     "@keyv/bigmap/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@pact-foundation/pact/chalk": ["chalk@6.0.0", "", {}, "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg=="],
 
     "@pact-foundation/pact-core/check-types": ["check-types@11.2.3", "", {}, "sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg=="],
 
@@ -3895,8 +3893,6 @@
 
     "espree/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "expect/jest-matcher-utils": ["jest-matcher-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.4.1", "pretty-format": "30.4.1" } }, "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A=="],
-
     "express/content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
@@ -3925,11 +3921,9 @@
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "jest-axe/axe-core": ["axe-core@4.10.2", "", {}, "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w=="],
+    "jest-diff/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
-    "jest-diff/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
-
-    "jest-matcher-utils/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+    "jest-matcher-utils/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
     "jest-message-util/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
@@ -4245,27 +4239,15 @@
 
     "eslint/file-entry-cache/flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "expect/jest-matcher-utils/jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
-
-    "expect/jest-matcher-utils/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
-
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "help-me/glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "istanbul-lib-report/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "jest-diff/pretty-format/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
-
     "jest-diff/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
-    "jest-diff/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "jest-matcher-utils/pretty-format/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
-
     "jest-matcher-utils/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "jest-matcher-utils/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "jest-message-util/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -4396,8 +4378,6 @@
     "eslint-plugin-filename-export/@typescript-eslint/utils/@typescript-eslint/typescript-estree/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "eslint-plugin-filename-export/@typescript-eslint/utils/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
-
-    "expect/jest-matcher-utils/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "help-me/glob/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -7,6 +7,9 @@ import re
 
 compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
+frontend_dockerfile = Path("frontend/Dockerfile.local").read_text(encoding="utf-8")
+nginx = Path("frontend/deploy/nginx.local.conf").read_text(encoding="utf-8")
+api_origin = Path("frontend/apps/web/src/config/api-origin.ts").read_text(encoding="utf-8")
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (
@@ -20,6 +23,36 @@ assert frontend and "condition: service_healthy" in frontend.group(1), (
 )
 assert '"${TRACERA_LOCAL_BIND_ADDR:-127.0.0.1}:${TRACERA_LOCAL_PORT:-18081}:80"' in compose, (
     "frontend publication must default to loopback"
+)
+assert "ENV VITE_API_URL=" in frontend_dockerfile, (
+    "local frontend build must opt into the browser's same-origin API path"
+)
+assert "VITE_API_BASE" not in frontend_dockerfile, (
+    "local frontend build must not set the unused VITE_API_BASE variable"
+)
+assert "window.location.origin" in api_origin, (
+    "empty VITE_API_URL must resolve to the browser's current origin"
+)
+assert "proxy_pass http://tracera-server:8080" in nginx, (
+    "local nginx must proxy API requests to the private Rust backend"
+)
+
+source_root = Path("frontend/apps/web/src")
+loopback_fallbacks = []
+for path in source_root.rglob("*"):
+    if (
+        path.suffix not in {".ts", ".tsx", ".js", ".jsx"}
+        or "__tests__" in path.parts
+        or "mocks" in path.parts
+        or ".test." in path.name
+    ):
+        continue
+    text = path.read_text(encoding="utf-8")
+    if "127.0.0.1:18000" in text or "localhost:4000" in text or ":18000" in text:
+        loopback_fallbacks.append(str(path))
+assert not loopback_fallbacks, (
+    "browser client must not fall back to an unpublished loopback backend: "
+    + ", ".join(loopback_fallbacks)
 )
 print("local Compose readiness contract: PASS")
 PY


### PR DESCRIPTION
## **User description**
## Summary
- build the local frontend with the canonical `VITE_API_URL` setting
- resolve unconfigured browser clients to `window.location.origin`, so Vite and local Compose nginx own the API route
- remove production direct fallbacks to unpublished `:18000` and add a static Compose regression contract

## Validation
- `bun -e "... api-origin resolver ..."` (same-origin and WebSocket origin)
- `./scripts/test-local-compose-contract.sh`
- `./scripts/test-local-stack-health.sh`
- `POSTGRES_PASSWORD=local-audit-password docker compose -f docker-compose.local.yml config` plus rendered contract assertions
- `git diff --check`

## Known gate
`bun install --frozen-lockfile --dry-run` remains blocked by the pre-existing lock mismatch addressed separately by #774; no lockfile was modified here. Docker daemon was unavailable, so this PR contains no live-container claim.


___

## **CodeAnt-AI Description**
Route all local frontend traffic through the same-origin API gateway

### What Changed
- Browser API, WebSocket, downloads, notifications, authentication, and preflight requests now use the configured API origin or the current frontend origin when no API URL is set
- Local Compose builds configure the frontend with the canonical API setting, allowing nginx to proxy requests to the private backend
- Removed direct browser fallbacks to unpublished local backend ports
- Settings now displays the resolved backend URL
- Added checks to prevent local Compose configuration from reintroducing direct backend routing

### Impact
`✅ Working local Compose API requests`
`✅ Fewer browser routing and CORS failures`
`✅ Consistent API, WebSocket, and notification connections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
