### PR TITLE
fix(web): omit absent Gherkin className prop

### DIFF
--- a/frontend/apps/web/src/components/specifications/bdd/GherkinViewer.tsx
+++ b/frontend/apps/web/src/components/specifications/bdd/GherkinViewer.tsx
@@ -373,7 +373,7 @@ export function GherkinViewer({
   if (!parsed.feature && parsed.scenarios.length === 0) {
     return (
       <RawGherkinCard
-        className={className}
+        {...(className === undefined ? {} : { className })}
         content={content}
         editorOptions={editorOptions}
         height={height}


### PR DESCRIPTION
## Summary

Avoid passing an explicit `undefined` to `RawGherkinCard.className` under `exactOptionalPropertyTypes`.

The viewer now omits `className` entirely when it is absent, while preserving the supplied value unchanged.

## Verification

- `cd frontend/apps/web && bunx tsc --noEmit --pretty false --project tsconfig.json`
- `git diff --check`

Scope: one source file; no install, test, full build, rebase, or unrelated formatting.