### PR TITLE
diagnostic(ci): surface Turbo build logs

### DIFF
--- a/frontend/turbo.json
+++ b/frontend/turbo.json
@@ -33,7 +33,7 @@
         "out/**",
         ".tsbuildinfo"
       ],
-      "outputLogs": "hash-only",
+      "outputLogs": "full",
       "env": ["NODE_ENV", "VITE_*", "NEXT_PUBLIC_*"]
     },
     "build:fast": {


### PR DESCRIPTION
Clean diagnostic successor to #828.

#828 remains preserved evidence and must not merge due contaminated scope.

This PR changes only `frontend/turbo.json`, setting the primary `build` task `outputLogs` from `hash-only` to `full` so CI exposes actual web-build diagnostics.