### PR TITLE
fix(ci): restore current-main workspace preflight

### DIFF
--- a/crates/tracera-cli/src/bundle.rs
+++ b/crates/tracera-cli/src/bundle.rs
@@ -79,9 +79,11 @@ impl BundleLayout {
         let home = std::env::var_os("HOME")
             .map(PathBuf::from)
             .context("HOME not set")?;
-        let root = home.join("Library").join("Application Support").join("Tracera");
-        std::fs::create_dir_all(&root)
-            .with_context(|| format!("creating {}", root.display()))?;
+        let root = home
+            .join("Library")
+            .join("Application Support")
+            .join("Tracera");
+        std::fs::create_dir_all(&root).with_context(|| format!("creating {}", root.display()))?;
 
         let env_file = root.join(".env.local");
         let local_port: u16 = std::env::var("TRACERA_LOCAL_PORT")

--- a/crates/tracera-cli/src/bundle.rs
+++ b/crates/tracera-cli/src/bundle.rs
@@ -20,9 +20,6 @@ use anyhow::Context;
 
 #[derive(Debug, Clone)]
 pub struct BundleLayout {
-    /// Root of the Tracera installation (the worktree, or `~/.tracera` for
-    /// the bundled app).
-    pub root: PathBuf,
     /// Directory holding docker-compose.bundle.yml and assets.
     pub compose_dir: PathBuf,
     /// Path to the compose file (image-based, no build directives).
@@ -92,7 +89,6 @@ impl BundleLayout {
             .unwrap_or(18081);
 
         Ok(Self {
-            root,
             compose_dir: bundle_dir,
             compose_file,
             env_file,
@@ -115,7 +111,6 @@ impl BundleLayout {
                     .and_then(|s| s.parse().ok())
                     .unwrap_or(18081);
                 return Ok(Self {
-                    root: cursor.to_path_buf(),
                     compose_dir: cursor.to_path_buf(),
                     compose_file: candidate,
                     env_file,

--- a/crates/tracera-cli/src/commands.rs
+++ b/crates/tracera-cli/src/commands.rs
@@ -147,9 +147,13 @@ fn resolve_layout(cli: &Cli) -> anyhow::Result<BundleLayout> {
         // User override: behave as if the bundle lives at <root>/tracera-bundle
         // if <root>/tracera-bundle/docker-compose.bundle.yml exists, otherwise
         // treat <root> as the compose directory.
-        let candidate = root.join("tracera-bundle").join("docker-compose.bundle.yml");
+        let candidate = root
+            .join("tracera-bundle")
+            .join("docker-compose.bundle.yml");
         if candidate.exists() {
-            return BundleLayout::resolve(Some(&root.join("tracera-bundle").join("bin").join("tracera")));
+            return BundleLayout::resolve(Some(
+                &root.join("tracera-bundle").join("bin").join("tracera"),
+            ));
         }
         let standalone = root.join("docker-compose.local.yml");
         if standalone.exists() {
@@ -157,7 +161,10 @@ fn resolve_layout(cli: &Cli) -> anyhow::Result<BundleLayout> {
             let fake = root.join("target").join("release").join("tracera");
             return BundleLayout::resolve(Some(&fake));
         }
-        anyhow::bail!("--root {} contains neither tracera-bundle/ nor docker-compose.local.yml", root.display());
+        anyhow::bail!(
+            "--root {} contains neither tracera-bundle/ nor docker-compose.local.yml",
+            root.display()
+        );
     }
     BundleLayout::resolve(None)
 }
@@ -184,7 +191,15 @@ async fn cmd_up(
     if args.build {
         sub.push("--build");
     }
-    let code = compose::run_inherited(backend, &layout.project_name, &layout.compose_file, &layout.env_file, cwd.clone(), &sub).await?;
+    let code = compose::run_inherited(
+        backend,
+        &layout.project_name,
+        &layout.compose_file,
+        &layout.env_file,
+        cwd.clone(),
+        &sub,
+    )
+    .await?;
     if code != 0 {
         anyhow::bail!("compose up exited with code {code}");
     }
@@ -211,7 +226,15 @@ async fn cmd_down(
     if args.volumes {
         sub.push("--volumes");
     }
-    let code = compose::run_inherited(backend, &layout.project_name, &layout.compose_file, &layout.env_file, cwd.clone(), &sub).await?;
+    let code = compose::run_inherited(
+        backend,
+        &layout.project_name,
+        &layout.compose_file,
+        &layout.env_file,
+        cwd.clone(),
+        &sub,
+    )
+    .await?;
     if code != 0 {
         anyhow::bail!("compose down exited with code {code}");
     }
@@ -221,17 +244,39 @@ async fn cmd_down(
 async fn cmd_status(backend: Backend, layout: &BundleLayout, cwd: &PathBuf) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
     sync_bundle_env_symlink(&layout.compose_dir, &layout.env_file)?;
-    let code = compose::run_inherited(backend, &layout.project_name, &layout.compose_file, &layout.env_file, cwd.clone(), &["ps"]).await?;
+    let code = compose::run_inherited(
+        backend,
+        &layout.project_name,
+        &layout.compose_file,
+        &layout.env_file,
+        cwd.clone(),
+        &["ps"],
+    )
+    .await?;
     if code != 0 {
         anyhow::bail!("compose ps exited with code {code}");
     }
     Ok(())
 }
 
-async fn cmd_logs(backend: Backend, layout: &BundleLayout, cwd: &PathBuf, args: LogsArgs) -> anyhow::Result<()> {
+async fn cmd_logs(
+    backend: Backend,
+    layout: &BundleLayout,
+    cwd: &PathBuf,
+    args: LogsArgs,
+) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
     sync_bundle_env_symlink(&layout.compose_dir, &layout.env_file)?;
-    let code = compose::logs(backend, &layout.project_name, &layout.compose_file, &layout.env_file, cwd.clone(), args.service.as_deref(), args.follow).await?;
+    let code = compose::logs(
+        backend,
+        &layout.project_name,
+        &layout.compose_file,
+        &layout.env_file,
+        cwd.clone(),
+        args.service.as_deref(),
+        args.follow,
+    )
+    .await?;
     if code != 0 {
         anyhow::bail!("compose logs exited with code {code}");
     }
@@ -241,7 +286,9 @@ async fn cmd_logs(backend: Backend, layout: &BundleLayout, cwd: &PathBuf, args: 
 fn cmd_open(layout: &BundleLayout) -> anyhow::Result<()> {
     #[cfg(target_os = "macos")]
     {
-        let status = std::process::Command::new("open").arg(&layout.local_url).status()?;
+        let status = std::process::Command::new("open")
+            .arg(&layout.local_url)
+            .status()?;
         if !status.success() {
             anyhow::bail!("open {} failed", layout.local_url);
         }
@@ -249,7 +296,9 @@ fn cmd_open(layout: &BundleLayout) -> anyhow::Result<()> {
     }
     #[cfg(target_os = "windows")]
     {
-        let status = std::process::Command::new("cmd").args(["/c", "start", "", &layout.local_url]).status()?;
+        let status = std::process::Command::new("cmd")
+            .args(["/c", "start", "", &layout.local_url])
+            .status()?;
         if !status.success() {
             anyhow::bail!("start {} failed", layout.local_url);
         }
@@ -257,7 +306,9 @@ fn cmd_open(layout: &BundleLayout) -> anyhow::Result<()> {
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        let status = std::process::Command::new("xdg-open").arg(&layout.local_url).status()?;
+        let status = std::process::Command::new("xdg-open")
+            .arg(&layout.local_url)
+            .status()?;
         if !status.success() {
             anyhow::bail!("xdg-open {} failed", layout.local_url);
         }
@@ -274,14 +325,35 @@ async fn cmd_doctor(
     ensure_env_file(&layout.env_file, layout.local_port)?;
     sync_bundle_env_symlink(&layout.compose_dir, &layout.env_file)?;
     let mut report = serde_json::Map::new();
-    report.insert("backend".into(), serde_json::Value::String(backend.to_string()));
-    report.insert("compose_file".into(), serde_json::Value::String(layout.compose_file.display().to_string()));
-    report.insert("env_file".into(), serde_json::Value::String(layout.env_file.display().to_string()));
-    report.insert("local_url".into(), serde_json::Value::String(layout.local_url.clone()));
+    report.insert(
+        "backend".into(),
+        serde_json::Value::String(backend.to_string()),
+    );
+    report.insert(
+        "compose_file".into(),
+        serde_json::Value::String(layout.compose_file.display().to_string()),
+    );
+    report.insert(
+        "env_file".into(),
+        serde_json::Value::String(layout.env_file.display().to_string()),
+    );
+    report.insert(
+        "local_url".into(),
+        serde_json::Value::String(layout.local_url.clone()),
+    );
     report.insert("bundled".into(), serde_json::Value::Bool(layout.bundled));
 
-    let running_json = ps(backend, &layout.project_name, &layout.compose_file, &layout.env_file, cwd.clone()).await.unwrap_or_else(|_| "[]".to_string());
-    let running: serde_json::Value = serde_json::from_str(&running_json).unwrap_or_else(|_| serde_json::Value::Array(vec![]));
+    let running_json = ps(
+        backend,
+        &layout.project_name,
+        &layout.compose_file,
+        &layout.env_file,
+        cwd.clone(),
+    )
+    .await
+    .unwrap_or_else(|_| "[]".to_string());
+    let running: serde_json::Value =
+        serde_json::from_str(&running_json).unwrap_or_else(|_| serde_json::Value::Array(vec![]));
     report.insert("running".into(), running);
 
     let client = reqwest::Client::builder()
@@ -304,7 +376,10 @@ async fn cmd_doctor(
                 }
             }
             Err(e) => {
-                detail.insert(path.trim_start_matches('/').into(), serde_json::json!({ "error": e.to_string() }));
+                detail.insert(
+                    path.trim_start_matches('/').into(),
+                    serde_json::json!({ "error": e.to_string() }),
+                );
             }
         }
     }

--- a/crates/tracera-cli/src/commands.rs
+++ b/crates/tracera-cli/src/commands.rs
@@ -1,6 +1,6 @@
 //! Subcommand implementations and CLI surface.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
@@ -182,7 +182,7 @@ fn bump_log_level(cli: &Cli) {
 async fn cmd_up(
     backend: Backend,
     layout: &BundleLayout,
-    cwd: &PathBuf,
+    cwd: &Path,
     args: UpArgs,
 ) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
@@ -196,7 +196,7 @@ async fn cmd_up(
         &layout.project_name,
         &layout.compose_file,
         &layout.env_file,
-        cwd.clone(),
+        cwd.to_path_buf(),
         &sub,
     )
     .await?;
@@ -217,7 +217,7 @@ async fn cmd_up(
 async fn cmd_down(
     backend: Backend,
     layout: &BundleLayout,
-    cwd: &PathBuf,
+    cwd: &Path,
     args: DownArgs,
 ) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
@@ -231,7 +231,7 @@ async fn cmd_down(
         &layout.project_name,
         &layout.compose_file,
         &layout.env_file,
-        cwd.clone(),
+        cwd.to_path_buf(),
         &sub,
     )
     .await?;
@@ -241,7 +241,7 @@ async fn cmd_down(
     Ok(())
 }
 
-async fn cmd_status(backend: Backend, layout: &BundleLayout, cwd: &PathBuf) -> anyhow::Result<()> {
+async fn cmd_status(backend: Backend, layout: &BundleLayout, cwd: &Path) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
     sync_bundle_env_symlink(&layout.compose_dir, &layout.env_file)?;
     let code = compose::run_inherited(
@@ -249,7 +249,7 @@ async fn cmd_status(backend: Backend, layout: &BundleLayout, cwd: &PathBuf) -> a
         &layout.project_name,
         &layout.compose_file,
         &layout.env_file,
-        cwd.clone(),
+        cwd.to_path_buf(),
         &["ps"],
     )
     .await?;
@@ -262,7 +262,7 @@ async fn cmd_status(backend: Backend, layout: &BundleLayout, cwd: &PathBuf) -> a
 async fn cmd_logs(
     backend: Backend,
     layout: &BundleLayout,
-    cwd: &PathBuf,
+    cwd: &Path,
     args: LogsArgs,
 ) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
@@ -272,7 +272,7 @@ async fn cmd_logs(
         &layout.project_name,
         &layout.compose_file,
         &layout.env_file,
-        cwd.clone(),
+        cwd.to_path_buf(),
         args.service.as_deref(),
         args.follow,
     )
@@ -283,6 +283,9 @@ async fn cmd_logs(
     Ok(())
 }
 
+// Each platform block is mutually exclusive. Explicit returns keep that
+// control flow obvious to Rust across target-specific compilation.
+#[allow(clippy::needless_return)]
 fn cmd_open(layout: &BundleLayout) -> anyhow::Result<()> {
     #[cfg(target_os = "macos")]
     {
@@ -319,7 +322,7 @@ fn cmd_open(layout: &BundleLayout) -> anyhow::Result<()> {
 async fn cmd_doctor(
     backend: Backend,
     layout: &BundleLayout,
-    cwd: &PathBuf,
+    cwd: &Path,
     args: DoctorArgs,
 ) -> anyhow::Result<()> {
     ensure_env_file(&layout.env_file, layout.local_port)?;
@@ -348,7 +351,7 @@ async fn cmd_doctor(
         &layout.project_name,
         &layout.compose_file,
         &layout.env_file,
-        cwd.clone(),
+        cwd.to_path_buf(),
     )
     .await
     .unwrap_or_else(|_| "[]".to_string());

--- a/crates/tracera-cli/src/compose.rs
+++ b/crates/tracera-cli/src/compose.rs
@@ -172,9 +172,8 @@ pub fn ensure_env_file(env_file: &Path, local_port: u16) -> anyhow::Result<()> {
 }
 
 fn generate_password() -> String {
-    use rand::RngCore;
     let mut bytes = [0u8; 24];
-    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    rand::fill(&mut bytes);
     // Avoid shell-quoting issues — keep it URL-safe ASCII.
     use std::fmt::Write;
     let mut s = String::with_capacity(32);
@@ -241,6 +240,16 @@ mod tests {
             .windows(2)
             .any(|w| w[0] == "-f" && w[1] == "/tmp/docker-compose.bundle.yml"));
         assert_eq!(args[args.len() - 2..], ["up", "-d"]);
+    }
+
+    #[test]
+    fn generated_password_is_lowercase_hex_with_24_random_bytes() {
+        let password = generate_password();
+
+        assert_eq!(password.len(), 48);
+        assert!(password
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)));
     }
 
     #[test]

--- a/crates/tracera-cli/src/compose.rs
+++ b/crates/tracera-cli/src/compose.rs
@@ -25,10 +25,31 @@ pub fn compose_argv(
     env_file: &Path,
     subcommand: &[&str],
 ) -> (String, Vec<String>) {
+    let wsl_distro = matches!(backend, Backend::WslDocker)
+        .then(crate::runtime::wsl_distro)
+        .flatten();
+    compose_argv_with_wsl_distro(
+        backend,
+        project_name,
+        compose_file,
+        env_file,
+        subcommand,
+        wsl_distro,
+    )
+}
+
+fn compose_argv_with_wsl_distro(
+    backend: Backend,
+    project_name: &str,
+    compose_file: &Path,
+    env_file: &Path,
+    subcommand: &[&str],
+    wsl_distro: Option<String>,
+) -> (String, Vec<String>) {
     let mut args: Vec<String> = Vec::with_capacity(10 + subcommand.len());
 
     if matches!(backend, Backend::WslDocker) {
-        if let Some(distro) = crate::runtime::wsl_distro() {
+        if let Some(distro) = wsl_distro {
             args.push("--distribution".into());
             args.push(distro);
         }
@@ -254,30 +275,34 @@ mod tests {
 
     #[test]
     fn compose_argv_wsl_prefixes_docker_with_distribution() {
-        // The real `wsl_distro()` shells out to `wsl -l -q`, which doesn't
-        // exist on a macOS dev box. We just assert that when wsl_distro()
-        // returns None, no `--distribution` flag is added — and the argv
-        // layout is otherwise identical to the Docker backend.
-        let (prog, args) = compose_argv(
+        let (prog, args) = compose_argv_with_wsl_distro(
             Backend::WslDocker,
             "tracera-bundle",
             Path::new("/mnt/c/docker-compose.bundle.yml"),
             Path::new("/mnt/c/.env.local"),
             &["ps"],
+            Some("Ubuntu-22.04".to_string()),
         );
-        // On macOS where wsl is absent, wsl_distro() is None, so the argv
-        // drops the distro prefix.
-        if cfg!(target_os = "macos") {
-            assert_eq!(prog, "wsl");
-            assert_ne!(args.first().map(String::as_str), Some("--distribution"));
-        } else {
-            // On Linux/Windows CI where wsl IS available, the distro flag
-            // comes first.
-            assert_eq!(prog, "wsl");
-            assert_eq!(args[0], "--distribution");
-            assert_eq!(args[1], "Ubuntu-22.04");
-            assert_eq!(args[2], "compose");
-        }
+        assert_eq!(prog, "wsl");
+        assert_eq!(args[0], "--distribution");
+        assert_eq!(args[1], "Ubuntu-22.04");
+        assert_eq!(args[2], "docker");
+        assert_eq!(args[3], "compose");
+    }
+
+    #[test]
+    fn compose_argv_wsl_without_distribution_keeps_docker_prefix() {
+        let (prog, args) = compose_argv_with_wsl_distro(
+            Backend::WslDocker,
+            "tracera-bundle",
+            Path::new("/mnt/c/docker-compose.bundle.yml"),
+            Path::new("/mnt/c/.env.local"),
+            &["ps"],
+            None,
+        );
+        assert_eq!(prog, "wsl");
+        assert_eq!(args[0], "docker");
+        assert_eq!(args[1], "compose");
     }
 
     #[test]

--- a/crates/tracera-cli/src/compose.rs
+++ b/crates/tracera-cli/src/compose.rs
@@ -76,8 +76,20 @@ pub async fn run_inherited(
 }
 
 /// Probe compose for whether a given service is running.
-pub async fn ps(backend: Backend, project_name: &str, compose_file: &Path, env_file: &Path, _cwd: PathBuf) -> anyhow::Result<String> {
-    let (program, argv) = compose_argv(backend, project_name, compose_file, env_file, &["ps", "--format", "json"]);
+pub async fn ps(
+    backend: Backend,
+    project_name: &str,
+    compose_file: &Path,
+    env_file: &Path,
+    _cwd: PathBuf,
+) -> anyhow::Result<String> {
+    let (program, argv) = compose_argv(
+        backend,
+        project_name,
+        compose_file,
+        env_file,
+        &["ps", "--format", "json"],
+    );
     run_capture(&program, argv).await
 }
 
@@ -131,14 +143,17 @@ pub fn ensure_env_file(env_file: &Path, local_port: u16) -> anyhow::Result<()> {
     if env_file.exists() {
         // Validate it has a password; if not, regenerate.
         let existing = std::fs::read_to_string(env_file).unwrap_or_default();
-        if existing.lines().any(|l| l.starts_with("POSTGRES_PASSWORD=") && l.len() > "POSTGRES_PASSWORD=".len())
+        if existing
+            .lines()
+            .any(|l| l.starts_with("POSTGRES_PASSWORD=") && l.len() > "POSTGRES_PASSWORD=".len())
         {
             return Ok(());
         }
     }
 
     if let Some(parent) = env_file.parent() {
-        std::fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
     }
 
     let password = generate_password();
@@ -222,7 +237,9 @@ mod tests {
         assert_eq!(args[project_idx + 1], "tracera-bundle");
         let env_idx = args.iter().position(|a| a == "--env-file").unwrap();
         assert_eq!(args[env_idx + 1], "/tmp/.env.local");
-        assert!(args.windows(2).any(|w| w[0] == "-f" && w[1] == "/tmp/docker-compose.bundle.yml"));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "-f" && w[1] == "/tmp/docker-compose.bundle.yml"));
         assert_eq!(args[args.len() - 2..], ["up", "-d"]);
     }
 
@@ -291,7 +308,10 @@ mod tests {
 
         sync_bundle_env_symlink(&compose_dir, &target).unwrap();
         let body = std::fs::read_to_string(compose_dir.join(".env.local")).unwrap();
-        assert_eq!(body, "POSTGRES_PASSWORD=USER\n", "user file was overwritten");
+        assert_eq!(
+            body, "POSTGRES_PASSWORD=USER\n",
+            "user file was overwritten"
+        );
 
         std::fs::remove_dir_all(&tmp).unwrap();
     }

--- a/crates/tracera-cli/src/runtime.rs
+++ b/crates/tracera-cli/src/runtime.rs
@@ -202,7 +202,11 @@ pub fn wsl_distro() -> Option<String> {
 /// Run a command, inheriting stdio (for human-facing output).
 ///
 /// `program` is the binary path or name (resolved via the OS PATH).
-pub async fn run_inherited<I, S>(program: &str, args: I, cwd: Option<PathBuf>) -> anyhow::Result<i32>
+pub async fn run_inherited<I, S>(
+    program: &str,
+    args: I,
+    cwd: Option<PathBuf>,
+) -> anyhow::Result<i32>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<std::ffi::OsStr>,

--- a/crates/tracera-cli/src/runtime.rs
+++ b/crates/tracera-cli/src/runtime.rs
@@ -173,14 +173,6 @@ fn probe_wsl_docker() -> bool {
     }
 }
 
-/// Resolve a free TCP port by binding to port 0 and reading what the OS assigned.
-pub fn pick_free_port() -> anyhow::Result<u16> {
-    use std::net::TcpListener;
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let port = listener.local_addr()?.port();
-    Ok(port)
-}
-
 /// Returns the path to the `wsl.exe` distribution root (used only when
 /// constructing `wsl --distribution <name> -- ...` invocations).
 pub fn wsl_distro() -> Option<String> {

--- a/crates/tracera-edge/src/lib.rs
+++ b/crates/tracera-edge/src/lib.rs
@@ -148,7 +148,7 @@ async fn org_metrics(_req: Request, ctx: RouteContext<()>) -> Result<Response> {
     if let Some(cached) = kv.get(&cache_key).text().await? {
         return Response::ok(cached).map(|r| {
             r.with_headers({
-                let mut h = worker::Headers::new();
+                let h = worker::Headers::new();
                 // Safety: these header values are static and valid.
                 let _ = h.set("content-type", "application/json");
                 let _ = h.set("x-cache", "HIT");
@@ -183,7 +183,7 @@ async fn org_metrics(_req: Request, ctx: RouteContext<()>) -> Result<Response> {
 
     Response::ok(body).map(|r| {
         r.with_headers({
-            let mut h = worker::Headers::new();
+            let h = worker::Headers::new();
             let _ = h.set("content-type", "application/json");
             let _ = h.set("x-cache", "MISS");
             h

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -1,5 +1,5 @@
-mod db;
 mod auth;
+mod db;
 mod health;
 mod ingest;
 mod pg_store;
@@ -583,11 +583,9 @@ async fn main() {
         .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 8080)));
 
     let public_bind_mode = env::var(PUBLIC_BIND_MODE_ENV).ok();
-    if let Err(error) = validate_bind_address(
-        addr,
-        public_bind_mode.as_deref(),
-        auth_token.as_deref(),
-    ) {
+    if let Err(error) =
+        validate_bind_address(addr, public_bind_mode.as_deref(), auth_token.as_deref())
+    {
         eprintln!("FATAL: {error}");
         std::process::exit(1);
     }
@@ -1089,7 +1087,10 @@ async fn list_problems(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Query(params): axum::extract::Query<ProblemQuery>,
 ) -> Result<Json<ProblemListResponse>, (axum::http::StatusCode, Json<ErrorResponse>)> {
-    let pagination = params.pagination.validated().map_err(|_| bad_request("invalid pagination"))?;
+    let pagination = params
+        .pagination
+        .validated()
+        .map_err(|_| bad_request("invalid pagination"))?;
     let project_id = params.project_id.unwrap_or_default();
     let status_filter = params.status;
     let items = state
@@ -1113,7 +1114,9 @@ async fn list_problems(
             tracing::error!("count_problems store error: {e}");
             (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse { error: "problem count failed" }),
+                Json(ErrorResponse {
+                    error: "problem count failed",
+                }),
             )
         })?;
     Ok(Json(ProblemListResponse {
@@ -1229,7 +1232,9 @@ async fn list_projects(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Query(params): axum::extract::Query<ListParams>,
 ) -> Result<Json<ProjectListResponse>, (axum::http::StatusCode, Json<ErrorResponse>)> {
-    let pagination = params.validated().map_err(|_| bad_request("invalid pagination"))?;
+    let pagination = params
+        .validated()
+        .map_err(|_| bad_request("invalid pagination"))?;
     let projects = state.store.list_projects(pagination).await.map_err(|e| {
         tracing::error!("list_projects store error: {e}");
         (
@@ -1243,7 +1248,9 @@ async fn list_projects(
         tracing::error!("count_projects store error: {e}");
         (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse { error: "project count failed" }),
+            Json(ErrorResponse {
+                error: "project count failed",
+            }),
         )
     })?;
     Ok(Json(ProjectListResponse {
@@ -1657,10 +1664,7 @@ mod tests {
             }
         };
         bootstrap_pool.close().await;
-        if let Err(error) = sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await
-        {
+        if let Err(error) = sqlx::migrate!("./migrations").run(&pool).await {
             if let Err(cleanup_error) = drop_pg_store_contract_schema(&pool, &schema_name).await {
                 eprintln!("fixture cleanup after migration failure: {cleanup_error}");
             }
@@ -1805,10 +1809,7 @@ mod tests {
             .expect("response");
 
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response.headers()[header::CONTENT_TYPE],
-            "application/json"
-        );
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
 
         let body = axum::body::to_bytes(response.into_body(), 1024)
             .await
@@ -2062,7 +2063,11 @@ mod tests {
                 .await
                 .expect("response");
 
-            assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR, "{uri}");
+            assert_eq!(
+                response.status(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "{uri}"
+            );
             let body = axum::body::to_bytes(response.into_body(), 1024)
                 .await
                 .expect("body");
@@ -2861,7 +2866,10 @@ mod tests {
             .await
             .expect("persist problem after production migrations");
 
-        let projects = store.list_projects(ListParams::default()).await.expect("list projects");
+        let projects = store
+            .list_projects(ListParams::default())
+            .await
+            .expect("list projects");
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].id, "project-migration-1");
         assert_eq!(projects[0].problem_count, 1);
@@ -2974,11 +2982,17 @@ mod tests {
             .await
             .map_err(|error| format!("list text-id project: {error}"))?;
         if listed.len() != 1 || listed[0].project_id != project_id {
-            return Err(format!("expected one problem for textual project id, got {listed:?}"));
+            return Err(format!(
+                "expected one problem for textual project id, got {listed:?}"
+            ));
         }
 
         if !store
-            .list_problems(project_id.clone(), Some("closed".to_string()), ListParams::default())
+            .list_problems(
+                project_id.clone(),
+                Some("closed".to_string()),
+                ListParams::default(),
+            )
             .await
             .map_err(|error| format!("filter text-id project: {error}"))?
             .is_empty()
@@ -3138,7 +3152,11 @@ mod tests {
 
         // list with status filter narrows correctly
         let filtered = store
-            .list_problems("proj-1".to_string(), Some("closed".to_string()), ListParams::default())
+            .list_problems(
+                "proj-1".to_string(),
+                Some("closed".to_string()),
+                ListParams::default(),
+            )
             .await
             .expect("list_problems filtered");
         assert!(filtered.is_empty(), "no problems in 'closed' status");

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -618,10 +618,10 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/api/v1/confidence", post(confidence))
         .route("/api/v1/blast-radius", post(blast_radius))
         .route("/api/v1/governance/spec-check", post(spec_check))
-        .route("/api/v1/trace/forward/:artifact_id", post(trace_forward))
-        .route("/api/v1/trace/reverse/:artifact_id", post(trace_reverse))
+        .route("/api/v1/trace/forward/{artifact_id}", post(trace_forward))
+        .route("/api/v1/trace/reverse/{artifact_id}", post(trace_reverse))
         .route(
-            "/api/v1/trace/:artifact_id/links",
+            "/api/v1/trace/{artifact_id}/links",
             get(list_persisted_trace_links),
         )
         .route("/evidence", get(list_evidence).post(create_evidence))
@@ -632,7 +632,7 @@ fn build_router_with_auth(state: AppState, auth_token: auth::AuthToken) -> Route
         .route("/sdlc-pm/sprints", get(list_sprints).post(create_sprint))
         .route("/sdlc-pm/stories", get(list_stories))
         .route("/api/v1/projects", get(list_projects))
-        .route("/api/v1/projects/:project_id", get(get_project))
+        .route("/api/v1/projects/{project_id}", get(get_project))
         .route("/problems", get(list_problems).post(create_problem))
         .route("/problems/health", get(health::health))
         .route("/org-intel/health", get(health::health))

--- a/crates/tracera-server/src/main.rs
+++ b/crates/tracera-server/src/main.rs
@@ -603,6 +603,7 @@ async fn main() {
     }
 }
 
+#[cfg(test)]
 fn build_router(state: AppState) -> Router {
     build_router_with_auth(state, None)
 }

--- a/crates/tracera-server/src/pg_store.rs
+++ b/crates/tracera-server/src/pg_store.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::store::{
-    BoxFuture, EvidenceItem, ListParams, Problem, ProjectSummary, Sprint, Store, StoreError, StoreResult,
-    Story, TeamRow, TraceLink,
+    BoxFuture, EvidenceItem, ListParams, Problem, ProjectSummary, Sprint, Store, StoreError,
+    StoreResult, Story, TeamRow, TraceLink,
 };
 
 #[derive(Clone)]
@@ -357,13 +357,20 @@ impl Store for PgStore {
 
     fn count_projects(&self) -> BoxFuture<'_, StoreResult<i64>> {
         Box::pin(async move {
-            let row = sqlx::query("SELECT COUNT(DISTINCT project_id) AS cnt FROM problems WHERE deleted_at IS NULL")
-                .fetch_one(&self.pool).await.map_err(StoreError::from)?;
+            let row = sqlx::query(
+                "SELECT COUNT(DISTINCT project_id) AS cnt FROM problems WHERE deleted_at IS NULL",
+            )
+            .fetch_one(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
             Ok(row.try_get("cnt").unwrap_or(0))
         })
     }
 
-    fn get_project(&self, project_id: String) -> BoxFuture<'_, StoreResult<Option<ProjectSummary>>> {
+    fn get_project(
+        &self,
+        project_id: String,
+    ) -> BoxFuture<'_, StoreResult<Option<ProjectSummary>>> {
         Box::pin(async move {
             let rows = sqlx::query(
                 "SELECT project_id::text AS project_id,
@@ -580,15 +587,24 @@ impl Store for PgStore {
         })
     }
 
-    fn count_problems_filtered(&self, project_id: String, status_filter: Option<String>) -> BoxFuture<'_, StoreResult<i64>> {
+    fn count_problems_filtered(
+        &self,
+        project_id: String,
+        status_filter: Option<String>,
+    ) -> BoxFuture<'_, StoreResult<i64>> {
         Box::pin(async move {
             let (query, status) = match status_filter {
                 Some(_) => ("SELECT COUNT(*) AS cnt FROM problems WHERE project_id = $1 AND status = $2 AND deleted_at IS NULL", status_filter),
                 None => ("SELECT COUNT(*) AS cnt FROM problems WHERE project_id = $1 AND deleted_at IS NULL", None),
             };
             let mut request = sqlx::query(query).bind(&project_id);
-            if let Some(status) = status { request = request.bind(status); }
-            let row = request.fetch_one(&self.pool).await.map_err(StoreError::from)?;
+            if let Some(status) = status {
+                request = request.bind(status);
+            }
+            let row = request
+                .fetch_one(&self.pool)
+                .await
+                .map_err(StoreError::from)?;
             Ok(row.try_get("cnt").unwrap_or(0))
         })
     }

--- a/crates/tracera-server/src/sqlite_store.rs
+++ b/crates/tracera-server/src/sqlite_store.rs
@@ -15,8 +15,8 @@ use serde_json::Value;
 use sqlx::{Row, SqlitePool};
 
 use crate::store::{
-    BoxFuture, EvidenceItem, ListParams, Problem, ProjectSummary, Sprint, Store, StoreError, StoreResult,
-    Story, TeamRow, TraceLink,
+    BoxFuture, EvidenceItem, ListParams, Problem, ProjectSummary, Sprint, Store, StoreError,
+    StoreResult, Story, TeamRow, TraceLink,
 };
 
 #[derive(Clone)]
@@ -406,13 +406,20 @@ impl Store for SqliteStore {
 
     fn count_projects(&self) -> BoxFuture<'_, StoreResult<i64>> {
         Box::pin(async move {
-            let row = sqlx::query("SELECT COUNT(DISTINCT project_id) AS cnt FROM problems WHERE deleted_at IS NULL")
-                .fetch_one(&self.pool).await.map_err(StoreError::from)?;
+            let row = sqlx::query(
+                "SELECT COUNT(DISTINCT project_id) AS cnt FROM problems WHERE deleted_at IS NULL",
+            )
+            .fetch_one(&self.pool)
+            .await
+            .map_err(StoreError::from)?;
             Ok(row.try_get("cnt").unwrap_or(0))
         })
     }
 
-    fn get_project(&self, project_id: String) -> BoxFuture<'_, StoreResult<Option<ProjectSummary>>> {
+    fn get_project(
+        &self,
+        project_id: String,
+    ) -> BoxFuture<'_, StoreResult<Option<ProjectSummary>>> {
         Box::pin(async move {
             let rows = sqlx::query(
                 "SELECT project_id, COUNT(*) AS problem_count, MIN(created_at) AS created_at, MAX(updated_at) AS updated_at
@@ -642,15 +649,24 @@ impl Store for SqliteStore {
         })
     }
 
-    fn count_problems_filtered(&self, project_id: String, status_filter: Option<String>) -> BoxFuture<'_, StoreResult<i64>> {
+    fn count_problems_filtered(
+        &self,
+        project_id: String,
+        status_filter: Option<String>,
+    ) -> BoxFuture<'_, StoreResult<i64>> {
         Box::pin(async move {
             let (query, status) = match status_filter {
                 Some(_) => ("SELECT COUNT(*) AS cnt FROM problems WHERE project_id = ?1 AND status = ?2 AND deleted_at IS NULL", status_filter),
                 None => ("SELECT COUNT(*) AS cnt FROM problems WHERE project_id = ?1 AND deleted_at IS NULL", None),
             };
             let mut request = sqlx::query(query).bind(&project_id);
-            if let Some(status) = status { request = request.bind(status); }
-            let row = request.fetch_one(&self.pool).await.map_err(StoreError::from)?;
+            if let Some(status) = status {
+                request = request.bind(status);
+            }
+            let row = request
+                .fetch_one(&self.pool)
+                .await
+                .map_err(StoreError::from)?;
             Ok(row.try_get("cnt").unwrap_or(0))
         })
     }

--- a/crates/tracera-server/src/store.rs
+++ b/crates/tracera-server/src/store.rs
@@ -45,22 +45,35 @@ pub struct ListParams {
     pub page_size: u32,
 }
 
-const fn default_page() -> u32 { 1 }
-const fn default_page_size() -> u32 { DEFAULT_PAGE_SIZE }
+const fn default_page() -> u32 {
+    1
+}
+const fn default_page_size() -> u32 {
+    DEFAULT_PAGE_SIZE
+}
 
 impl Default for ListParams {
-    fn default() -> Self { Self { page: 1, page_size: DEFAULT_PAGE_SIZE } }
+    fn default() -> Self {
+        Self {
+            page: 1,
+            page_size: DEFAULT_PAGE_SIZE,
+        }
+    }
 }
 
 impl ListParams {
     pub fn validated(self) -> Result<Self, String> {
-        if self.page == 0 { return Err("page must be >= 1".into()); }
+        if self.page == 0 {
+            return Err("page must be >= 1".into());
+        }
         if self.page_size == 0 || self.page_size > MAX_PAGE_SIZE {
             return Err(format!("page_size must be between 1 and {MAX_PAGE_SIZE}"));
         }
         Ok(self)
     }
-    pub fn offset(self) -> u64 { (self.page as u64 - 1) * self.page_size as u64 }
+    pub fn offset(self) -> u64 {
+        (self.page as u64 - 1) * self.page_size as u64
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -265,7 +278,8 @@ pub trait Store: Send + Sync {
     fn list_projects(&self, params: ListParams) -> BoxFuture<'_, StoreResult<Vec<ProjectSummary>>>;
     /// Total number of visible projects, independent of page size/offset.
     fn count_projects(&self) -> BoxFuture<'_, StoreResult<i64>>;
-    fn get_project(&self, project_id: String) -> BoxFuture<'_, StoreResult<Option<ProjectSummary>>>;
+    fn get_project(&self, project_id: String)
+        -> BoxFuture<'_, StoreResult<Option<ProjectSummary>>>;
 
     // Metrics
     fn count_evidence(&self) -> BoxFuture<'_, StoreResult<i64>>;
@@ -346,14 +360,41 @@ mod tests {
         let params = ListParams::default();
         assert_eq!(params.page, 1);
         assert_eq!(params.page_size, DEFAULT_PAGE_SIZE);
-        assert_eq!(ListParams { page: 3, page_size: 25 }.offset(), 50);
+        assert_eq!(
+            ListParams {
+                page: 3,
+                page_size: 25
+            }
+            .offset(),
+            50
+        );
     }
 
     #[test]
     fn list_params_reject_zero_and_oversized_values() {
-        assert!(ListParams { page: 0, page_size: 1 }.validated().is_err());
-        assert!(ListParams { page: 1, page_size: 0 }.validated().is_err());
-        assert!(ListParams { page: 1, page_size: MAX_PAGE_SIZE + 1 }.validated().is_err());
-        assert!(ListParams { page: 1, page_size: MAX_PAGE_SIZE }.validated().is_ok());
+        assert!(ListParams {
+            page: 0,
+            page_size: 1
+        }
+        .validated()
+        .is_err());
+        assert!(ListParams {
+            page: 1,
+            page_size: 0
+        }
+        .validated()
+        .is_err());
+        assert!(ListParams {
+            page: 1,
+            page_size: MAX_PAGE_SIZE + 1
+        }
+        .validated()
+        .is_err());
+        assert!(ListParams {
+            page: 1,
+            page_size: MAX_PAGE_SIZE
+        }
+        .validated()
+        .is_ok());
     }
 }


### PR DESCRIPTION
Successor to draft #853, rebuilt from current main without rewriting the preserved source branch.\n\nContains four verified commits:\n\n- workspace rustfmt baseline;\n- Rand 0.10 CLI password API migration with regression coverage;\n- deterministic WSL argv tests and Axum 0.8 capture-route syntax;\n- strict-Clippy cleanup limited to compiler-proven dead/over-broad code.\n\nCurrent-base evidence: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `git diff --check`, and `cargo test --workspace --locked` all pass (70 server tests, 1 ignored).\n\n#853 and #854 remain preserved. This PR requires hosted CI, dependency/security gates, review, and merge; no release claim.