### PR TITLE
fix(dogfood): restore local runtime and structured project errors

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -22,6 +22,7 @@ ENV VITE_API_URL=
 # Use the documented `bun run` form; older pinned Bun releases do not parse
 # `bun --cwd <dir> run <script>` as a script invocation.
 WORKDIR /workspace/frontend/apps/web
+RUN bun run postinstall
 RUN bun run build
 RUN test -f /workspace/frontend/dist/index.html
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,7 +1,7 @@
 # Build the approved rich dashboard with the workspace-pinned Bun release.
 # Keep VITE_API_URL empty so the packaged SPA uses the Rust server's same-origin
 # API and WebSocket routes in the production image.
-FROM oven/bun:1.1.38-alpine AS frontend-build
+FROM oven/bun:1.3.11-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -5,7 +5,7 @@ FROM oven/bun:1.1.38-alpine AS frontend-build
 
 WORKDIR /workspace/frontend
 
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache bash python3 make g++
 
 COPY frontend/package.json frontend/bun.lock ./
 COPY frontend/apps ./apps
@@ -13,7 +13,8 @@ COPY frontend/packages ./packages
 COPY frontend/scripts ./scripts
 COPY frontend/turbo.json frontend/tsconfig.json frontend/tsconfig.packages.json ./
 
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
+RUN bun run postinstall
 
 ENV NODE_ENV=production
 ENV VITE_API_URL=

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -11,7 +11,6 @@ mod validation;
 
 use axum::{
     extract::DefaultBodyLimit,
-    response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
@@ -1266,24 +1265,35 @@ async fn list_projects(
 async fn get_project(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Path(project_id): axum::extract::Path<String>,
-) -> axum::response::Response {
-    match state.store.get_project(project_id.clone()).await {
-        Ok(Some(project)) => Json(ProjectResponse {
-            id: project.id,
-            name: project.name,
-            description: project.description,
-            created_at: project.created_at,
-            updated_at: project.updated_at,
-            metadata: project.metadata,
-            problem_count: project.problem_count,
-        })
-        .into_response(),
-        Ok(None) => axum::http::StatusCode::NOT_FOUND.into_response(),
-        Err(error) => {
+) -> Result<Json<ProjectResponse>, (axum::http::StatusCode, Json<ErrorResponse>)> {
+    let project = state
+        .store
+        .get_project(project_id)
+        .await
+        .map_err(|error| {
             tracing::error!("get_project store error: {error}");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "project lookup failed",
+                }),
+            )
+        })?
+        .ok_or((
+            axum::http::StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "project not found",
+            }),
+        ))?;
+    Ok(Json(ProjectResponse {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+        metadata: project.metadata,
+        problem_count: project.problem_count,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -2026,6 +2036,61 @@ mod tests {
             .await
             .expect("body");
         assert_eq!(body.as_ref(), br#"{"error":"project listing failed"}"#);
+    }
+
+    #[tokio::test]
+    async fn project_lookup_returns_structured_not_found() {
+        let store = make_sqlite_store().await;
+        let app = build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(store),
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/projects/missing-project")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("body");
+        assert_eq!(body.as_ref(), br#"{"error":"project not found"}"#);
+    }
+
+    #[tokio::test]
+    async fn project_lookup_returns_structured_5xx_when_store_is_unavailable() {
+        let store = make_sqlite_store().await;
+        store.pool.close().await;
+        let app = build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(store),
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/projects/project-1")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("body");
+        assert_eq!(body.as_ref(), br#"{"error":"project lookup failed"}"#);
     }
 
     #[tokio::test]

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -620,10 +620,10 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/api/v1/confidence", post(confidence))
         .route("/api/v1/blast-radius", post(blast_radius))
         .route("/api/v1/governance/spec-check", post(spec_check))
-        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
-        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/api/v1/trace/forward/{artifact_id}", post(trace_forward))
+        .route("/api/v1/trace/reverse/{artifact_id}", post(trace_reverse))
         .route(
-            "/api/v1/trace/:artifact_id/links",
+            "/api/v1/trace/{artifact_id}/links",
             get(list_persisted_trace_links),
         )
         .route("/evidence", get(list_evidence).post(create_evidence))
@@ -634,7 +634,7 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/sdlc-pm/sprints", get(list_sprints).post(create_sprint))
         .route("/sdlc-pm/stories", get(list_stories))
         .route("/api/v1/projects", get(list_projects))
-        .route("/api/v1/projects/:project_id", get(get_project))
+        .route("/api/v1/projects/{project_id}", get(get_project))
         .route("/problems", get(list_problems).post(create_problem))
         .route("/problems/health", get(health::health))
         .route("/org-intel/health", get(health::health))
@@ -1816,6 +1816,29 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_slice(&body).expect("json body");
         assert_eq!(payload["count"], 0);
         assert_eq!(payload["items"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn api_router_matches_persisted_trace_links_route_parameter() {
+        let store = make_sqlite_store().await;
+        let app = build_router(AppState {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            backend: "sqlite",
+            started_at: Instant::now(),
+            store: Arc::new(store),
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/trace/REQ-001/links")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,5 +154,5 @@
     "vitest": "^4.1.10",
     "zod": "4.3.6"
   },
-  "packageManager": "bun@1.1.38"
+  "packageManager": "bun@1.3.11"
 }

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -14,6 +14,9 @@ frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="
 package_manager = frontend_package["packageManager"]
 package_manager_name, package_manager_version = package_manager.split("@", 1)
 assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+assert package_manager_version == "1.3.11", (
+    "frontend packageManager must use the supported Bun 1.3.11 toolchain"
+)
 bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
 assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
 assert bun_image.group(1) == package_manager_version, (

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -10,6 +10,7 @@ compose = Path("docker-compose.yml").read_text(encoding="utf-8")
 legacy_compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
 frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+web_package = json.loads(Path("frontend/apps/web/package.json").read_text(encoding="utf-8"))
 
 package_manager = frontend_package["packageManager"]
 package_manager_name, package_manager_version = package_manager.split("@", 1)
@@ -35,6 +36,19 @@ if frontend_package.get("scripts", {}).get("postinstall", "").startswith("bash "
     assert dockerfile.index(bash_install.group(0)) < dockerfile.index(postinstall_command), (
         "frontend build must install Bash before postinstall"
     )
+
+web_postinstall_command = "RUN bun run postinstall"
+web_workdir = "WORKDIR /workspace/frontend/apps/web"
+web_build_command = "RUN bun run build"
+assert web_package.get("scripts", {}).get("postinstall"), (
+    "web workspace must declare the router compatibility postinstall hook"
+)
+assert dockerfile.count(web_postinstall_command) >= 2, (
+    "frontend image must run the web workspace postinstall explicitly"
+)
+assert dockerfile.index(web_workdir) < dockerfile.rindex(web_postinstall_command) < dockerfile.index(web_build_command), (
+    "web workspace postinstall must run after entering apps/web and before its build"
+)
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (

--- a/scripts/test-local-compose-contract.sh
+++ b/scripts/test-local-compose-contract.sh
@@ -3,11 +3,35 @@ set -euo pipefail
 
 python3 - <<'PY'
 from pathlib import Path
+import json
 import re
 
 compose = Path("docker-compose.yml").read_text(encoding="utf-8")
 legacy_compose = Path("docker-compose.local.yml").read_text(encoding="utf-8")
 dockerfile = Path("Dockerfile.rust").read_text(encoding="utf-8")
+frontend_package = json.loads(Path("frontend/package.json").read_text(encoding="utf-8"))
+
+package_manager = frontend_package["packageManager"]
+package_manager_name, package_manager_version = package_manager.split("@", 1)
+assert package_manager_name == "bun", "frontend packageManager must declare Bun"
+bun_image = re.search(r"^FROM oven/bun:([^\s]+)-alpine AS frontend-build$", dockerfile, re.M)
+assert bun_image, "frontend build stage must use an explicit Bun Alpine image"
+assert bun_image.group(1) == package_manager_version, (
+    "frontend build Bun image must match frontend/package.json packageManager"
+)
+install_command = "RUN bun install --frozen-lockfile --ignore-scripts"
+postinstall_command = "RUN bun run postinstall"
+assert install_command in dockerfile, "frontend install must defer lifecycle scripts"
+assert postinstall_command in dockerfile, "frontend install must run the declared postinstall explicitly"
+assert dockerfile.index(install_command) < dockerfile.index(postinstall_command), (
+    "frontend install must precede the explicit postinstall"
+)
+if frontend_package.get("scripts", {}).get("postinstall", "").startswith("bash "):
+    bash_install = re.search(r"^RUN apk add --no-cache .*\bbash\b", dockerfile, re.M)
+    assert bash_install, "frontend postinstall requires Bash in the Alpine build stage"
+    assert dockerfile.index(bash_install.group(0)) < dockerfile.index(postinstall_command), (
+        "frontend build must install Bash before postinstall"
+    )
 
 assert "HEALTHCHECK" in dockerfile, "Rust image must define a healthcheck"
 assert "wget -q -O /dev/null http://127.0.0.1:8080/health" in dockerfile, (


### PR DESCRIPTION
## User-facing outcome

Local Tracera dogfood uses the declared Bun lifecycle and returns structured JSON for missing/unavailable project lookups rather than empty framework responses.

## Scope

- Restore the preserved PR #851 candidate exactly at d99a252.
- Docker/Bun lifecycle alignment, Axum route capture syntax, and project lookup ErrorResponse contract.
- Four files only: Dockerfile.rust, server main.rs, frontend/package.json, and local compose contract script.

## Evidence

- Candidate is 0 behind current main and 5 commits ahead; merge-tree is conflict-free.
- `cargo test -p tracera-server project_lookup_returns_structured -- --nocapture` passes 2/2 in an isolated target directory.
- `git diff --check` passes.
- Prior branch deletion risk is now mitigated by repository ruleset `preserve branch evidence` (all branches; deletion and non-fast-forward blocked; no bypasses) and disabled merged-branch auto-deletion.

## Promotion gates

This remains draft. Required hosted checks, review, merge to main, configured live compose/browser dogfood, and public-host security evidence are still required.

Supersedes the deleted review branch for closed-unmerged PR #851; original candidate remains preserved by immutable tag `preserve/tracera/20260816/pr851-final-api-errors-d99a2524`.