### PR TITLE
ci: pin cargo deny policy contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: cargo-deny check
-        uses: EmbarkStudios/cargo-deny-action@v1
+        uses: EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868
         with:
           arguments: --all-features
 
@@ -179,6 +179,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tracera-desktop-${{ matrix.os }}-${{ matrix.arch }}
-          path: frontend/apps/desktop/Tracera-*-${{ matrix.os }}-${{ matrix.arch }}.{{ matrix.archive_format }}
+          path: frontend/apps/desktop/Tracera-*-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.archive_format }}
           if-no-files-found: error
 
   release:

--- a/deny.toml
+++ b/deny.toml
@@ -21,7 +21,7 @@ allow = [
   "CC0-1.0",
   "CDLA-Permissive-2.0",
   "ISC",
-  "LGPL-2.1-or-later",
+  "LGPL-2.1",
   "MIT",
   "MIT-0",
   "Unicode-3.0",

--- a/frontend/scripts/test-ci-policy-contract.mjs
+++ b/frontend/scripts/test-ci-policy-contract.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+const deny = readFileSync(join(repoRoot, "deny.toml"), "utf8");
+const ci = readFileSync(join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+const releaseWorkflowTest = readFileSync(
+  join(repoRoot, "frontend", "scripts", "test-release-desktop-workflow.mjs"),
+  "utf8",
+);
+
+assert.match(
+  deny,
+  /"LGPL-2\.1"/,
+  "cargo-deny must use the parser-compatible bare LGPL identifier",
+);
+assert.doesNotMatch(
+  deny,
+  /"LGPL-2\.1(?:\+|-or-later)"/,
+  "cargo-deny must not use unsupported LGPL suffix forms",
+);
+assert.match(
+  ci,
+  /EmbarkStudios\/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868/,
+  "cargo-deny action must stay pinned to the parser-compatible revision",
+);
+assert.match(
+  ci,
+  /name: Security Scan[\s\S]*?uses: actions\/checkout@v4\s+with:\s+fetch-depth: 0[\s\S]*?name: gitleaks/,
+  "Gitleaks must receive full history so its PR base parent exists locally",
+);
+assert.match(
+  releaseWorkflowTest,
+  /^#!\/usr\/bin\/env bun$/m,
+  "CI contract test scripts must use the repository Bun runtime",
+);
+
+console.log("CI policy contract verified");

--- a/frontend/scripts/test-release-desktop-workflow.mjs
+++ b/frontend/scripts/test-release-desktop-workflow.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env bun
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const workflowPath = join(import.meta.dirname, "..", "..", ".github", "workflows", "release-desktop.yml");
+const workflow = readFileSync(workflowPath, "utf8");
+
+assert.ok(
+  workflow.includes("${{ matrix.archive_format }}"),
+  "release-desktop artifact upload must interpolate matrix.archive_format",
+);
+assert.ok(
+  !workflow.includes(".{{ matrix.archive_format }}"),
+  "release-desktop artifact upload must not use a literal GitHub expression",
+);
+
+console.log("release-desktop artifact upload interpolation verified");


### PR DESCRIPTION
## **User description**
Supersedes #823 after exact hosted-action provenance identified the parser as cargo-deny 0.14.21.

This focused CI/release-contract PR:
- pins Cargo Deny to immutable action `3f4a782664881cf5725d0ffd23969fcce89fd868`
- uses its required bare GNU `LGPL-2.1` allow identifier
- preserves the proven Gitleaks-history and desktop artifact interpolation repairs
- keeps static contract verifiers Bun-native

Local evidence:
- `bun frontend/scripts/test-ci-policy-contract.mjs`
- `bun frontend/scripts/test-release-desktop-workflow.mjs`
- `git diff --check`

Known independent gates: frontend artifact assertion, Vercel deployment, and runtime dogfood are not claimed fixed here.


___

## **CodeAnt-AI Description**
Fix CI policy checks and desktop release artifact uploads

### What Changed
- Desktop release builds now upload archives using the correct file format, instead of looking for filenames with a literal workflow expression.
- Cargo license checks use the identifier and pinned action revision accepted by the policy tool.
- Security scans receive the full repository history so pull request base commits can be inspected.
- Added checks that detect regressions in these CI and release workflow contracts.

### Impact
`✅ Reliable desktop artifact uploads`
`✅ Consistent Cargo license checks`
`✅ Complete pull request security scans`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
