### PR TITLE
fix(frontend): order fast builds after workspace dependencies

### DIFF
--- a/.github/workflows/frontend-contract-checks.yml
+++ b/.github/workflows/frontend-contract-checks.yml
@@ -27,6 +27,10 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
         working-directory: frontend
 
+      - name: Verify Turbo build ordering
+        run: npm run test:turbo-build-order
+        working-directory: frontend
+
       - name: Build web bundle
         run: npm run build
         working-directory: frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "build:parallel": "turbo build --parallel --concurrency=8",
     "test": "turbo test --concurrency=4",
     "test:unit": "turbo test --filter=@tracertm/web --concurrency=4",
+    "test:turbo-build-order": "node scripts/test-turbo-build-order.mjs",
     "test:parallel": "turbo test --parallel --concurrency=4",
     "test:perf": "bun scripts/run-all-performance-tests.ts",
     "test:perf:build": "bun scripts/test-build-performance.ts",

--- a/frontend/scripts/test-turbo-build-order.mjs
+++ b/frontend/scripts/test-turbo-build-order.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/** Verify every web build task waits for workspace dependency builds. */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const turboConfigPath = path.resolve(scriptsDir, '..', 'turbo.json');
+const turboConfig = JSON.parse(fs.readFileSync(turboConfigPath, 'utf8'));
+
+for (const taskName of ['build', 'build:fast']) {
+  test(`${taskName} waits for workspace dependency builds`, () => {
+    const dependsOn = turboConfig.tasks[taskName]?.dependsOn;
+    assert.ok(Array.isArray(dependsOn), `${taskName} must declare dependsOn`);
+    assert.ok(
+      dependsOn.includes('^build'),
+      `${taskName} must include ^build so declarations exist before dependents compile`,
+    );
+  });
+}

--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -37,7 +37,7 @@
       "env": ["NODE_ENV", "VITE_*", "NEXT_PUBLIC_*"]
     },
     "build:fast": {
-      "dependsOn": [],
+      "dependsOn": ["^build"],
       "inputs": [
         "src/**",
         "public/**",


### PR DESCRIPTION
## Summary
- make the Turbo `build:fast` task wait for workspace dependency `build` tasks
- add a deterministic static ordering contract and execute it before the frontend CI build

## Evidence
- RED: the new contract failed because `build:fast` omitted `^build`
- GREEN: `node frontend/scripts/test-turbo-build-order.mjs` passes (2/2)
- Turbo dry graph proves `@tracertm/web#build:fast` waits for `api-client`, `state`, `types`, and `ui` build tasks

## Deliberately not run
- no dependency install or full frontend/container build: capacity remains under the approved build threshold.