### PR TITLE
fix(docker): unblock canonical local Tracera dogfood

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -22,6 +22,7 @@ ENV VITE_API_URL=
 # Use the documented `bun run` form; older pinned Bun releases do not parse
 # `bun --cwd <dir> run <script>` as a script invocation.
 WORKDIR /workspace/frontend/apps/web
+RUN bun run postinstall
 RUN bun run build
 RUN test -f /workspace/frontend/dist/index.html
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,7 +1,7 @@
 # Build the approved rich dashboard with the workspace-pinned Bun release.
 # Keep VITE_API_URL empty so the packaged SPA uses the Rust server's same-origin
 # API and WebSocket routes in the production image.
-FROM oven/bun:1.1.38-alpine AS frontend-build
+FROM oven/bun:1.3.11-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -5,7 +5,7 @@ FROM oven/bun:1.1.38-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache bash python3 make g++
 
 COPY frontend/package.json frontend/bun.lock ./
 COPY frontend/apps ./apps
@@ -13,7 +13,8 @@ COPY frontend/packages ./packages
 COPY frontend/scripts ./scripts
 COPY frontend/turbo.json frontend/tsconfig.json frontend/tsconfig.packages.json ./
 
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
+RUN bun run postinstall
 
 ENV NODE_ENV=production
 ENV VITE_API_URL=

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -11,7 +11,6 @@ mod validation;
 
 use axum::{
     extract::DefaultBodyLimit,
-    response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
@@ -1266,24 +1265,35 @@ async fn list_projects(
 async fn get_project(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Path(project_id): axum::extract::Path<String>,
-) -> axum::response::Response {
-    match state.store.get_project(project_id.clone()).await {
-        Ok(Some(project)) => Json(ProjectResponse {
-            id: project.id,
-            name: project.name,
-            description: project.description,
-            created_at: project.created_at,
-            updated_at: project.updated_at,
-            metadata: project.metadata,
-            problem_count: project.problem_count,
-        })
-        .into_response(),
-        Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
-        Err(error) => {
+) -> Result<Json<ProjectResponse>, (axum::http::StatusCode, Json<ErrorResponse>)> {
+    let project = state
+        .store
+        .get_project(project_id)
+        .await
+        .map_err(|error| {
             tracing::error!("get_project store error: {error}");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "project lookup failed",
+                }),
+            )
+        })?
+        .ok_or((
+            axum::http::StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "project not found",
+            }),
+        ))?;
+    Ok(Json(ProjectResponse {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+        metadata: project.metadata,
+        problem_count: project.problem_count,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -2026,6 +2036,61 @@ mod tests {
             .await
             .expect("body");
         assert_eq!(body.as_ref(), br#"{"error":"project listing failed"}"#);
+    }
+
+    #[tokio::test]
+    async fn project_lookup_returns_structured_not_found() {
+        let store = make_sqlite_store().await;
+        let app = build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(store),
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/projects/missing-project")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("body");
+        assert_eq!(body.as_ref(), br#"{"error":"project not found"}"#);
+    }
+
+    #[tokio::test]
+    async fn project_lookup_returns_structured_5xx_when_store_is_unavailable() {
+        let store = make_sqlite_store().await;
+        store.pool.close().await;
+        let app = build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(store),
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/projects/project-1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("body");
+        assert_eq!(body.as_ref(), br#"{"error":"project lookup failed"}"#);
     }
 
     #[tokio::test]

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -620,10 +620,10 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/api/v1/confidence", post(confidence))
         .route("/api/v1/blast-radius", post(blast_radius))
         .route("/api/v1/governance/spec-check", post(spec_check))
-        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
-        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/api/v1/trace/forward/{artifact_id}", post(trace_forward))
+        .route("/api/v1/trace/reverse/{artifact_id}", post(trace_reverse))
         .route(
-            "/api/v1/trace/:artifact_id/links",
+            "/api/v1/trace/{artifact_id}/links",
             get(list_persisted_trace_links),
         )
         .route("/evidence", get(list_evidence).post(create_evidence))
@@ -634,7 +634,7 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/sdlc-pm/sprints", get(list_sprints).post(create_sprint))
         .route("/sdlc-pm/stories", get(list_stories))
         .route("/api/v1/projects", get(list_projects))
-        .route("/api/v1/projects/:project_id", get(get_project))
+        .route("/api/v1/projects/{project_id}", get(get_project))
         .route("/problems", get(list_problems).post(create_problem))
         .route("/problems/health", get(health::health))
         .route("/org-intel/health", get(health::health))
@@ -1816,6 +1816,29 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_slice(&body).expect("json body");
         assert_eq!(payload["count"], 0);
         assert_eq!(payload["items"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn api_router_matches_persisted_trace_links_route_parameter() {
+        let store = make_sqlite_store().await;
+        let app = build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(store),
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/trace/REQ-001/links")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,5 +154,5 @@
     "vitest": "^4.1.10",
     "zod": "4.3.6"
   },
-  "packageManager": "bun@1.1.38"
+  "packageManager": "bun@1.3.11"
 }

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -14,6 +14,9 @@ frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="
 package_manager = frontend_package["packageManager"]
 package_manager_name, package_manager_version = package_manager.split("@", 1)
 assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+assert package_manager_version == "1.3.11", (
+    "frontend packageManager must use the supported Bun 1.3.11 toolchain"
+)
 bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
 assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
 assert bun_image.group(1) == package_manager_version, (

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -10,6 +10,7 @@ compose = Path("docker-compose.yml").read_text(encoding="utf-8")
 legacy_compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
 frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+web_package = json.loads(Path("frontend/apps/web/package.json").read_text(encoding="utf-8"))
 
 package_manager = frontend_package["packageManager"]
 package_manager_name, package_manager_version = package_manager.split("@", 1)
@@ -35,6 +36,19 @@ if frontend_package.get("scripts", {}).get("postinstall", "").startswith("bash "
     assert dockerfile.index(bash_install.group(0)) < dockerfile.index(postinstall_command), (
         "frontend build must install Bash before postinstall"
     )
+
+web_postinstall_command = "RUN bun run postinstall"
+web_workdir = "WORKDIR /workspace/frontend/apps/web"
+web_build_command = "RUN bun run build"
+assert web_package.get("scripts", {}).get("postinstall"), (
+    "web workspace must declare the router compatibility postinstall hook"
+)
+assert dockerfile.count(web_postinstall_command) >= 2, (
+    "frontend image must run the web workspace postinstall explicitly"
+)
+assert dockerfile.index(web_workdir) < dockerfile.rindex(web_postinstall_command) < dockerfile.index(web_build_command), (
+    "web workspace postinstall must run after entering apps/web and before its build"
+)
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -3,11 +3,35 @@ set -euo pipefail
 
 python3 - <<'PY'
 from pathlib import Path
+import json
 import re
 
 compose = Path("docker-compose.yml").read_text(encoding="utf-8")
 legacy_compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
+frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+
+package_manager = frontend_package["packageManager"]
+package_manager_name, package_manager_version = package_manager.split("@", 1)
+assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
+assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
+assert bun_image.group(1) == package_manager_version, (
+    "frontend build Bun image must match frontend/package.json packageManager"
+)
+install_command = "RUN bun install --frozen-lockfile --ignore-scripts"
+postinstall_command = "RUN bun run postinstall"
+assert install_command in dockerfile, "frontend install must defer lifecycle scripts"
+assert postinstall_command in dockerfile, "frontend install must run the declared postinstall explicitly"
+assert dockerfile.index(install_command) < dockerfile.index(postinstall_command), (
+    "frontend install must precede the explicit postinstall"
+)
+if frontend_package.get("scripts", {}).get("postinstall", "").startswith("bash "):
+    bash_install = re.search(r"^RUN apk add --no-cache .*\bbash\b", dockerfile, re.M)
+    assert bash_install, "frontend postinstall requires Bash in the Alpine build stage"
+    assert dockerfile.index(bash_install.group(0)) < dockerfile.index(postinstall_command), (
+        "frontend build must install Bash before postinstall"
+    )
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (


### PR DESCRIPTION
## **User description**
## Purpose

One clean, main-based replacement for the vanished Docker lifecycle branch, combining only the preserved local-dogfood blockers.

## Scope

- make Docker Bun lifecycle installation reproducible
- align frontend toolchain metadata to Bun 1.3.11
- update Axum 0.8 route capture syntax so the Tracera server routes compile/test

## Provenance

- `preserve/docker-bun-lifecycle-20260815` -> `05123200c7059d533c8792865680be15c94ba5cf`
- `preserve/docker-bun-coherence-20260815` -> `c42e3687549879621a3ddc841cf47b7626696163`
- `preserve/axum-route-syntax-20260815` -> `f0f2f21c897ab82a1a842ada706d5fcd3c5158d6`
- reconstructed clean commits: `394b771ff`, `d2a758356`, `e471c6be5`

## Verification

- `git diff --check origin/main...HEAD` passed
- exact cumulative scope verified: `Dockerfile.rust`, `frontend/package.json`, `scripts/test-local-compose-contract.sh`, `crates/tracera-server/src/main.rs`
- Dynamic Docker build passed at source `c42e3687549879621a3ddc841cf47b7626696163`
  - log: `/private/tmp/tracera-849-c42e368-docker-build-20260815T022334.log`
  - marker: `docker_build_exit=0`
  - image: `tracera-buildproof-849:c42e368`
- Router regression: 71 tests passed at source `f0f2f21c897ab82a1a842ada706d5fcd3c5158d6`

Runtime compose startup, authenticated Evidence round-trip, hosted required CI, review, and merge remain separate gates.


___

## **CodeAnt-AI Description**
Unblock local Docker builds and restore trace and project API routing

### What Changed
- Local frontend builds now use Bun 1.3.11 consistently, install lifecycle dependencies in controlled steps, and run the web workspace setup before building.
- Docker builds include the required shell tools and complete the frontend post-install setup before packaging the dashboard.
- Trace and project endpoints now accept path parameters correctly with the current server routing, including persisted trace-link requests.
- Added a route check to prevent regressions when fetching links for a specific artifact.

### Impact
`✅ Successful local Docker frontend builds`
`✅ Reliable dashboard packaging`
`✅ Working trace-link and project API requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
