### PR TITLE
fix(compose): require local API auth token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Copy to .env.local and replace the placeholder before starting the local stack.
 # This file is intentionally safe to commit; .env.local is ignored.
 POSTGRES_PASSWORD=replace-with-a-long-random-local-password
+TRACERA_AUTH_TOKEN=replace-with-a-long-random-local-bearer-token
 TRACERA_LOCAL_PORT=18081

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -19,6 +19,10 @@ services:
       dockerfile: Dockerfile.rust
     environment:
       TRACERA_BIND_ADDR: 0.0.0.0:8080
+      # The API is reachable only through the sibling frontend on this private
+      # Compose network; declare that boundary for the Rust listener.
+      TRACERA_PUBLIC_BIND_MODE: "private-network"
+      TRACERA_AUTH_TOKEN: ${TRACERA_AUTH_TOKEN:?TRACERA_AUTH_TOKEN is required}
       TRACERA_TRUSTED_PROXY: "true"
       DATABASE_URL: postgres://tracera:${POSTGRES_PASSWORD}@postgres:5432/tracera
     expose: ["8080"]

--- a/docs/deployment/local-compose.md
+++ b/docs/deployment/local-compose.md
@@ -10,7 +10,7 @@ value into shell history:
 
 ```sh
 cp .env.example .env.local
-# Replace POSTGRES_PASSWORD with a long random value in .env.local.
+# Replace POSTGRES_PASSWORD and TRACERA_AUTH_TOKEN with distinct long random values in .env.local.
 chmod 600 .env.local
 docker compose --env-file .env.local -f docker-compose.local.yml up -d --build
 curl --fail --silent http://127.0.0.1:18081/health

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -18,6 +18,12 @@ assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (
 server = re.search(r"(?ms)^  tracera-server:\n(.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", compose)
 frontend = re.search(r"(?ms)^  frontend:\n(.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", compose)
 assert server and "healthcheck:" in server.group(1), "server service healthcheck missing"
+assert 'TRACERA_PUBLIC_BIND_MODE: "private-network"' in server.group(1), (
+    "private backend must declare its private-network deployment boundary"
+)
+assert "TRACERA_AUTH_TOKEN: ${TRACERA_AUTH_TOKEN:?TRACERA_AUTH_TOKEN is required}" in server.group(1), (
+    "private backend must receive the required in-process API bearer token"
+)
 assert frontend and "condition: service_healthy" in frontend.group(1), (
     "frontend must wait for a healthy server"
 )


### PR DESCRIPTION
## Summary
- require an explicit local bearer token for the private Compose backend
- document the token alongside the local Postgres credential
- lock the local Compose contract with a focused assertion

## Validation
- retained static checks: passed
- backend-first local Compose dogfood: passed Postgres migration, health and readiness, bearer rejection, authenticated evidence read/write, and direct Postgres readback

## Remaining gates
- draft pending required approval and hosted required checks