### PR TITLE
fix(ci): disable Prettier lifecycle scripts

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -55,7 +55,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm install --global prettier@3.6.2
+          npm install --global --ignore-scripts prettier@3.6.2
           prettier --version
 
       - name: prettier check

--- a/frontend/scripts/test-trunk-check-workflow.mjs
+++ b/frontend/scripts/test-trunk-check-workflow.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = new URL(".", import.meta.url);
+const workflow = await readFile(
+  fileURLToPath(new URL("../../.github/workflows/trunk-check.yml", scriptDirectory)),
+  "utf8",
+);
+
+assert.match(
+  workflow,
+  /npm install --global --ignore-scripts prettier@3\.6\.2/,
+  "Trunk Check must install pinned Prettier without lifecycle scripts",
+);


### PR DESCRIPTION
## Outcome

Trunk Check installs its pinned Prettier binary without running package lifecycle scripts, satisfying the Sonar security requirement while preserving the existing scoped formatting check.

## Scope

- Add `--ignore-scripts` to the one global Prettier install.
- Add a static regression guard for the workflow command.

## Evidence

- RED: guard failed until `--ignore-scripts` was present.
- GREEN: `node frontend/scripts/test-trunk-check-workflow.mjs` passes.
- `actionlint .github/workflows/trunk-check.yml` passes.
- `git diff --check` passes.

Hosted Sonar, required CI, review, and protected merge remain required.