### PR TITLE
fix(frontend): enforce canonical Tracera deployment title

### DIFF
--- a/frontend/apps/web/index.html
+++ b/frontend/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TraceRTM</title>
+    <title>Tracera</title>
     <!-- Geist font family (Vercel) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- normalize the deployment document title to canonical `Tracera`
- satisfy `frontend/scripts/test-deployment-artifact.mjs` canonical-title contract

## Validation
- source inspection confirms `<title>Tracera</title>`
- full Bun artifact validation remains blocked by an existing frozen-lockfile mismatch

## Governance
- Focused adjacent fix only; no merge, release, or dogfood claim.
- Review, hosted build, artifact, and runtime evidence remain required.