### PR TITLE
fix(ci): restore protected aggregate contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
 
   rust-build:
     name: Rust Build
-    needs: [rust-lint, rust-test]
-    if: always() && !failure() && !cancelled()
+    needs: [detect-changes, rust-lint, rust-test]
+    if: always() && !failure() && !cancelled() && needs.detect-changes.outputs.rust == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -289,42 +289,75 @@ jobs:
   # ===========================================================================
   # STAGE 5: Aggregation gate for branch protection
   # ===========================================================================
-  ci:
-    name: CI
+  lint:
+    # These display names are branch-protection contexts. Keep them stable.
+    name: ci / lint
     if: always()
     needs:
       - detect-changes
       - rust-lint
-      - rust-test
       - python-lint
-      - python-test
       - go-lint
-      - go-test
       - typescript-lint
-      - typescript-test
       - security-scan
       - dependency-review
       - trunk-check
     runs-on: ubuntu-latest
     steps:
-      - name: Check all jobs
+      - name: Aggregate lint and quality gates
         run: |
-          # Fail if any required job failed (not skipped)
-          results=("${{ needs.rust-lint.result }}" \
-                   "${{ needs.rust-test.result }}" \
-                   "${{ needs.python-lint.result }}" \
-                   "${{ needs.python-test.result }}" \
-                   "${{ needs.go-lint.result }}" \
-                   "${{ needs.go-test.result }}" \
-                   "${{ needs.typescript-lint.result }}" \
-                   "${{ needs.typescript-test.result }}" \
-                   "${{ needs.security-scan.result }}")
-          
+          # Skipped path-filtered jobs are valid; failures and cancellations are not.
+          results=(
+            "rust-lint=${{ needs.rust-lint.result }}"
+            "python-lint=${{ needs.python-lint.result }}"
+            "go-lint=${{ needs.go-lint.result }}"
+            "typescript-lint=${{ needs.typescript-lint.result }}"
+            "security-scan=${{ needs.security-scan.result }}"
+            "dependency-review=${{ needs.dependency-review.result }}"
+            "trunk-check=${{ needs.trunk-check.result }}"
+          )
+
           for result in "${results[@]}"; do
+            echo "$result"
+            result="${result#*=}"
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-              echo "❌ Required job failed: $result"
+              echo "Required lint or quality gate failed: $result"
               exit 1
             fi
           done
-          
-          echo "✅ All required checks passed"
+
+          echo "All lint and quality gates passed or were skipped"
+
+  test:
+    # These display names are branch-protection contexts. Keep them stable.
+    name: ci / test
+    if: always()
+    needs:
+      - lint
+      - rust-test
+      - python-test
+      - go-test
+      - typescript-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate test gates
+        run: |
+          # A passing test context must attest both lint and every executed test job.
+          results=(
+            "lint=${{ needs.lint.result }}"
+            "rust-test=${{ needs.rust-test.result }}"
+            "python-test=${{ needs.python-test.result }}"
+            "go-test=${{ needs.go-test.result }}"
+            "typescript-test=${{ needs.typescript-test.result }}"
+          )
+
+          for result in "${results[@]}"; do
+            echo "$result"
+            result="${result#*=}"
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "Required test gate failed: $result"
+              exit 1
+            fi
+          done
+
+          echo "All test gates passed or were skipped"

--- a/frontend/scripts/test-ci-protected-contexts.mjs
+++ b/frontend/scripts/test-ci-protected-contexts.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = new URL(".", import.meta.url);
+const workflow = await readFile(
+  fileURLToPath(new URL("../../.github/workflows/ci.yml", scriptDirectory)),
+  "utf8",
+);
+
+assert.match(workflow, /^  lint:\n(?:    #.*\n)?    name: ci \/ lint$/m);
+assert.match(workflow, /^  test:\n(?:    #.*\n)?    name: ci \/ test$/m);
+assert.match(workflow, /needs:\s*\[detect-changes, rust-lint, rust-test\]/);
+assert.match(workflow, /needs\.detect-changes\.outputs\.rust == 'true'/);


### PR DESCRIPTION
Restores the exact branch-protection contexts `ci / lint` and `ci / test` as real aggregations over lint and test dependencies. It also prevents Rust Build from requesting the external Blacksmith runner when no Rust paths changed.

Evidence:
- regression guard: pass
- workflow YAML parse: pass
- actionlint: pass after narrowly ignoring only the pre-existing Blacksmith custom runner labels
- Prettier and diff hygiene: pass

No auto-merge is requested.