### PR TITLE
fix(web): align test run mutation optionality

### DIFF
--- a/frontend/apps/web/src/hooks/test-runs/test-run-hooks.ts
+++ b/frontend/apps/web/src/hooks/test-runs/test-run-hooks.ts
@@ -76,7 +76,7 @@ function useStartTestRun(): UseMutationResult<
 > {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (vars: { id: string; executedBy?: string }) => {
+    mutationFn: async (vars: { id: string; executedBy?: string | undefined }) => {
       const result = await testRunApi.startTestRun(vars.id, vars.executedBy);
       return result;
     },
@@ -95,7 +95,11 @@ function useCompleteTestRun(): UseMutationResult<
 > {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (vars: { id: string; failureSummary?: string; notes?: string }) => {
+    mutationFn: async (vars: {
+      id: string;
+      failureSummary?: string | undefined;
+      notes?: string | undefined;
+    }) => {
       const result = await testRunApi.completeTestRun(vars.id, vars.failureSummary, vars.notes);
       return result;
     },


### PR DESCRIPTION
## Summary
- align test-run mutation variables with their declared exact-optional public contracts
- cover `executedBy`, `failureSummary`, and `notes` without widening mutation output contracts

## Validation
- `bun x tsc --noEmit --pretty false`
  - exits nonzero on existing unrelated web diagnostics
  - emits no `test-run-hooks.ts` diagnostics after this change
- `git diff --check`

## Scope
One source file only: `frontend/apps/web/src/hooks/test-runs/test-run-hooks.ts`.

Draft until required hosted checks and review complete.