### PR TITLE
fix(docker): make Bun lifecycle install reproducible

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,7 +1,7 @@
 # Build the approved rich dashboard with the workspace-pinned Bun release.
 # Keep VITE_API_URL empty so the packaged SPA uses the Rust server's same-origin
 # API and WebSocket routes in the production image.
-FROM oven/bun:1.1.38-alpine AS frontend-build
+FROM oven/bun:1.3.11-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -5,7 +5,7 @@ FROM oven/bun:1.1.38-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache bash python3 make g++
 
 COPY frontend/package.json frontend/bun.lock ./
 COPY frontend/apps ./apps
@@ -13,7 +13,8 @@ COPY frontend/packages ./packages
 COPY frontend/scripts ./scripts
 COPY frontend/turbo.json frontend/tsconfig.json frontend/tsconfig.packages.json ./
 
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
+RUN bun run postinstall
 
 ENV NODE_ENV=production
 ENV VITE_API_URL=

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,5 +154,5 @@
     "vitest": "^4.1.10",
     "zod": "4.3.6"
   },
-  "packageManager": "bun@1.1.38"
+  "packageManager": "bun@1.3.11"
 }

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -14,6 +14,9 @@ frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="
 package_manager = frontend_package["packageManager"]
 package_manager_name, package_manager_version = package_manager.split("@", 1)
 assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+assert package_manager_version == "1.3.11", (
+    "frontend packageManager must use the supported Bun 1.3.11 toolchain"
+)
 bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
 assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
 assert bun_image.group(1) == package_manager_version, (

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -3,11 +3,35 @@ set -euo pipefail
 
 python3 - <<'PY'
 from pathlib import Path
+import json
 import re
 
 compose = Path("docker-compose.yml").read_text(encoding="utf-8")
 legacy_compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
+frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+
+package_manager = frontend_package["packageManager"]
+package_manager_name, package_manager_version = package_manager.split("@", 1)
+assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
+assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
+assert bun_image.group(1) == package_manager_version, (
+    "frontend build Bun image must match frontend/package.json packageManager"
+)
+install_command = "RUN bun install --frozen-lockfile --ignore-scripts"
+postinstall_command = "RUN bun run postinstall"
+assert install_command in dockerfile, "frontend install must defer lifecycle scripts"
+assert postinstall_command in dockerfile, "frontend install must run the declared postinstall explicitly"
+assert dockerfile.index(install_command) < dockerfile.index(postinstall_command), (
+    "frontend install must precede the explicit postinstall"
+)
+if frontend_package.get("scripts", {}).get("postinstall", "").startswith("bash "):
+    bash_install = re.search(r"^RUN apk add --no-cache .*\bbash\b", dockerfile, re.M)
+    assert bash_install, "frontend postinstall requires Bash in the Alpine build stage"
+    assert dockerfile.index(bash_install.group(0)) < dockerfile.index(postinstall_command), (
+        "frontend build must install Bash before postinstall"
+    )
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (


### PR DESCRIPTION
## Why

Restores the two preserved Docker/Bun commits as one clean, main-based PR after their earlier PRs became unreachable.

## Scope

- separate root lifecycle installation from workspace postinstall hooks
- install Bash for the image lifecycle contract
- align the frontend Bun toolchain metadata to Bun 1.3.11

## Verification

- `git diff --check origin/main...HEAD`
- exact cumulative scope: `Dockerfile.rust`, `frontend/package.json`, `scripts/test-local-compose-contract.sh`
- dynamic Docker build accepted from source commit `c42e3687549879621a3ddc841cf47b7626696163`
  - log: `/private/tmp/tracera-849-c42e368-docker-build-20260815T022334.log`
  - terminal marker: `docker_build_exit=0`
  - image: `tracera-buildproof-849:c42e368`

## Provenance

- preserved source refs: `preserve/docker-bun-lifecycle-20260815` (`05123200c7059d533c8792865680be15c94ba5cf`) and `preserve/docker-bun-coherence-20260815` (`c42e3687549879621a3ddc841cf47b7626696163`)
- reconstructed commits: `d94f70b28` then `42955e23d`

This is deliberately a single non-stacked draft PR; runtime promotion remains a separate gate.