### PR TITLE
fix(web): define client core backend URL

### DIFF
--- a/frontend/apps/web/src/__tests__/api/client-core.test.ts
+++ b/frontend/apps/web/src/__tests__/api/client-core.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { clientCore } from "@/api/client-core";
+import { API_ORIGIN } from "@/config/api-origin";
+
+describe("clientCore", () => {
+  it("returns the configured backend origin for a backend path", () => {
+    expect(clientCore.getBackendURL("/api/v1/evidence")).toBe(API_ORIGIN);
+  });
+});

--- a/frontend/apps/web/src/api/client-core.ts
+++ b/frontend/apps/web/src/api/client-core.ts
@@ -13,6 +13,8 @@ import { responseHandlers } from './client-response-handlers';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- openapi-fetch needs explicit HttpMethod keys to avoid PathsWithMethod resolving to never under exactOptionalPropertyTypes
 type AnyPaths = { [path: string]: { [method in HttpMethod]: any } };
 
+const getBackendURL = (_path?: string): string => API_ORIGIN;
+
 const API_BASE_URL = API_ORIGIN;
 
 const rawApiClient = createClient<AnyPaths>({


### PR DESCRIPTION
fixes first TS error; full tsc now advances to pre-existing forms/hooks/stores errors.