### PR TITLE
fix(selfhost): wire protected API to Postgres

### DIFF
--- a/crates/tracera-server/src/auth.rs
+++ b/crates/tracera-server/src/auth.rs
@@ -1,0 +1,86 @@
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header::AUTHORIZATION, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::sync::Arc;
+
+pub(crate) type AuthToken = Option<Arc<str>>;
+
+/// Require a bearer token for application routes when configured. Health and
+/// readiness probes stay public so container orchestrators can inspect them.
+pub(crate) async fn require_bearer(
+    State(expected): State<AuthToken>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if expected.is_none() || is_health_route(request.uri().path()) {
+        return next.run(request).await;
+    }
+
+    let valid = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|provided| {
+            constant_time_equal(provided.as_bytes(), expected.as_ref().unwrap().as_bytes())
+        });
+
+    if valid {
+        next.run(request).await
+    } else {
+        (
+            StatusCode::UNAUTHORIZED,
+            [("www-authenticate", "Bearer")],
+            "unauthorized",
+        )
+            .into_response()
+    }
+}
+
+fn is_health_route(path: &str) -> bool {
+    matches!(
+        path,
+        "/health" | "/healthz" | "/ready" | "/readyz" | "/api/v1/health"
+    ) || path.ends_with("/health")
+        || path.ends_with("/healthz")
+}
+
+fn constant_time_equal(left: &[u8], right: &[u8]) -> bool {
+    let mut difference = left.len() ^ right.len();
+    for index in 0..left.len().max(right.len()) {
+        difference |= (left.get(index).copied().unwrap_or_default()
+            ^ right.get(index).copied().unwrap_or_default()) as usize;
+    }
+    difference == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{constant_time_equal, is_health_route};
+
+    #[test]
+    fn constant_time_comparison_requires_exact_bytes() {
+        assert!(constant_time_equal(b"token", b"token"));
+        assert!(!constant_time_equal(b"token", b"Token"));
+        assert!(!constant_time_equal(b"token", b"token-extra"));
+    }
+
+    #[test]
+    fn health_probe_routes_are_public_but_application_routes_are_not() {
+        for path in [
+            "/health",
+            "/healthz",
+            "/ready",
+            "/readyz",
+            "/evidence/health",
+            "/api/v1/health",
+        ] {
+            assert!(is_health_route(path), "{path} should be a probe route");
+        }
+        assert!(!is_health_route("/evidence"));
+    }
+}

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod db;
 mod health;
 mod ingest;
@@ -40,6 +41,11 @@ const MAX_REQUEST_BODY_BYTES: usize = 8 * 1024 * 1024;
 /// Requests above this bound must use a future paged/export path instead of
 /// allowing an unbounded response allocation.
 const MAX_COVERAGE_LINKS: usize = 25_000;
