### PR TITLE
fix(ci): restore Mergify schema

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,13 +20,11 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge dependabot/Renovate PRs when CI passes
   - name: Auto-merge dependency updates
     conditions:
-      - author=dependabot[bot] | renovate[bot]
+      - 'author ~= ^(?:dependabot\[bot\]|renovate\[bot\])$'
       - check-success=ci
       - -conflict
       - -closed
@@ -37,13 +35,11 @@ pull_request_rules:
           {{ title }} (#{{ number }})
           
           Co-authored-by: {{ author }}
-      post_merge:
-        action: close
 
   # Auto-merge bot PRs (CI configs, formatting) when CI passes
   - name: Auto-merge bot housekeeping PRs
     conditions:
-      - author=trunk-io[bot] | mergify[bot] | github-actions[bot]
+      - 'author ~= ^(?:trunk-io\[bot\]|mergify\[bot\]|github-actions\[bot\])$'
       - check-success=ci
       - check-success=lint
       - -conflict
@@ -61,7 +57,7 @@ pull_request_rules:
       request_reviews:
         teams:
           - phenotype/core
-        github_accounts:
+        users:
           - KooshaPari
 
   # Label PRs based on changed files
@@ -102,7 +98,7 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - age>=30d
+      - updated-at < 30 days ago
       - "#review-requested=0"
     actions:
       comment:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
         method: squash
         commit_message_template: |
           {{ title }} (#{{ number }})
-          
+
           Co-authored-by: {{ author }}
 
   # Auto-merge dependabot/Renovate PRs when CI passes
@@ -33,7 +33,7 @@ pull_request_rules:
         method: squash
         commit_message_template: |
           {{ title }} (#{{ number }})
-          
+
           Co-authored-by: {{ author }}
 
   # Auto-merge bot PRs (CI configs, formatting) when CI passes

--- a/frontend/scripts/test-mergify-config.mjs
+++ b/frontend/scripts/test-mergify-config.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = new URL(".", import.meta.url);
+const config = await readFile(
+  fileURLToPath(new URL("../../.mergify.yml", scriptDirectory)),
+  "utf8",
+);
+
+assert.match(config, /author ~= \^\(\?:dependabot\\\[bot\\\]\|renovate\\\[bot\\\]\)\$/);
+assert.match(config, /author ~= \^\(\?:trunk-io\\\[bot\\\]\|mergify\\\[bot\\\]\|github-actions\\\[bot\\\]\)\$/);
+assert.match(config, /updated-at < 30 days ago/);
+assert.match(config, /\n        users:\n          - KooshaPari/);
+assert.doesNotMatch(config, /post_merge:|github_accounts:|age>=30d/);


### PR DESCRIPTION
Repairs the Mergify ruleset schema currently rejected on every PR.

- Restores the reviewed valid syntax from the preserved prior repair.
- Removes unsupported post_merge actions.
- Adds an executable static guard for unsupported constructs.

Mergify evaluates the default-branch configuration, so this PR cannot clear the existing Mergify check until a protected-flow merge makes the configuration live. No auto-merge is requested.