### PR TITLE
fix(ci): restore scorecard job permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,14 +14,15 @@ on:
   push:
     branches: [main]
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    security:
-      permissions: read-all
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Goal

Restore valid least-privilege permissions for the OpenSSF Scorecard job.

## Scope

- Changes `.github/workflows/scorecard.yml` only.
- Moves the permissions block from the invalid `security.permissions` location to `jobs.analysis.permissions`.
- Grants only the Scorecard job permissions required for checkout, OIDC, and SARIF upload.

## Local evidence

- `actionlint -color=false .github/workflows/scorecard.yml` passed.
- `yq eval . .github/workflows/scorecard.yml` parsed successfully.
- `git diff --check` passed.

No merge or auto-merge has been requested.