+const PUBLIC_BIND_MODE_ENV: &str = "TRACERA_PUBLIC_BIND_MODE";
+const AUTH_TOKEN_ENV: &str = "TRACERA_AUTH_TOKEN";
+const AUTHENTICATED_PROXY_MODE: &str = "authenticated-proxy";
+const LOOPBACK_PUBLISHED_MODE: &str = "loopback-published";
+const PRIVATE_NETWORK_MODE: &str = "private-network";
 use validation::{
     validate_text, MAX_ID_CHARS, MAX_INGEST_ISSUES, MAX_LONG_TEXT_CHARS, MAX_METADATA_BYTES,
     MAX_SHORT_TEXT_CHARS, MAX_URL_CHARS,
@@ -61,6 +67,30 @@ struct AppState {
     backend: &'static str,
     started_at: Instant,
     store: Arc<dyn Store>,
+}
+
+fn validate_bind_address(
+    addr: SocketAddr,
+    public_bind_mode: Option<&str>,
+    auth_token: Option<&str>,
+) -> Result<(), String> {
+    if addr.ip().is_loopback() {
+        return Ok(());
+    }
+    if !matches!(
+        public_bind_mode,
+        Some(AUTHENTICATED_PROXY_MODE | LOOPBACK_PUBLISHED_MODE | PRIVATE_NETWORK_MODE)
+    ) {
+        return Err(format!(
+            "refusing non-loopback bind to {addr}; set {PUBLIC_BIND_MODE_ENV} to an explicit authenticated-proxy, loopback-published, or private-network deployment mode"
+        ));
+    }
+    if auth_token.is_some_and(|token| !token.is_empty()) {
+        return Ok(());
+    }
+    Err(format!(
+        "refusing non-loopback bind to {addr}; {AUTH_TOKEN_ENV} must contain a bearer token"
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -490,7 +520,11 @@ async fn main() {
         store,
     };
 
-    let app = build_router(state);
+    let auth_token = env::var(AUTH_TOKEN_ENV)
+        .ok()
+        .filter(|token| !token.is_empty())
+        .map(Arc::<str>::from);
+    let app = build_router_with_auth(state, auth_token.clone());
 
     let frontend_dist = env::var("TRACERA_FRONTEND_DIST")
         .map(PathBuf::from)
@@ -504,11 +538,13 @@ async fn main() {
         .and_then(|v| v.parse().ok())
         .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 8080)));
 
-    if !addr.ip().is_loopback() {
-        tracing::warn!(
-            %addr,
-            "server is bound beyond loopback; put it behind an authenticated TLS reverse proxy"
-        );
+    if let Err(error) = validate_bind_address(
+        addr,
+        env::var(PUBLIC_BIND_MODE_ENV).ok().as_deref(),
+        auth_token.as_deref(),
+    ) {
+        eprintln!("FATAL: {error}");
+        std::process::exit(1);
     }
 
     let listener = tokio::net::TcpListener::bind(addr)
@@ -525,6 +561,10 @@ async fn main() {
 }
 
 fn build_router(state: AppState) -> Router {
+    build_router_with_auth(state, None)
+}
+
+fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Router {
     Router::new()
         .route("/healthz", get(health::healthz))
         .route("/health", get(health::health))
@@ -535,8 +575,8 @@ fn build_router(state: AppState) -> Router {
         .route("/api/v1/confidence", post(confidence))
         .route("/api/v1/blast-radius", post(blast_radius))
         .route("/api/v1/governance/spec-check", post(spec_check))
-        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
-        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/api/v1/trace/forward/{artifact_id}", post(trace_forward))
+        .route("/api/v1/trace/reverse/{artifact_id}", post(trace_reverse))
         .route("/evidence", get(list_evidence).post(create_evidence))
         .route("/evidence/health", get(health::health))
         .route("/ingest/github", post(ingest_github))
@@ -550,6 +590,10 @@ fn build_router(state: AppState) -> Router {
         .route("/org-intel/teams", get(list_teams))
         .route("/org-intel/metrics", get(org_metrics))
         .with_state(state)
+        .layer(axum::middleware::from_fn_with_state(
+            auth_token,
+            auth::require_bearer,
+        ))
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         .layer(SetResponseHeaderLayer::if_not_present(
             header::X_CONTENT_TYPE_OPTIONS,
@@ -1289,6 +1333,68 @@ mod tests {
     use chrono::TimeZone;
     use http::{Request, StatusCode};
     use tower::ServiceExt;
+
+    #[test]
+    fn public_bind_requires_explicit_mode_and_token() {
+        let loopback = "127.0.0.1:8080".parse().expect("loopback address");
+        let public = "0.0.0.0:8080".parse().expect("public address");
+
+        assert!(validate_bind_address(loopback, None, None).is_ok());
+        assert!(validate_bind_address(public, None, None).is_err());
+        assert!(validate_bind_address(public, Some(AUTHENTICATED_PROXY_MODE), None).is_err());
+        assert!(validate_bind_address(public, Some(PRIVATE_NETWORK_MODE), Some("secret")).is_ok());
+        assert!(validate_bind_address(public, Some(PRIVATE_NETWORK_MODE), Some("")).is_err());
+    }
+
+    #[tokio::test]
+    async fn public_auth_requires_bearer_for_application_routes_but_not_probes() {
+        let store = make_sqlite_store().await;
+        let app = build_router_with_auth(
+            AppState {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                backend: "sqlite",
+                started_at: Instant::now(),
+                store: Arc::new(store),
+            },
+            Some(Arc::<str>::from("secret")),
+        );
+
+        let unauthorized = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/evidence")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let health = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(health.status(), StatusCode::OK);
+
+        let authorized = app
+            .oneshot(
+                Request::builder()
+                    .uri("/evidence")
+                    .header(header::AUTHORIZATION, "Bearer secret")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(authorized.status(), StatusCode::OK);
+    }
 
     #[tokio::test]
     async fn api_router_emits_readiness_and_security_contract() {

--- a/deploy/selfhost/README.md
+++ b/deploy/selfhost/README.md
@@ -20,6 +20,7 @@ This stack runs Tracera on your desktop, publishes it through Caddy, and exposes
 Set these before starting the stack:
 
 - `CF_TUNNEL_TOKEN`: Cloudflare Tunnel token for the named tunnel
+- `POSTGRES_PASSWORD`: database password for the private Postgres service
 - `TRACERA_PUBLIC_HOSTNAME`: public hostname served by the tunnel, for example `tracera.pheno.studio`
 
 WorkOS AuthKit is not wired in yet, but these placeholders show where its settings would live:
@@ -57,6 +58,12 @@ traffic. Before enabling a Cloudflare Tunnel or public DNS, configure an active
 
 The strict gate fails closed until authentication and an HTTPS listener are
 present. It does not inspect or require credentials, so it is safe to run in CI.
+
+The server image is built from `Dockerfile.rust` and uses the compose Postgres
+service through `DATABASE_URL`. The image currently packages the Rust API only;
+the checked-in frontend bundle is not part of this image, so this stack is not
+a dashboard release until a separately validated frontend image or bundle is
+provided. Do not treat a green API health probe as frontend dogfood evidence.
 
 ## Run
 

--- a/deploy/selfhost/docker-compose.selfhost.yml
+++ b/deploy/selfhost/docker-compose.selfhost.yml
@@ -1,17 +1,35 @@
 services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: tracera
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: tracera
+    expose:
+      - "5432"
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tracera -d tracera"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
   tracera-server:
-    image: rust:1.82-bookworm
-    working_dir: /workspace
-    command: sh -lc "cargo run --release -p tracera-server"
+    build:
+      context: ../..
+      dockerfile: Dockerfile.rust
     environment:
       TRACERA_BIND_ADDR: 0.0.0.0:8080
-      TRACERA_TRUSTED_PROXY: "true"
-    volumes:
-      - ../..:/workspace
-      - tracera-cargo-cache:/usr/local/cargo/registry
-      - tracera-target-cache:/workspace/target
+      TRACERA_PUBLIC_BIND_MODE: ${TRACERA_PUBLIC_BIND_MODE:?TRACERA_PUBLIC_BIND_MODE=authenticated-proxy is required}
+      TRACERA_AUTH_TOKEN: ${TRACERA_AUTH_TOKEN:?TRACERA_AUTH_TOKEN is required for in-process API protection}
+      DATABASE_URL: postgres://tracera:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/tracera
     expose:
       - "8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
 
   caddy:
@@ -44,7 +62,6 @@ services:
     restart: unless-stopped
 
 volumes:
+  pg-data:
   caddy-data:
   caddy-config:
-  tracera-cargo-cache:
-  tracera-target-cache:


### PR DESCRIPTION
## Scope
- add fail-closed bearer auth for non-health routes when TRACERA_AUTH_TOKEN is configured
- reject non-loopback binds without explicit deployment mode and non-empty token
- repair selfhost compose with health-gated Postgres, DATABASE_URL, and Dockerfile build
- keep 8080/5432 internal and document that Dockerfile.rust currently ships API only, not dashboard assets
- update two Axum 0.8 path captures so router tests can instantiate

## Evidence
- `cargo test -p tracera-server public_` (3 passed)
- `./scripts/verify-deployment-manifests.sh` (passed)
- `./scripts/verify-deployment-security.sh --mode private` (passed)

## Remaining gates
- Docker build/compose runtime not run: Docker daemon unavailable in this environment.
- Public mode remains intentionally blocked until Caddy has an active auth directive; no public exposure is claimed.
- Frontend bundle is not included in current Dockerfile.rust; this PR does not claim a usable dashboard release.