### PR TITLE
fix(ci): validate Mergify workflow rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,13 +20,11 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge dependabot/Renovate PRs when CI passes
   - name: Auto-merge dependency updates
     conditions:
-      - author=dependabot[bot] | renovate[bot]
+      - 'author ~= ^(?:dependabot\[bot\]|renovate\[bot\])$'
       - check-success=ci
       - -conflict
       - -closed
@@ -37,13 +35,11 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge bot PRs (CI configs, formatting) when CI passes
   - name: Auto-merge bot housekeeping PRs
     conditions:
-      - author=trunk-io[bot] | mergify[bot] | github-actions[bot]
+      - 'author ~= ^(?:trunk-io\[bot\]|mergify\[bot\]|github-actions\[bot\])$'
       - check-success=ci
       - check-success=lint
       - -conflict
@@ -61,7 +57,7 @@ pull_request_rules:
       request_reviews:
         teams:
           - phenotype/core
-        github_accounts:
+        users:
           - KooshaPari
 
   # Label PRs based on changed files
@@ -102,7 +98,7 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - age>=30d
+      - updated-at < 30 days ago
       - "#review-requested=0"
     actions:
       comment:


### PR DESCRIPTION
## Goal

Restore valid Mergify configuration parsing so merge-policy checks can run.

## Scope

- Changes `.mergify.yml` only.
- Replaces invalid multi-login author conditions with anchored regex conditions.
- Replaces unsupported `age` with `updated-at < 30 days ago`.
- Removes unsupported/redundant `post_merge` blocks and uses `request_reviews.users`.

## Validation

- YAML parsed successfully (11 pull-request rules).
- Targeted assertions confirm each hosted-invalid construct is absent and its supported translation is present.
- `git diff --check origin/main...HEAD` passed.

This is a standalone Mergify-config repair, separate from PR #842. No merge, rebase, or auto-merge has been requested.