### PR TITLE
fix(docker): align frontend Bun toolchain

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,7 +1,7 @@
 # Build the approved rich dashboard with the workspace-pinned Bun release.
 # Keep VITE_API_URL empty so the packaged SPA uses the Rust server's same-origin
 # API and WebSocket routes in the production image.
-FROM oven/bun:1.1.38-alpine AS frontend-build
+FROM oven/bun:1.3.11-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,5 +154,5 @@
     "vitest": "^4.1.10",
     "zod": "4.3.6"
   },
-  "packageManager": "bun@1.1.38"
+  "packageManager": "bun@1.3.11"
 }

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -14,6 +14,9 @@ frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="
 package_manager = frontend_package["packageManager"]
 package_manager_name, package_manager_version = package_manager.split("@", 1)
 assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+assert package_manager_version == "1.3.11", (
+    "frontend packageManager must use the supported Bun 1.3.11 toolchain"
+)
 bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
 assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
 assert bun_image.group(1) == package_manager_version, (


### PR DESCRIPTION
## Summary

This stacked follow-up to #848 makes the Docker frontend build use the supported Bun 1.3.11 toolchain consistently with the frontend package-manager declaration.

The underlying issue is drift: the canonical Rust image still used Bun 1.1.38 while the known working local Docker path uses Bun 1.3.11. That makes container behavior diverge and obscures lifecycle-install failures.

Changes are intentionally limited to:
- `Dockerfile.rust`: frontend stage `oven/bun:1.3.11-alpine`.
- `frontend/package.json`: `packageManager: bun@1.3.11`.
- `scripts/test-local-compose-contract.sh`: require Bun 1.3.11 and image/packageManager parity.

## Dependency

This PR is stacked on #848 (`fix/docker-bun-lifecycle-pact-20260815-r2`) and must merge only after #848. #848 supplies the lifecycle-safe frozen install and explicit repository postinstall; this PR supplies the synchronized Bun version contract.

## Validation

- RED: the updated contract failed on #848 with `frontend packageManager must use the supported Bun 1.3.11 toolchain`.
- GREEN: `./scripts/test-local-compose-contract.sh` passed.
- `git diff --check` passed.
- A foreground canonical Docker build reached the updated Bun 1.3.11 stage and lifecycle-disabled frozen install, but its PTY was reclaimed before a terminal BuildKit result and no resulting image was observed. This is an explicit remaining dynamic-build gate, not a pass.
