### PR TITLE
fix(ci): provide stable required check contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,54 @@ jobs:
       - uses: actions/checkout@v4
       - uses: trunk-io/trunk-action@v1
 
+  # Stable branch-protection contexts. These aggregates run even when an
+  # individual language job is skipped by the path filter.
+  required-ci-lint:
+    name: ci / lint
+    if: always()
+    needs:
+      - rust-lint
+      - python-lint
+      - go-lint
+      - typescript-lint
+      - trunk-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check lint results
+        run: |
+          results=("${{ needs.rust-lint.result }}" \
+                   "${{ needs.python-lint.result }}" \
+                   "${{ needs.go-lint.result }}" \
+                   "${{ needs.typescript-lint.result }}" \
+                   "${{ needs.trunk-check.result }}")
+          for result in "${results[@]}"; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              exit 1
+            fi
+          done
+
+  required-ci-test:
+    name: ci / test
+    if: always()
+    needs:
+      - rust-test
+      - python-test
+      - go-test
+      - typescript-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          results=("${{ needs.rust-test.result }}" \
+                   "${{ needs.python-test.result }}" \
+                   "${{ needs.go-test.result }}" \
+                   "${{ needs.typescript-test.result }}")
+          for result in "${results[@]}"; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              exit 1
+            fi
+          done
+
   # ===========================================================================
   # STAGE 5: Aggregation gate for branch protection
   # ===========================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,12 +367,12 @@ jobs:
                    "${{ needs.typescript-lint.result }}" \
                    "${{ needs.typescript-test.result }}" \
                    "${{ needs.security-scan.result }}")
-          
+
           for result in "${results[@]}"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "❌ Required job failed: $result"
               exit 1
             fi
           done
-          
+
           echo "✅ All required checks passed"

--- a/tests/test_required_ci_contexts.cjs
+++ b/tests/test_required_ci_contexts.cjs
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const workflow = readFileSync(
+  join(__dirname, '..', '.github', 'workflows', 'ci.yml'),
+  'utf8',
+);
+
+function jobBlock(jobId) {
+  const match = workflow.match(
+    new RegExp(`^  ${jobId}:\\n([\\s\\S]*?)(?=^  [A-Za-z0-9_-]+:|\\z)`, 'm'),
+  );
+  assert.ok(match, `expected ${jobId} aggregate job`);
+  return match[0];
+}
+
+function assertAggregateJob({ jobId, context, needs }) {
+  const block = jobBlock(jobId);
+  assert.match(block, new RegExp(`^    name: ${context}$`, 'm'));
+  assert.match(block, /^    if: always\(\)$/m);
+
+  for (const dependency of needs) {
+    assert.match(block, new RegExp(`^      - ${dependency}$`, 'm'));
+  }
+}
+
+test('CI emits the protected lint and test contexts across all merge entrypoints', () => {
+  assert.match(workflow, /^  push:/m);
+  assert.match(workflow, /^  pull_request:/m);
+  assert.match(workflow, /^  merge_group:/m);
+
+  assertAggregateJob({
+    jobId: 'required-ci-lint',
+    context: 'ci / lint',
+    needs: ['rust-lint', 'python-lint', 'go-lint', 'typescript-lint', 'trunk-check'],
+  });
+  assertAggregateJob({
+    jobId: 'required-ci-test',
+    context: 'ci / test',
+    needs: ['rust-test', 'python-test', 'go-test', 'typescript-test'],
+  });
+});


### PR DESCRIPTION
## Summary
- add stable `ci / lint` and `ci / test` aggregate jobs for protected required contexts
- preserve path-filtered language jobs while failing aggregates on failed or cancelled dependencies
- cover the merge-entrypoint and aggregate-job contract with a focused Node test

## Validation
- `node --test tests/test_required_ci_contexts.cjs`
- `actionlint -ignore 'label "blacksmith-[^"]+" is unknown' .github/workflows/ci.yml`\n- `git diff --check`\n\nDraft only: no branch-protection, ruleset, merge, or auto-merge changes.