### PR TITLE
fix(cli): migrate password generation to rand 0.10

### DIFF
--- a/crates/tracera-cli/src/compose.rs
+++ b/crates/tracera-cli/src/compose.rs
@@ -157,9 +157,8 @@ pub fn ensure_env_file(env_file: &Path, local_port: u16) -> anyhow::Result<()> {
 }
 
 fn generate_password() -> String {
-    use rand::RngCore;
     let mut bytes = [0u8; 24];
-    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    rand::fill(&mut bytes);
     // Avoid shell-quoting issues — keep it URL-safe ASCII.
     use std::fmt::Write;
     let mut s = String::with_capacity(32);
@@ -224,6 +223,14 @@ mod tests {
         assert_eq!(args[env_idx + 1], "/tmp/.env.local");
         assert!(args.windows(2).any(|w| w[0] == "-f" && w[1] == "/tmp/docker-compose.bundle.yml"));
         assert_eq!(args[args.len() - 2..], ["up", "-d"]);
+    }
+
+    #[test]
+    fn generated_password_is_lowercase_hex_with_24_random_bytes() {
+        let password = generate_password();
+
+        assert_eq!(password.len(), 48);
+        assert!(password.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)));
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

Dependabot commit f7cb8a58 upgraded direct dependency `rand` from 0.8.7 to 0.10.2 but did not migrate the CLI password generator from `RngCore` / `OsRng.fill_bytes`. This makes `tracera-cli` fail to compile in the workspace preflight.

## Scope

- Replace the obsolete Rand 0.8 calls with supported Rand 0.10 `rand::fill`.
- Add a regression test: generated database passwords are 24 random bytes encoded as 48 lowercase hex characters.

## Evidence

- New test was RED on exact current-main compilation errors E0432/E0425.
- Focused password test and full `cargo test -p tracera-cli` pass: 7/7.
- `git diff --check` passes.

Current main has independent workspace-format drift, including this file. Draft PR #853 carries that mechanical baseline; this PR intentionally does not mix in formatting churn. No merge performed.