### PR TITLE
fix(ci): recover Pages and runtime hosted gates

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,8 +41,9 @@ jobs:
           VITE_API_URL: ${{ vars.TRACERA_API_BASE }}
         run: |
           test -n "$VITE_API_URL"
+          node "$GITHUB_WORKSPACE/frontend/scripts/test-deploy-pages-api-base-command.mjs"
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            PRODUCTION_DEPLOY=1 npm run test:api-base
+            PRODUCTION_DEPLOY=1 npm --prefix "$GITHUB_WORKSPACE/frontend" run test:api-base
           fi
           VITE_BASE="$VITE_BASE" bun run vite build
         working-directory: frontend/apps/web

--- a/.github/workflows/runtime-latency-smoke.yml
+++ b/.github/workflows/runtime-latency-smoke.yml
@@ -41,21 +41,50 @@ jobs:
         run: cargo build --locked --release -p tracera-server
       - name: Run ephemeral runtime and latency smoke
         run: |
+          port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
           tmp_dir="$(mktemp -d)"
+          log_path="${RUNNER_TEMP:-/tmp}/tracera-latency.log"
+          pid=""
+          cleanup() {
+            if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+              kill "${pid}" 2>/dev/null || true
+              wait "${pid}" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
           DATABASE_URL="sqlite://${tmp_dir}/tracera.db?mode=rwc" \
-          TRACERA_BIND_ADDR="127.0.0.1:18080" \
+          TRACERA_BIND_ADDR="127.0.0.1:${port}" \
           TRACERA_FRONTEND_DIST="${GITHUB_WORKSPACE}/frontend/dist" \
-          RUST_LOG=tracera_server=warn ./target/release/tracera-server >/tmp/tracera-latency.log 2>&1 &
+          RUST_LOG=tracera_server=warn ./target/release/tracera-server >"${log_path}" 2>&1 &
           pid="$!"
-          trap 'kill "${pid}" 2>/dev/null || true; wait "${pid}" 2>/dev/null || true; rm -rf "${tmp_dir}"' EXIT
-          for _ in $(seq 1 50); do curl --silent --fail http://127.0.0.1:18080/health >/dev/null && break; sleep 0.1; done
-          curl --silent --fail http://127.0.0.1:18080/ready >/dev/null
+          ready=0
+          for _ in $(seq 1 50); do
+            if curl --silent --show-error --fail "http://127.0.0.1:${port}/health" >/dev/null; then
+              ready=1
+              break
+            fi
+            if ! kill -0 "${pid}" 2>/dev/null; then
+              break
+            fi
+            sleep 0.1
+          done
+          if [[ "${ready}" != "1" ]]; then
+            echo "runtime latency smoke: server did not become ready" >&2
+            cat "${log_path}" >&2
+            exit 1
+          fi
+          if ! curl --silent --show-error --fail "http://127.0.0.1:${port}/ready" >/dev/null; then
+            echo "runtime latency smoke: /ready failed" >&2
+            cat "${log_path}" >&2
+            exit 1
+          fi
           TRACERA_LATENCY_P95_MS=250 TRACERA_LATENCY_MAX_MS=1000 \
-            ./scripts/runtime-latency-smoke.py --base-url http://127.0.0.1:18080 --requests 80 --concurrency 4 --json
+            ./scripts/runtime-latency-smoke.py --base-url "http://127.0.0.1:${port}" --requests 80 --concurrency 4 --json
         env:
-          # runtime-smoke selects a free port and exports no reusable service;
-          # latency is run against the explicit ephemeral port below instead.
+          # The workflow keeps this server alive through the latency harness.
           TRACERA_SERVER_BIN: ./target/release/tracera-server
 
       - name: Run latency harness contract test
-        run: ./scripts/test-runtime-latency-smoke.sh
+        run: |
+          bash ./scripts/test-runtime-latency-workflow.sh
+          ./scripts/test-runtime-latency-smoke.sh

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -620,10 +620,10 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/api/v1/confidence", post(confidence))
         .route("/api/v1/blast-radius", post(blast_radius))
         .route("/api/v1/governance/spec-check", post(spec_check))
-        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
-        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/api/v1/trace/forward/{artifact_id}", post(trace_forward))
+        .route("/api/v1/trace/reverse/{artifact_id}", post(trace_reverse))
         .route(
-            "/api/v1/trace/:artifact_id/links",
+            "/api/v1/trace/{artifact_id}/links",
             get(list_persisted_trace_links),
         )
         .route("/evidence", get(list_evidence).post(create_evidence))
@@ -634,7 +634,7 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/sdlc-pm/sprints", get(list_sprints).post(create_sprint))
         .route("/sdlc-pm/stories", get(list_stories))
         .route("/api/v1/projects", get(list_projects))
-        .route("/api/v1/projects/:project_id", get(get_project))
+        .route("/api/v1/projects/{project_id}", get(get_project))
         .route("/problems", get(list_problems).post(create_problem))
         .route("/problems/health", get(health::health))
         .route("/org-intel/health", get(health::health))

--- a/frontend/scripts/test-api-base.mjs
+++ b/frontend/scripts/test-api-base.mjs
@@ -9,7 +9,7 @@ const http = ['http', '://'].join('')
 function run(raw, extra = {}) {
   try {
     execFileSync(process.execPath, [script], {
-      env: { ...process.env, VITE_API_URL: raw, ...extra },
+      env: { ...process.env, PRODUCTION_DEPLOY: '0', VITE_API_URL: raw, ...extra },
       stdio: 'pipe',
     })
     return { ok: true, output: '' }

--- a/frontend/scripts/test-deploy-pages-api-base-command.mjs
+++ b/frontend/scripts/test-deploy-pages-api-base-command.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const workflow = fileURLToPath(
+  new URL('../../.github/workflows/deploy-pages.yml', import.meta.url),
+)
+
+test('Pages validates the production API base from the frontend workspace root', () => {
+  const source = readFileSync(workflow, 'utf8')
+
+  assert.match(
+    source,
+    /PRODUCTION_DEPLOY=1 npm --prefix "\$GITHUB_WORKSPACE\/frontend" run test:api-base/,
+  )
+})

--- a/scripts/test-runtime-latency-workflow.sh
+++ b/scripts/test-runtime-latency-workflow.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the hosted smoke aligned with the lifecycle guarantees in
+# scripts/runtime-smoke.sh: select a dynamic loopback port, retain the server
+# through latency measurement, and print its log when readiness fails.
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="${root}/.github/workflows/runtime-latency-smoke.yml"
+
+fail() { echo "runtime latency workflow contract: $*" >&2; exit 1; }
+
+[[ -f "${workflow}" ]] || fail "workflow is missing"
+grep -Fq 'port="$(python3 -c' "${workflow}" || fail "workflow must select a dynamic loopback port"
+grep -Fq 'TRACERA_BIND_ADDR="127.0.0.1:${port}"' "${workflow}" || fail "workflow must bind the server to its dynamic port"
+grep -Fq 'log_path="${RUNNER_TEMP:-/tmp}/tracera-latency.log"' "${workflow}" || fail "workflow must keep a diagnosable server log"
+grep -Fq 'kill -0 "${pid}"' "${workflow}" || fail "workflow must detect an exited server during readiness"
+grep -Fq 'cat "${log_path}" >&2' "${workflow}" || fail "workflow must print the server log on readiness failure"
+! grep -Fq '127.0.0.1:18080' "${workflow}" || fail "workflow must not hard-code port 18080"
+
+echo "runtime latency workflow contract: PASS"


### PR DESCRIPTION
## Scope

- make API-base test fixtures independent of inherited production mode
- run Pages API-base validation from the frontend workspace root
- make runtime smoke diagnostic and dynamic-port safe
- update Axum route captures so the release server starts

## Evidence

- `node --test frontend/scripts/test-deploy-pages-api-base-command.mjs` passed
- API-base suite passed normally and with `PRODUCTION_DEPLOY=1`
- `cargo test --locked -p tracera-server`: 70 passed, 1 external-Postgres test ignored
- hosted runtime run 31853939707 passed all smoke and latency steps

## Remaining gates

Pages still requires a public HTTPS `TRACERA_API_BASE`; Vercel production secrets, Sonar policy debt, review, protected merge, deployed endpoint evidence, and dogfood remain outside this PR.