### PR TITLE
fix(web): isolate same-origin browser API routing

### DIFF
--- a/frontend/Dockerfile.local
+++ b/frontend/Dockerfile.local
@@ -4,7 +4,7 @@ COPY package.json package-lock.json ./
 COPY apps ./apps
 COPY scripts ./scripts
 RUN npm ci --ignore-scripts
-ENV VITE_API_BASE=
+ENV VITE_API_URL=
 RUN npm run build
 
 FROM nginx:1.27-alpine

--- a/frontend/apps/web/src/api/client-core.ts
+++ b/frontend/apps/web/src/api/client-core.ts
@@ -2,6 +2,7 @@ import type { HttpMethod } from 'openapi-typescript-helpers';
 
 import createClient from 'openapi-fetch';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 
 import { getCSRFHeaders } from '../lib/csrf';
@@ -12,22 +13,7 @@ import { responseHandlers } from './client-response-handlers';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- openapi-fetch needs explicit HttpMethod keys to avoid PathsWithMethod resolving to never under exactOptionalPropertyTypes
 type AnyPaths = { [path: string]: { [method in HttpMethod]: any } };
 
-const getBackendURL = (_path?: string): string => {
-  const { env } = import.meta;
-  let url = '';
-
-  if (env && env.VITE_API_URL) {
-    url = env.VITE_API_URL;
-  }
-
-  if (url !== '') {
-    return url.replace(/\/$/, '');
-  }
-
-  return 'http://127.0.0.1:18000';
-};
-
-const API_BASE_URL = getBackendURL();
+const API_BASE_URL = API_ORIGIN;
 
 const rawApiClient = createClient<AnyPaths>({
   baseUrl: API_BASE_URL,

--- a/frontend/apps/web/src/api/executions.ts
+++ b/frontend/apps/web/src/api/executions.ts
@@ -1,5 +1,7 @@
 // Execution API endpoints for QA Integration
 
+import { API_ORIGIN } from '@/config/api-origin';
+
 import { client, handleApiResponse, safeApiCall } from './client';
 
 const { apiClient } = client;
@@ -187,7 +189,7 @@ const create = async (projectId: string, data: ExecutionCreate): Promise<Executi
   );
 
 const downloadArtifact = (projectId: string, executionId: string, artifactId: string): string =>
-  `${import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000'}/api/v1/projects/${projectId}/executions/${executionId}/artifacts/${artifactId}/download`;
+  `${API_ORIGIN}/api/v1/projects/${projectId}/executions/${executionId}/artifacts/${artifactId}/download`;
 
 const get = async (projectId: string, executionId: string): Promise<Execution> =>
   handleApiResponse(

--- a/frontend/apps/web/src/api/github.ts
+++ b/frontend/apps/web/src/api/github.ts
@@ -4,8 +4,9 @@
  */
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 /**
  * Default fetch config for authenticated requests

--- a/frontend/apps/web/src/config/api-origin.ts
+++ b/frontend/apps/web/src/config/api-origin.ts
@@ -1,8 +1,8 @@
 /** Single browser origin for the approved Tracera gateway. */
-export const API_ORIGIN = (
-  import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000'
-).replace(/\/$/, '');
+const configuredApiOrigin = import.meta.env.VITE_API_URL?.trim();
+const browserOrigin = typeof window === 'undefined' ? '' : window.location.origin;
 
-export const WS_ORIGIN = (
-  import.meta.env.VITE_WS_URL ?? API_ORIGIN.replace(/^http/, 'ws')
-).replace(/\/$/, '');
+export const API_ORIGIN = (configuredApiOrigin || browserOrigin).replace(/\/$/, '');
+
+const configuredWsOrigin = import.meta.env.VITE_WS_URL?.trim();
+export const WS_ORIGIN = (configuredWsOrigin || API_ORIGIN.replace(/^http/, 'ws')).replace(/\/$/, '');

--- a/frontend/apps/web/src/config/constants.ts
+++ b/frontend/apps/web/src/config/constants.ts
@@ -1,3 +1,5 @@
+import { API_ORIGIN, WS_ORIGIN } from './api-origin';
+
 // Application constants
 
 const APP_NAME = 'TraceRTM';
@@ -13,9 +15,8 @@ const AUTH_ROUTES = {
 } as const;
 
 // API configuration (gateway-only; no direct backend URLs)
-const { VITE_API_URL, VITE_WS_URL } = import.meta.env || {};
-const API_BASE_URL = VITE_API_URL || 'http://127.0.0.1:18000';
-const WS_BASE_URL = VITE_WS_URL || 'ws://127.0.0.1:18000';
+const API_BASE_URL = API_ORIGIN;
+const WS_BASE_URL = WS_ORIGIN;
 // 30 seconds
 const API_TIMEOUT = 30_000;
 

--- a/frontend/apps/web/src/hooks/coverage/api.ts
+++ b/frontend/apps/web/src/hooks/coverage/api.ts
@@ -8,10 +8,11 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+const API_URL = API_ORIGIN;
 
 function transformCoverage(data: Record<string, unknown>): TestCoverage {
   return {

--- a/frontend/apps/web/src/hooks/integrationsApi.ts
+++ b/frontend/apps/web/src/hooks/integrationsApi.ts
@@ -1,7 +1,8 @@
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 export { API_URL, getAuthHeaders };

--- a/frontend/apps/web/src/hooks/item-specs/constants.ts
+++ b/frontend/apps/web/src/hooks/item-specs/constants.ts
@@ -1,14 +1,14 @@
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const DEFAULT_API_URL = 'http://127.0.0.1:18000';
 const DEFAULT_REQUIREMENT_LIMIT = Number('100');
 const DEFAULT_TEST_LIMIT = Number('100');
 const DEFAULT_FLAKY_THRESHOLD = Number('0.2');
 const DEFAULT_FLAKY_LIMIT = Number('50');
 const DEFAULT_QUARANTINED_LIMIT = Number('50');
-const API_URL = import.meta.env.VITE_API_URL ?? DEFAULT_API_URL;
+const API_URL = API_ORIGIN;
 
 const getBulkHeaders = (): Record<string, string> => ({
   ...getAuthHeaders(),

--- a/frontend/apps/web/src/hooks/problems/problemsApi.ts
+++ b/frontend/apps/web/src/hooks/problems/problemsApi.ts
@@ -9,6 +9,7 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import {
   asArray,
   asBoolean,
@@ -22,7 +23,7 @@ import {
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface ProblemFilters {
   projectId: string;

--- a/frontend/apps/web/src/hooks/processes/process-api.ts
+++ b/frontend/apps/web/src/hooks/processes/process-api.ts
@@ -1,6 +1,7 @@
 import type { Process, ProcessExecution } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import type {
   CreateExecutionData,
@@ -14,7 +15,7 @@ import { processParsers } from './process-parsers';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface ProcessesResponse {
   processes: Process[];

--- a/frontend/apps/web/src/hooks/qa-metrics/api.ts
+++ b/frontend/apps/web/src/hooks/qa-metrics/api.ts
@@ -1,4 +1,5 @@
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import type {
   CoverageMetrics,
@@ -21,7 +22,7 @@ import {
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 async function readJsonRecord(res: Response): Promise<Record<string, unknown>> {
   const json: unknown = await res.json();

--- a/frontend/apps/web/src/hooks/test-runs/test-run-api.ts
+++ b/frontend/apps/web/src/hooks/test-runs/test-run-api.ts
@@ -1,6 +1,7 @@
 import type { TestResult, TestRun, TestRunActivity, TestRunStats } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import type { CreateTestRunData, SubmitTestResultData, TestRunFilters } from './test-run-types';
 
@@ -9,7 +10,7 @@ import { testRunParsers } from './test-run-parsers';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface TestRunsResponse {
   testRuns: TestRun[];

--- a/frontend/apps/web/src/hooks/test-suites/api.ts
+++ b/frontend/apps/web/src/hooks/test-suites/api.ts
@@ -7,6 +7,7 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 import { asJsonObject, getOptionalArray, getOptionalNumber, getString } from './decoders';
 import {
@@ -18,7 +19,7 @@ import {
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface TestSuiteFilters {
   projectId: string;

--- a/frontend/apps/web/src/hooks/testCasesApi.ts
+++ b/frontend/apps/web/src/hooks/testCasesApi.ts
@@ -12,10 +12,11 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 const submitReviewResponseSchema = z.object({
   id: z.string(),

--- a/frontend/apps/web/src/hooks/use-specifications/api/base.ts
+++ b/frontend/apps/web/src/hooks/use-specifications/api/base.ts
@@ -1,4 +1,6 @@
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+import { API_ORIGIN } from '@/config/api-origin';
+
+const API_URL = API_ORIGIN;
 
 const setOptionalParam = (
   params: URLSearchParams,

--- a/frontend/apps/web/src/hooks/useChat.ts
+++ b/frontend/apps/web/src/hooks/useChat.ts
@@ -8,13 +8,14 @@ import type { SSEEvent, ToolCall } from '@/lib/ai/types';
 
 import { createAgentSession } from '@/api/agent';
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { buildSystemPrompt } from '@/lib/ai/systemPrompt';
 import { logger } from '@/lib/logger';
 import { useChatStore } from '@/stores/chat-store';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface SendMessageOptions {
   onChunk?: (chunk: string) => void;

--- a/frontend/apps/web/src/hooks/useItemSpecAnalytics.ts
+++ b/frontend/apps/web/src/hooks/useItemSpecAnalytics.ts
@@ -19,11 +19,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 // =============================================================================
 // Types

--- a/frontend/apps/web/src/hooks/useItems.ts
+++ b/frontend/apps/web/src/hooks/useItems.ts
@@ -4,11 +4,12 @@ import { toast } from 'sonner';
 import type { CreateItemData, CreateItemWithSpecData } from '@/hooks/use-items/items-utils';
 import type { Item, TypedItem, ViewType, ItemStatus } from '@tracertm/types';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import itemsUtils from '@/hooks/use-items/items-utils';
 import { QUERY_CONFIGS, queryKeys } from '@/lib/queryConfig';
 import { useAuthStore } from '@/stores/authStore';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface ItemFilters {
   projectId?: string | undefined;

--- a/frontend/apps/web/src/hooks/useNotifications.ts
+++ b/frontend/apps/web/src/hooks/useNotifications.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import type { SSEClient } from '@/lib/sse-client';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import { createNotificationSSEClient } from '@/lib/sse-client';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -28,7 +29,7 @@ export function useNotifications() {
   const { token } = useAuthStore();
   const queryClient = useQueryClient();
   const sseClientRef = useRef<SSEClient | null>(null);
-  const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+  const API_URL = API_ORIGIN;
 
   // Fetch initial notifications
   const query = useQuery({

--- a/frontend/apps/web/src/hooks/useQaMetrics.ts
+++ b/frontend/apps/web/src/hooks/useQaMetrics.ts
@@ -3,10 +3,11 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 interface QAMetricsSummary {
   projectId: string;

--- a/frontend/apps/web/src/hooks/useTemporal.ts
+++ b/frontend/apps/web/src/hooks/useTemporal.ts
@@ -6,12 +6,13 @@ import * as ReactQuery from '@tanstack/react-query';
 import type { Branch, Version } from '@/components/temporal/TemporalNavigator';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { QUERY_CONFIGS, queryKeys } from '@/lib/queryConfig';
 
 const { getAuthHeaders } = client;
 const { useMutation, useQuery, useQueryClient } = ReactQuery;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 type JsonObject = Record<string, unknown>;
 type TemporalConflict = Record<string, unknown>;
 

--- a/frontend/apps/web/src/hooks/useViewportGraph.ts
+++ b/frontend/apps/web/src/hooks/useViewportGraph.ts
@@ -25,11 +25,12 @@ import type { Edge, Node } from '@xyflow/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 /**
  * Viewport bounds with zoom level

--- a/frontend/apps/web/src/hooks/useWebhooks.ts
+++ b/frontend/apps/web/src/hooks/useWebhooks.ts
@@ -11,10 +11,11 @@ import type {
 } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL ?? 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 
 const toNumber = (value: unknown, fallback: number): number =>
   value === undefined ? fallback : Number(value);

--- a/frontend/apps/web/src/hooks/useWorkflows.ts
+++ b/frontend/apps/web/src/hooks/useWorkflows.ts
@@ -3,10 +3,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { WorkflowRun, WorkflowSchedule } from '@tracertm/types';
 
 import { client } from '@/api/client';
+import { API_ORIGIN } from '@/config/api-origin';
 
 const { getAuthHeaders } = client;
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+const API_URL = API_ORIGIN;
 const REFRESH_RUNS_INTERVAL_MS = 15_000;
 const REFRESH_SCHEDULES_INTERVAL_MS = 30_000;
 

--- a/frontend/apps/web/src/lib/openapi-utils.ts
+++ b/frontend/apps/web/src/lib/openapi-utils.ts
@@ -1,3 +1,4 @@
+import { API_ORIGIN } from '@/config/api-origin';
 import { logger } from '@/lib/logger';
 /**
  * OpenAPI Utilities
@@ -174,7 +175,7 @@ export function getSupportedAuthTypes(
  */
 export function getServerUrls(spec: OpenAPISpec): string[] {
   if (!spec.servers || spec.servers.length === 0) {
-    return ['http://127.0.0.1:18000'];
+    return [API_ORIGIN];
   }
   return spec.servers.map((server) => server.url);
 }

--- a/frontend/apps/web/src/lib/preflight.ts
+++ b/frontend/apps/web/src/lib/preflight.ts
@@ -590,11 +590,6 @@ const fetchMcpStatus = async (baseUrl: string): Promise<Record<string, InfraStat
   }
 };
 
-const getDevHost = (): string =>
-  window.location.hostname && window.location.hostname !== 'localhost'
-    ? window.location.hostname
-    : '127.0.0.1';
-
 const buildChecks = (): PreflightCheck[] => {
   const checks: PreflightCheck[] = [];
   const configuredApiUrl = (import.meta.env?.VITE_API_URL ?? '').trim().replace(/\/$/, '');
@@ -612,18 +607,9 @@ const buildChecks = (): PreflightCheck[] => {
     return checks;
   }
 
-  // Use the approved local gateway. Direct legacy service ports are never
-  // browser origins; they bypass the readiness/auth contract.
-  const devHost = getDevHost();
-  const useGateway = window.location.port === '18000';
-  const gatewayBase = useGateway ? window.location.origin : `http://${devHost}:18000`;
-
-  if (useGateway) {
-    checks.push({ name: 'backend', url: gatewayBase });
-    return checks;
-  }
-
-  checks.push({ name: 'backend', url: gatewayBase });
+  // Keep development on the browser origin too: Vite proxies this path while
+  // the local Compose nginx serves it directly.
+  checks.push({ name: 'backend', url: window.location.origin });
   return checks;
 };
 

--- a/frontend/apps/web/src/lib/sse-client.ts
+++ b/frontend/apps/web/src/lib/sse-client.ts
@@ -2,6 +2,8 @@
  * Server-Sent Events (SSE) client with automatic reconnection and exponential backoff
  */
 
+import { API_ORIGIN } from '@/config/api-origin';
+
 export interface SSEClientOptions {
   url: string;
   headers?: Record<string, string>;
@@ -207,7 +209,7 @@ export function createNotificationSSEClient(
     return null;
   }
 
-  const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:18000';
+  const API_URL = API_ORIGIN;
 
   return new SSEClient({
     url: `${API_URL}/api/v1/notifications/stream`,

--- a/frontend/apps/web/src/pages/settings/Settings.tsx
+++ b/frontend/apps/web/src/pages/settings/Settings.tsx
@@ -1,3 +1,5 @@
+import { API_ORIGIN } from '@/config/api-origin';
+
 export function Settings() {
   return (
     <div className='space-y-6'>
@@ -22,7 +24,7 @@ export function Settings() {
             <label className='text-sm font-medium'>Backend URL</label>
             <input
               type='text'
-              defaultValue='http://127.0.0.1:18000'
+              defaultValue={API_ORIGIN}
               className='mt-1 h-10 w-full rounded-lg border px-3'
             />
           </div>

--- a/frontend/apps/web/src/stores/auth-store.ts
+++ b/frontend/apps/web/src/stores/auth-store.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { API_ORIGIN } from '@/config/api-origin';
 import { getCSRFHeaders } from '@/lib/csrf';
 import { logger } from '@/lib/logger';
 
-const API_BASE_URL_DEFAULT = 'http://127.0.0.1:18000';
+const API_BASE_URL_DEFAULT = API_ORIGIN;
 const AUTH_TOKEN_KEY = 'auth_token';
 const HTTP_UNAUTHORIZED = Number('401');
 const REFRESH_INTERVAL_MINUTES = Number('20');

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -7,6 +7,9 @@ import re
 
 compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
+frontend_dockerfile = Path("frontend/Dockerfile.local").read_text(encoding="utf-8")
+nginx = Path("frontend/deploy/nginx.local.conf").read_text(encoding="utf-8")
+api_origin = Path("frontend/apps/web/src/config/api-origin.ts").read_text(encoding="utf-8")
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (
@@ -20,6 +23,36 @@ assert frontend and "condition: service_healthy" in frontend.group(1), (
 )
 assert '"${TRACERA_LOCAL_BIND_ADDR:-127.0.0.1}:${TRACERA_LOCAL_PORT:-18081}:80"' in compose, (
     "frontend publication must default to loopback"
+)
+assert "ENV VITE_API_URL=" in frontend_dockerfile, (
+    "local frontend build must opt into the browser's same-origin API path"
+)
+assert "VITE_API_BASE" not in frontend_dockerfile, (
+    "local frontend build must not set the unused VITE_API_BASE variable"
+)
+assert "window.location.origin" in api_origin, (
+    "empty VITE_API_URL must resolve to the browser's current origin"
+)
+assert "proxy_pass http://tracera-server:8080" in nginx, (
+    "local nginx must proxy API requests to the private Rust backend"
+)
+
+source_root = Path("frontend/apps/web/src")
+loopback_fallbacks = []
+for path in source_root.rglob("*"):
+    if (
+        path.suffix not in {".ts", ".tsx", ".js", ".jsx"}
+        or "__tests__" in path.parts
+        or "mocks" in path.parts
+        or ".test." in path.name
+    ):
+        continue
+    text = path.read_text(encoding="utf-8")
+    if "127.0.0.1:18000" in text or "localhost:4000" in text or ":18000" in text:
+        loopback_fallbacks.append(str(path))
+assert not loopback_fallbacks, (
+    "browser client must not fall back to an unpublished loopback backend: "
+    + ", ".join(loopback_fallbacks)
 )
 print("local Compose readiness contract: PASS")
 PY


### PR DESCRIPTION
## Preservation / bounded extraction

This draft preserves the current-main extraction of the intended browser same-origin/API-origin lane from #794. It intentionally excludes old #794 server-test/fixture deletion, Cargo/workflow churn, title/trace-marker commits, and unrelated frontend debt.

### Scope
- gateway-origin resolver and browser same-origin routing
- frontend API clients/hooks/preflight/SSE/settings/auth consumers
- local Dockerfile environment wiring
- local compose readiness contract

### Evidence
- Base: e9050f5f05cd30ddf809ebc0dcd5f309eaae3b84
- Head: d4a62101f
- `bun install --frozen-lockfile`: BLOCKED because live main package manifests drift from the lockfile (`@sentry`, `@trpc/react-query`, lucide, zod, packageManager); no lockfile guessing performed.
- API-origin and compose validation pending lock reconciliation.
- Frontend build remains subject to existing TypeScript debt.

This is a preservation/WIP PR, not merge-ready.