### PR TITLE
fix(web): type form array default items

### DIFF
--- a/frontend/apps/web/src/components/forms/FormArrayField.test.tsx
+++ b/frontend/apps/web/src/components/forms/FormArrayField.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import { FormArrayField } from './FormArrayField';
+
+interface StringListForm {
+  labels: string[];
+}
+
+function StringListHarness() {
+  const { control, register } = useForm<StringListForm>({
+    defaultValues: { labels: [] },
+  });
+
+  return (
+    <FormArrayField<StringListForm>
+      addButtonLabel='Add label'
+      control={control}
+      defaultValue=''
+      label='Labels'
+      name='labels'
+      renderField={(index) => <input aria-label={`Label ${index + 1}`} {...register(`labels.${index}`)} />}
+    />
+  );
+}
+
+describe(FormArrayField, () => {
+  it('appends the configured empty string item for a string-array field', () => {
+    render(<StringListHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add label' }));
+
+    expect(screen.getByRole('textbox', { name: 'Label 1' })).toHaveValue('');
+  });
+});

--- a/frontend/apps/web/src/components/forms/FormArrayField.tsx
+++ b/frontend/apps/web/src/components/forms/FormArrayField.tsx
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { ArrayPath, Control, FieldArray, FieldValues } from 'react-hook-form';
+import type { ArrayPath, Control, FieldArrayPathValue, FieldValues } from 'react-hook-form';
 
 import { Plus, Trash2 } from 'lucide-react';
 import { useFieldArray } from 'react-hook-form';
@@ -14,13 +14,16 @@ export interface FormArrayFieldProps<T extends FieldValues> {
   label: string;
   helpText?: string;
   renderField: (index: number) => React.ReactNode;
-  defaultValue?: FieldArray<T, ArrayPath<T>>;
+  defaultValue?: FormArrayItem<T>;
   addButtonLabel?: string;
   removeButtonLabel?: string;
   minItems?: number;
   maxItems?: number;
   className?: string;
 }
+
+type FormArrayItem<T extends FieldValues> =
+  FieldArrayPathValue<T, ArrayPath<T>> extends ReadonlyArray<infer Item> ? Item : never;
 
 export function FormArrayField<T extends FieldValues>({
   control,
@@ -56,9 +59,9 @@ export function FormArrayField<T extends FieldValues>({
           size='sm'
           onClick={() => {
             if (defaultValue !== undefined) {
-              append(defaultValue);
+              append(defaultValue as never);
             } else {
-              append({} as FieldArray<T, ArrayPath<T>>);
+              append({} as never);
             }
           }}
           disabled={!canAdd}


### PR DESCRIPTION
## Summary
- type `FormArrayField` defaults as the element of the selected array field
- preserve configured scalar default append behavior
- add a string-array regression test

## Validation
- `cd frontend/apps/web && bun run test -- --run src/components/forms/FormArrayField.test.tsx` (1 passed)
- `git diff --check`

## Compiler evidence
The TS2749 misuse of `FieldArray` as a type is reproduced by the string-array consumer and cleared by this change. A full web typecheck advances to unrelated pre-existing errors; this PR does not claim it is green.