### PR TITLE
fix(docker): separate Bun lifecycle hooks

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -5,7 +5,7 @@ FROM oven/bun:1.1.38-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache bash python3 make g++
 
 COPY frontend/package.json frontend/bun.lock ./
 COPY frontend/apps ./apps
@@ -13,7 +13,8 @@ COPY frontend/packages ./packages
 COPY frontend/scripts ./scripts
 COPY frontend/turbo.json frontend/tsconfig.json frontend/tsconfig.packages.json ./
 
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
+RUN bun run postinstall
 
 ENV NODE_ENV=production
 ENV VITE_API_URL=

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -3,11 +3,35 @@ set -euo pipefail
 
 python3 - <<'PY'
 from pathlib import Path
+import json
 import re
 
 compose = Path("docker-compose.yml").read_text(encoding="utf-8")
 legacy_compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
+frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+
+package_manager = frontend_package["packageManager"]
+package_manager_name, package_manager_version = package_manager.split("@", 1)
+assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
+assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
+assert bun_image.group(1) == package_manager_version, (
+    "frontend build Bun image must match frontend/package.json packageManager"
+)
+install_command = "RUN bun install --frozen-lockfile --ignore-scripts"
+postinstall_command = "RUN bun run postinstall"
+assert install_command in dockerfile, "frontend install must defer lifecycle scripts"
+assert postinstall_command in dockerfile, "frontend install must run the declared postinstall explicitly"
+assert dockerfile.index(install_command) < dockerfile.index(postinstall_command), (
+    "frontend install must precede the explicit postinstall"
+)
+if frontend_package.get("scripts", {}).get("postinstall", "").startswith("bash "):
+    bash_install = re.search(r"^RUN apk add --no-cache .*\bbash\b", dockerfile, re.M)
+    assert bash_install, "frontend postinstall requires Bash in the Alpine build stage"
+    assert dockerfile.index(bash_install.group(0)) < dockerfile.index(postinstall_command), (
+        "frontend build must install Bash before postinstall"
+    )
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (


### PR DESCRIPTION
## Summary
- install the pinned Bun workspace with lifecycle scripts deferred
- run the declared root postinstall explicitly after installing Bash
- enforce Bun pin, lifecycle ordering, and Bash prerequisite in the local Compose contract

## Validation
- `bash scripts/test-local-compose-contract.sh` (pass)
- `git diff --check` (pass before commit)
- canonical Docker build with the external existing-Postgres-volume overlay: frozen install and explicit postinstall passed; build then stopped at unrelated `TS2578` in `src/lib/use-sync-external-store-with-selector-shim.ts`

No application TypeScript changes are included.